### PR TITLE
Add options parameter to `localforage` adapter

### DIFF
--- a/packages/automerge-repo-storage-localforage/.mocharc.json
+++ b/packages/automerge-repo-storage-localforage/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "extension": ["ts"],
+  "spec": "test/*.test.ts",
+  "loader": "ts-node/esm"
+}

--- a/packages/automerge-repo-storage-localforage/package.json
+++ b/packages/automerge-repo-storage-localforage/package.json
@@ -10,7 +10,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "watch": "npm-watch"
+    "watch": "npm-watch",
+    "test": "mocha --no-warnings --experimental-specifier-resolution=node"
   },
   "dependencies": {
     "automerge-repo": "^0.0.44",

--- a/packages/automerge-repo-storage-localforage/src/index.ts
+++ b/packages/automerge-repo-storage-localforage/src/index.ts
@@ -1,17 +1,31 @@
 import * as localforage from "localforage"
 import { StorageAdapter } from "automerge-repo"
 
+type LocalForageStorageAdapterOptions = {
+  localforage?: LocalForageDbMethodsCore
+}
+
 /** Saving & loading via localforage. Very naive but probably fine for blob-storage.  */
-export class LocalForageStorageAdapter extends StorageAdapter {
+export class LocalForageStorageAdapter implements StorageAdapter {
+  #localforage: LocalForageDbMethodsCore;
+  
+  constructor(options: LocalForageStorageAdapterOptions = {}) {
+    this.#localforage = options.localforage || localforage;
+  }
+  
+  get localforage() {
+    return this.#localforage;
+  }
+  
   load(docId: string) {
-    return localforage.getItem<Uint8Array>(docId)
+    return this.#localforage.getItem<Uint8Array>(docId)
   }
 
   save(docId: string, binary: Uint8Array) {
-    localforage.setItem(docId, binary)
+    this.#localforage.setItem(docId, binary)
   }
 
   remove(docId: string) {
-    localforage.removeItem(docId)
+    this.#localforage.removeItem(docId)
   }
 }

--- a/packages/automerge-repo-storage-localforage/test/index.test.ts
+++ b/packages/automerge-repo-storage-localforage/test/index.test.ts
@@ -1,0 +1,39 @@
+import { expect } from "chai"
+import { LocalForageStorageAdapter } from "../src"
+import { localforageMock } from "./localforage.mock"
+
+import * as localforage from "localforage";
+
+describe("localforage tests", () => {
+  it("can be instantiated", async () => {
+    const adapter = new LocalForageStorageAdapter();
+    
+    expect(adapter).to.be.an.instanceof(LocalForageStorageAdapter);
+    
+    expect(adapter.load).to.be.a("function");
+    expect(adapter.localforage).to.equal(localforage);
+  })
+
+  it("can be instantiated with options", async () => {
+    const data = {
+      'test': new Uint8Array([1,2,3])
+    };
+    
+    const mock = localforageMock(data)
+    
+    const adapter = new LocalForageStorageAdapter({
+      localforage: mock
+    });
+
+    const val = await adapter.load("test");
+    expect(val).to.deep.equal(new Uint8Array([1,2,3]));
+
+    adapter.save("test2", new Uint8Array([4,5,6]));
+    expect(data['test2']).to.deep.equal(new Uint8Array([4, 5, 6]));
+    
+    adapter.remove("test");
+    expect(data['test']).to.be.undefined;
+
+    expect(adapter.localforage).not.to.equal(localforage);
+  })
+})

--- a/packages/automerge-repo-storage-localforage/test/localforage.mock.ts
+++ b/packages/automerge-repo-storage-localforage/test/localforage.mock.ts
@@ -1,0 +1,32 @@
+export const localforageMock = (data: Record<string, Uint8Array>): LocalForageDbMethodsCore => {
+  return ({
+    clear(callback?: (err: any) => void): Promise<void> {
+      return Promise.resolve(undefined)
+    },
+    getItem(key: string, callback?: (err: any, value: (any | null)) => void): Promise<any | null> {
+      return Promise.resolve(data[key] || null)
+    },
+    iterate<U>(iteratee: (value: any, key: string, iterationNumber: number) => U, callback?: (err: any, result: U) => void): Promise<U> {
+      return Promise.resolve(undefined)
+    },
+    key(keyIndex: number, callback?: (err: any, key: string) => void): Promise<string> {
+      return Promise.resolve("")
+    },
+    keys(callback?: (err: any, keys: string[]) => void): Promise<string[]> {
+      return Promise.resolve([])
+    },
+    length(callback?: (err: any, numberOfKeys: number) => void): Promise<number> {
+      return Promise.resolve(0)
+    },
+    removeItem(key: string, callback?: (err: any) => void): Promise<void> {
+      delete data[key]
+
+      return Promise.resolve(undefined)
+    },
+    setItem(key: string, value: any, callback?: (err: any, value: any) => void): Promise<any> {
+      data[key] = value
+
+      return Promise.resolve(undefined)
+    },
+  })
+};


### PR DESCRIPTION
I was looking for a way to specify the localforage configuration for different repos (within the same application) and thought this might be the most logical solution.