### PR TITLE
automerge-repo: Fix failing test when patches are emitted

### DIFF
--- a/packages/automerge-repo/README.md
+++ b/packages/automerge-repo/README.md
@@ -66,7 +66,7 @@ A `DocHandle` also emits these events:
 - `change({handle: DocHandle})`  
   Called any time changes are created or received on the document. Request the `value()` from the
   handle.
-- `patch({handle: DocHandle, before: Doc, after: Doc, patch: Patch})`  
+- `patch({handle: DocHandle, before: Doc, after: Doc, patches: Patch[]})`  
   Useful for manual increment maintenance of a video, most notably for text editors.
 
 ## Creating a repo

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -47,10 +47,10 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
     this.documentId = documentId
     this.doc = Automerge.init({
       patchCallback: (
-        patch: any, // Automerge.Patch,
+        patches: Automerge.Patch[],
         before: Automerge.Doc<T>,
         after: Automerge.Doc<T>
-      ) => this.__notifyPatchListeners(patch, before, after),
+      ) => this.__notifyPatchListeners(patches, before, after),
     })
 
     // new documents don't need to block on an initial value setting
@@ -112,11 +112,11 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
   }
 
   __notifyPatchListeners(
-    patch: any, //Automerge.Patch,
+    patches: Automerge.Patch[],
     before: Automerge.Doc<T>,
     after: Automerge.Doc<T>
   ) {
-    this.emit("patch", { handle: this, patch, before, after })
+    this.emit("patch", { handle: this, patches, before, after })
   }
 
   async value() {
@@ -168,7 +168,7 @@ export interface DocHandleChangeEvent<T> {
 
 export interface DocHandlePatchEvent<T> {
   handle: DocHandle<T>
-  patch: any // Automerge.Patch
+  patches: Automerge.Patch[]
   before: Automerge.Doc<T>
   after: Automerge.Doc<T>
 }

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -110,13 +110,12 @@ describe("DocHandle", () => {
       "test-document-id" as DocumentId,
       true
     )
-    handle.on("patch", ({ /*handle,*/ patch, after }) => {
-      assert.deepEqual(patch, {
+    handle.on("patch", ({ patches, after }) => {
+      assert.deepEqual(patches, [{
         action: "put",
         path: ["foo"],
         value: "bar",
-        conflict: false,
-      })
+      }])
 
       assert(after.foo === "bar", "after message didn't match")
       done()


### PR DESCRIPTION
There was a small breaking change in `automerge v2.0.1` which changed how patches are emitted. They are now passed to the callback as an array of Patches, rather than individually. This had caused the test to fail.

This PR amends both the source and the test to match the new API in `automerge`.

Obviously this is a breaking change for repo too, but given that the change has already occurred upstream, I would imagine it's worth doing.

Two notes:
1. I have left the event name as the singular `patch`
2. `package.json` includes `@automerge/automerge` with a version of `*`. It might be worth restricting this to `>=2.0.1`