### PR TITLE
Add API for creating `DocHandle`s using the unstable Automerge branch

### DIFF
--- a/packages/automerge-repo/README.md
+++ b/packages/automerge-repo/README.md
@@ -43,9 +43,11 @@ This library provides two main components: the `Repo` itself, and the `DocHandle
 
 A `Repo` exposes these methods:
 
-- `create<T>()`  
-  Creates a new, empty `Automerge.Doc` and returns a `DocHandle` for it.
-- `find<T>(docId: DocumentId)`  
+- `create<T>(options?: DocHandleOptions)`  
+  Creates a new, empty `Automerge.Doc` and returns a `DocHandle` for it. 
+  - `options` - Optional configuration object with properties:  
+    - `unstable` - Uses the unstable Automerge API
+- `find<T>(docId: DocumentId)`
   Looks up a given document either on the local machine or (if necessary) over any configured
   networks.
 - `.on("document", ({handle: DocHandle}) => void)`  
@@ -54,7 +56,7 @@ A `Repo` exposes these methods:
 A `DocHandle` is a wrapper around an `Automerge.Doc`. Its primary function is to dispatch changes to
 the document.
 
-- `handle.change((doc: T) => void)` Calls the provided callback with an instrumented mutable object
+- `handle.change((doc: Extend<T>) => void)` Calls the provided callback with an instrumented mutable object
   representing the document. Any changes made to the document will be recorded and distributed to
   other nodes.
 - `handle.value()` Returns a `Promise<Doc<T>>` that will contain the current value of the document.

--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -1,6 +1,6 @@
 import EventEmitter from "eventemitter3"
 import { v4 } from "uuid"
-import { DocHandle, DocumentId } from "./DocHandle.js"
+import { DocHandle, DocHandleOptions, DocumentId } from "./DocHandle.js"
 
 export class DocCollection extends EventEmitter<DocCollectionEvents<unknown>> {
   handles: { [documentId: DocumentId]: DocHandle<unknown> } = {}
@@ -9,11 +9,15 @@ export class DocCollection extends EventEmitter<DocCollectionEvents<unknown>> {
     super()
   }
 
-  cacheHandle(documentId: DocumentId, newDoc: boolean): DocHandle<unknown> {
+  cacheHandle(
+    documentId: DocumentId,
+    newDoc: boolean,
+    options: DocHandleOptions = {}
+  ): DocHandle<unknown> {
     if (this.handles[documentId]) {
       return this.handles[documentId]
     }
-    const handle = new DocHandle<unknown>(documentId, newDoc)
+    const handle = new DocHandle<unknown>(documentId, newDoc, options)
     this.handles[documentId] = handle
     return handle
   }
@@ -25,6 +29,15 @@ export class DocCollection extends EventEmitter<DocCollectionEvents<unknown>> {
   create<T>(): DocHandle<T> {
     const documentId = v4() as DocumentId
     const handle = this.cacheHandle(documentId, true) as DocHandle<T>
+    this.emit("document", { handle })
+    return handle
+  }
+
+  createUnstable<T>(): DocHandle<T> {
+    const documentId = v4() as DocumentId
+    const handle = this.cacheHandle(documentId, true, {
+      unstable: true,
+    }) as DocHandle<T>
     this.emit("document", { handle })
     return handle
   }

--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -26,18 +26,9 @@ export class DocCollection extends EventEmitter<DocCollectionEvents<unknown>> {
   // (but: we need to make sure the storage system will collect it)
   // (next: we need to have some kind of reify function)
   // (then: cambria!)
-  create<T>(): DocHandle<T> {
+  create<T>(options?: DocHandleOptions): DocHandle<T> {
     const documentId = v4() as DocumentId
-    const handle = this.cacheHandle(documentId, true) as DocHandle<T>
-    this.emit("document", { handle })
-    return handle
-  }
-
-  createUnstable<T>(): DocHandle<T> {
-    const documentId = v4() as DocumentId
-    const handle = this.cacheHandle(documentId, true, {
-      unstable: true,
-    }) as DocHandle<T>
+    const handle = this.cacheHandle(documentId, true, options) as DocHandle<T>
     this.emit("document", { handle })
     return handle
   }

--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -37,13 +37,13 @@ export class DocCollection extends EventEmitter<DocCollectionEvents<unknown>> {
    * find() locates a document by id. It gets data from the local system, but also by sends a
    * 'document' event which a CollectionSynchronizer would use to advertise interest to other peers
    */
-  find<T>(documentId: DocumentId): DocHandle<T> {
+  find<T>(documentId: DocumentId, options?: DocHandleOptions): DocHandle<T> {
     // TODO: we want a way to make sure we don't yield
     //       intermediate document states during initial synchronization
     if (this.handles[documentId]) {
       return this.handles[documentId] as DocHandle<T>
     }
-    const handle = this.cacheHandle(documentId, false)
+    const handle = this.cacheHandle(documentId, false, options)
 
     // we don't directly initialize a value here because
     // the StorageSubsystem and Synchronizers go and get the data

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -1,6 +1,6 @@
 import EventEmitter from "eventemitter3"
 import * as Automerge from "@automerge/automerge"
-import { ChangeOptions, Doc, Extend } from "@automerge/automerge"
+import type { ChangeFn, ChangeOptions, Doc } from "@automerge/automerge"
 import { ChannelId, PeerId } from "."
 
 import debug from "debug"
@@ -163,7 +163,7 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
     return this.doc
   }
 
-  change(callback: (doc: Extend<T>) => void, options: ChangeOptions<T> = {}) {
+  change(callback: ChangeFn<T>, options: ChangeOptions<T> = {}) {
     this.value().then(() => {
       const newDoc = Automerge.change<T>(this.doc, options, callback)
       this.__notifyChangeListeners(newDoc)

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -1,5 +1,5 @@
 import { CollectionSynchronizer } from "../src/synchronizer/CollectionSynchronizer"
-import { DocCollection } from "../dist"
+import { DocCollection } from "../src"
 import assert from "assert"
 
 describe("CollectionSynchronizer", () => {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -37,7 +37,7 @@ describe("Repo", () => {
   })
 
   it("can create and change a document using the unstable Automerge API", done => {
-    const handle = repo.createUnstable<TestDoc>()
+    const handle = repo.create<TestDoc>({ unstable: true })
 
     handle.change(doc => {
       doc.foo = "bar"


### PR DESCRIPTION
This introduces a new method to the `DocCollection` class to allow new `DocHandle`s to be created using the Automerge `unstable` branch.

Tests were failing to build due to an incorrect type on the `DocHandle` change method and an import from `dist` in one of the tests. Corrected both of those here too, but please let me know if you would like me to separate those out into another PR.