### PR TITLE
Use Automerge.ChangeFn

### DIFF
--- a/packages/automerge-repo-react-hooks/src/index.ts
+++ b/packages/automerge-repo-react-hooks/src/index.ts
@@ -1,4 +1,3 @@
-export * from "./types"
 export { useDocument } from "./useDocument"
 export { useHandle } from "./useHandle"
 export { RepoContext, useRepo } from "./useRepo"

--- a/packages/automerge-repo-react-hooks/src/types.ts
+++ b/packages/automerge-repo-react-hooks/src/types.ts
@@ -1,2 +1,0 @@
-export type ChangeFn<T> = (d: T) => void
-export type Change<T> = (cf: ChangeFn<T>) => void

--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -1,7 +1,6 @@
-import { Doc } from "@automerge/automerge"
+import { Doc, ChangeFn } from "@automerge/automerge"
 import { DocumentId, DocHandleChangePayload } from "automerge-repo"
 import { useEffect, useState } from "react"
-import { ChangeFn } from "./types"
 import { useRepo } from "./useRepo"
 
 export function useDocument<T>(documentId?: DocumentId) {


### PR DESCRIPTION
Fixes this build error: 

```
src/useDocument.ts(29,19): error TS2345: Argument of type 
'import("C:/git/pvh/automerge-repo/packages/automerge-repo-react-hooks/src/types").ChangeFn<T>' 
is not assignable to parameter of type 
'import("C:/git/pvh/automerge-repo/node_modules/@automerge/automerge/dist/stable").ChangeFn<T>'.
```

We were using vendored types for Automerge `Change` and `ChangeFn`: 

```ts
// types.ts (deleted)
export type ChangeFn<T> = (d: T) => void
export type Change<T> = (cf: ChangeFn<T>) => void
```

Instead we can just import these directly from Automerge: 
```ts
import { Doc, ChangeFn } from "@automerge/automerge"
```
