### PR TITLE
Straighten out SharePolicy type

### DIFF
--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -1,7 +1,8 @@
 import EventEmitter from "eventemitter3"
 import { v4 as uuid } from "uuid"
 import { DocHandle } from "./DocHandle.js"
-import type { DocumentId, PeerId } from "./types.js"
+import { type DocumentId } from "./types.js"
+import { type SharePolicy } from "./Repo.js"
 
 /**
  * A DocCollection is a collection of DocHandles. It supports creating new documents and finding
@@ -10,14 +11,12 @@ import type { DocumentId, PeerId } from "./types.js"
 export class DocCollection extends EventEmitter<DocCollectionEvents<unknown>> {
   #handleCache: Record<DocumentId, DocHandle<unknown>> = {}
 
+  /** By default, we share generously with all peers. */
+  sharePolicy: SharePolicy = async () => true
+
   constructor() {
     super()
   }
-
-  sharePolicy: (peerId: PeerId, documentId: DocumentId) => Promise<boolean> =
-    async () => {
-      return true
-    }
 
   /** Returns an existing handle if we have it; creates one otherwise. */
   #handleFromCache(

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -11,10 +11,6 @@ import debug from "debug"
 
 const SYNC_CHANNEL = "sync_channel" as ChannelId
 
-/** By default, we share generously with all peers. */
-const GENEROUS_SHARE_POLICY = (async (_peerId, _documentId) =>
-  true) as SharePolicy
-
 /** A Repo is a DocCollection with networking, syncing, and storage capabilities. */
 export class Repo extends DocCollection {
   #log: debug.Debugger
@@ -23,17 +19,12 @@ export class Repo extends DocCollection {
   storageSubsystem?: StorageSubsystem
   ephemeralData: EphemeralData
 
-  constructor({
-    storage,
-    network,
-    peerId,
-    sharePolicy = GENEROUS_SHARE_POLICY,
-  }: RepoConfig) {
+  constructor({ storage, network, peerId, sharePolicy }: RepoConfig) {
     super()
 
     this.#log = debug(`automerge-repo:repo:${peerId}`)
 
-    this.sharePolicy = sharePolicy
+    this.sharePolicy = sharePolicy ?? this.sharePolicy
 
     // The storage subsystem has access to some form of persistence, and deals with save and loading documents.
     const storageSubsystem = storage ? new StorageSubsystem(storage) : undefined
@@ -126,7 +117,6 @@ export class Repo extends DocCollection {
   }
 }
 
-type SharePolicy = (peerId: PeerId, documentId: DocumentId) => Promise<boolean>
 export interface RepoConfig {
   /** Our unique identifier */
   peerId?: PeerId
@@ -143,3 +133,8 @@ export interface RepoConfig {
    */
   sharePolicy?: SharePolicy
 }
+
+export type SharePolicy = (
+  peerId: PeerId,
+  documentId?: DocumentId
+) => Promise<boolean>

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -14,7 +14,7 @@ export type {
   PeerDisconnectedPayload,
 } from "./network/NetworkAdapter.js"
 export { NetworkSubsystem } from "./network/NetworkSubsystem.js"
-export { Repo } from "./Repo.js"
+export { Repo, SharePolicy } from "./Repo.js"
 export { StorageAdapter } from "./storage/StorageAdapter.js"
 export { StorageSubsystem } from "./storage/StorageSubsystem.js"
 export { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js"

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -34,6 +34,7 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
 
     networkAdapter.on("peer-candidate", ({ peerId, channelId }) => {
       this.#log(`peer candidate: ${peerId} `)
+
       if (!this.#adaptersByPeer[peerId]) {
         // TODO: handle losing a server here
         this.#adaptersByPeer[peerId] = networkAdapter

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -45,9 +45,7 @@ describe("CollectionSynchronizer", () => {
   it("should not synchronize to a peer which is excluded from the share policy", done => {
     const handle = collection.create()
 
-    collection.sharePolicy = async (peerId: PeerId, documentId: string) => {
-      return peerId !== "peer1"
-    }
+    collection.sharePolicy = async (peerId: PeerId) => peerId !== "peer1"
 
     synchronizer.addDocument(handle.documentId).then(() => {
       synchronizer.once("message", () => {
@@ -61,13 +59,12 @@ describe("CollectionSynchronizer", () => {
 
   it("should not synchronize a document which is excluded from the share policy", done => {
     const handle = collection.create()
-    collection.sharePolicy = async (_, documentId: DocumentId) => {
-      return documentId !== handle.documentId
-    }
+    collection.sharePolicy = async (_, documentId) =>
+      documentId !== handle.documentId
 
     synchronizer.addPeer("peer2" as PeerId)
 
-    synchronizer.once("message", event => {
+    synchronizer.once("message", () => {
       done(new Error("Should not have sent a message"))
     })
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -9,6 +9,7 @@ import {
   HandleState,
   InboundMessagePayload,
   PeerId,
+  SharePolicy,
 } from "../src"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
@@ -82,14 +83,15 @@ describe("Repo", () => {
       const { port1: bobToCharlie, port2: charlieToBob } = bobCharlieChannel
 
       const excludedDocuments: DocumentId[] = []
-      const excludedPeers: PeerId[] = []
 
-      const sharePolicy = async (peerId: PeerId, documentId: DocumentId) => {
+      const sharePolicy: SharePolicy = async (peerId, documentId) => {
+        if (documentId === undefined) return false
+
         // make sure that charlie never gets excluded documents
         if (excludedDocuments.includes(documentId) && peerId === "charlie")
           return false
 
-        return !excludedPeers.includes(peerId)
+        return true
       }
 
       const aliceRepo = new Repo({


### PR DESCRIPTION
This PR changes the `SharePolicy` type (introduced in #21) to make the `documentId` parameter optional: 

https://github.com/automerge/automerge-repo/blob/8bb595db3ba03c5866777c478400b5e5333487d8/packages/automerge-repo/src/Repo.ts#L137-L140

This PR includes a couple of related refactorings — see inline comments below. 
