### PR TITLE
Refactor DocHandle

### DIFF
--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -30,7 +30,7 @@ export class DocCollection extends EventEmitter<DocCollectionEvents> {
     if (this.#handleCache[documentId]) return this.#handleCache[documentId]
 
     // If not, create a new handle, cache it, and return it
-    const handle = new DocHandle<T>(documentId, isNew)
+    const handle = new DocHandle<T>(documentId, { isNew })
     this.#handleCache[documentId] = handle
     return handle
   }

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -23,7 +23,10 @@ export class DocHandle<T> //
 
   #machine: DocHandleXstateMachine<T>
 
-  constructor(public documentId: DocumentId, isNew: boolean = false) {
+  constructor(
+    public documentId: DocumentId,
+    { isNew = false, timeoutDelay = 7000 }: DocHandleOptions = {}
+  ) {
     super()
     this.#log = debug(`automerge-repo:dochandle:${documentId.slice(0, 5)}`)
 
@@ -69,7 +72,7 @@ export class DocHandle<T> //
               },
               after: {
                 // If we don't get a response within a certain time, we... do something but not sure what
-                [TIMEOUT_DELAY]: { actions: "failTimeout", target: ERROR },
+                [timeoutDelay]: { actions: "failTimeout", target: ERROR },
               },
             },
             ready: {
@@ -177,6 +180,11 @@ export class DocHandle<T> //
 
 // TYPES
 
+interface DocHandleOptions {
+  isNew?: boolean
+  timeoutDelay?: number
+}
+
 export const HandleState = {
   IDLE: "idle",
   LOADING: "loading",
@@ -281,6 +289,5 @@ type DocHandleXstateMachine<T> = Interpreter<
 
 // CONSTANTS
 
-const TIMEOUT_DELAY = 7000
 const { IDLE, LOADING, REQUESTING, READY, ERROR } = HandleState
 const { CREATE, LOAD, FIND, REQUEST, UPDATE, TIMEOUT } = Event

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -58,8 +58,6 @@ export class DocHandle<T> //
               on: {
                 // LOAD is called by the Repo if the document is found in storage
                 LOAD: { actions: "onLoad", target: READY },
-                // TODO: UPDATE doesn't belong here
-                UPDATE: { actions: "onUpdate", target: READY },
                 // REQUEST is called by the Repo if the document is not found in storage
                 REQUEST: { target: REQUESTING },
               },
@@ -173,6 +171,7 @@ export class DocHandle<T> //
 
   /** `change` is called by the repo when the document is changed locally  */
   async change(callback: A.ChangeFn<T>, options: A.ChangeOptions<T> = {}) {
+    if (this.state === LOADING) throw new Error("Cannot change while loading")
     const doc = await this.value()
     const newDoc = A.change(doc, options, callback)
     this.#machine.send(UPDATE, { payload: { doc: newDoc } })

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -138,7 +138,7 @@ export class DocHandle<T> //
 
   /** Returns the docHandle's state (READY, ) */
   get #state() {
-    return this.#machine?.getSnapshot().value as HandleState
+    return this.#machine?.getSnapshot().value
   }
 
   // PUBLIC

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -134,28 +134,20 @@ export class DocHandle<T> //
 
   /**
    * Returns the current document, waiting for the handle to be ready if necessary.
-   * @param waitForState The states to wait for. Defaults to `READY`.
    */
-  async value(waitForState: HandleState[] = [READY]) {
-    if (waitForState.includes(this.state)) {
+  async value() {
+    if (this.isReady()) {
       // we're already at one of the desired states; yield a tick
       await pause()
     } else {
       // wait until we reach one of the desired states
       await new Promise<void>(async resolve =>
         this.#machine.onTransition(() => {
-          if (waitForState.includes(this.state)) resolve()
+          if (this.isReady()) resolve()
         })
       )
     }
     return this.doc
-  }
-
-  /**
-   * Returns the current document, waiting for the handle to be either in READY or REQUESTING state.
-   */
-  async provisionalValue() {
-    return this.value([READY, REQUESTING])
   }
 
   /** `load` is called by the repo when the document is found in storage */

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -151,7 +151,7 @@ export class DocHandle<T> //
   }
 
   /** `load` is called by the repo when the document is found in storage */
-  async load(binary: Uint8Array) {
+  load(binary: Uint8Array) {
     this.#machine.send(LOAD, { payload: { binary } })
   }
 

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -223,33 +223,12 @@ export const Event = {
 } as const
 type Event = (typeof Event)[keyof typeof Event]
 
-type CreateEvent = {
-  type: typeof CREATE
-  payload: { documentId: string }
-}
-
-type LoadEvent = {
-  type: typeof LOAD
-  payload: { binary: Uint8Array }
-}
-
-type FindEvent = {
-  type: typeof FIND
-  payload: { documentId: string }
-}
-
-type RequestEvent = {
-  type: typeof REQUEST
-}
-
-type UpdateEvent<T> = {
-  type: typeof UPDATE
-  payload: { doc: A.Doc<T> }
-}
-
-type TimeoutEvent = {
-  type: typeof TIMEOUT
-}
+type CreateEvent = { type: typeof CREATE; payload: { documentId: string } }
+type LoadEvent = { type: typeof LOAD; payload: { binary: Uint8Array } }
+type FindEvent = { type: typeof FIND; payload: { documentId: string } }
+type RequestEvent = { type: typeof REQUEST }
+type UpdateEvent<T> = { type: typeof UPDATE; payload: { doc: A.Doc<T> } }
+type TimeoutEvent = { type: typeof TIMEOUT }
 
 type DocHandleEvent<T> =
   | CreateEvent

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -160,22 +160,26 @@ export class DocHandle<T> //
     return this.value([READY, REQUESTING])
   }
 
-  async loadIncremental(binary: Uint8Array) {
+  /** `load` is called by the repo when the document is found in storage */
+  async load(binary: Uint8Array) {
     this.#machine.send(LOAD, { payload: { binary } })
   }
 
-  updateDoc(callback: (doc: A.Doc<T>) => A.Doc<T>) {
+  /** `update` is called by the repo when we receive changes from the network */
+  update(callback: (doc: A.Doc<T>) => A.Doc<T>) {
     const newDoc = callback(this.doc)
     this.#machine.send(UPDATE, { payload: { doc: newDoc } })
   }
 
+  /** `change` is called by the repo when the document is changed locally  */
   async change(callback: A.ChangeFn<T>, options: A.ChangeOptions<T> = {}) {
     const doc = await this.value()
     const newDoc = A.change(doc, options, callback)
     this.#machine.send(UPDATE, { payload: { doc: newDoc } })
   }
 
-  requestSync() {
+  /** `request` is called by the repo when the document is not found in storage */
+  request() {
     if (this.state === LOADING) this.#machine.send(REQUEST)
   }
 }

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -32,7 +32,7 @@ export class Repo extends DocCollection {
       if (storageSubsystem) {
         // Try to load from disk
         const binary = await storageSubsystem.loadBinary(handle.documentId)
-        handle.loadIncremental(binary)
+        handle.load(binary)
 
         // Save when the document changes
         handle.on("change", ({ handle }) =>
@@ -41,7 +41,7 @@ export class Repo extends DocCollection {
       }
 
       // Advertise our interest in the document
-      handle.requestSync()
+      handle.request()
 
       // Register the document with the synchronizer
       synchronizer.addDocument(handle.documentId)

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -35,9 +35,10 @@ export class Repo extends DocCollection {
         handle.load(binary)
 
         // Save when the document changes
-        handle.on("change", ({ handle }) =>
-          storageSubsystem.save(handle.documentId, handle.doc)
-        )
+        handle.on("change", async ({ handle }) => {
+          const doc = await handle.value()
+          storageSubsystem.save(handle.documentId, doc)
+        })
       }
 
       // Advertise our interest in the document

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -38,7 +38,7 @@ export class DocSynchronizer extends Synchronizer {
 
   async #syncWithPeers() {
     this.#log(`syncWithPeers`)
-    const doc = await this.handle.provisionalValue()
+    const doc = await this.handle.value()
     this.#peers.forEach(peerId => this.#sendSyncMessage(peerId, doc))
   }
 
@@ -106,7 +106,7 @@ export class DocSynchronizer extends Synchronizer {
 
   async beginSync(peerId: PeerId) {
     this.#log(`beginSync: ${peerId}`)
-    const doc = await this.handle.provisionalValue()
+    const doc = await this.handle.value()
 
     // HACK: if we have a sync state already, we round-trip it through the encoding system to make
     // sure state is preserved. This prevents an infinite loop caused by failed attempts to send
@@ -135,7 +135,7 @@ export class DocSynchronizer extends Synchronizer {
 
     // We need to block receiving the syncMessages until we've checked local storage
     // TODO: this is kind of an opaque way of doing this...
-    // await this.handle.provisionalValue()
+    // await this.handle.value()
 
     this.#logMessage(`onSyncMessage 🡐 ${peerId}`, message)
 

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -139,7 +139,7 @@ export class DocSynchronizer extends Synchronizer {
 
     this.#logMessage(`onSyncMessage 🡐 ${peerId}`, message)
 
-    this.handle.updateDoc(doc => {
+    this.handle.update(doc => {
       const [newDoc, newSyncState] = A.receiveSyncMessage(
         doc,
         this.#getSyncState(peerId),

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -10,12 +10,12 @@ describe("DocHandle", () => {
     assert.equal(handle.documentId, "test-document-id")
   })
 
-  it("should not be ready until updateDoc is called", () => {
+  it("should not be ready until update is called", () => {
     const handle = new DocHandle<TestDoc>("test-document-id" as DocumentId)
     assert.equal(handle.isReady(), false)
-    // updateDoc is called by the sync / storage systems
+    // update is called by the sync / storage systems
     // this call is just to simulate loading
-    handle.updateDoc(doc => Automerge.change(doc, d => (d.foo = "bar")))
+    handle.update(doc => Automerge.change(doc, d => (d.foo = "bar")))
     assert.equal(handle.isReady(), true)
   })
 
@@ -24,7 +24,7 @@ describe("DocHandle", () => {
     assert.equal(handle.isReady(), false)
     let tooSoon = true as boolean
 
-    handle.updateDoc(doc => {
+    handle.update(doc => {
       tooSoon = false
       return Automerge.change(doc, d => (d.foo = "bar"))
     })
@@ -40,7 +40,7 @@ describe("DocHandle", () => {
     const handle = new DocHandle<TestDoc>("test-document-id" as DocumentId)
     assert.equal(handle.isReady(), false)
 
-    handle.loadIncremental(
+    handle.load(
       Automerge.save(
         Automerge.change<{ foo: string }>(
           Automerge.init(),
@@ -57,7 +57,7 @@ describe("DocHandle", () => {
     const handle = new DocHandle<TestDoc>("test-document-id" as DocumentId)
     assert.equal(handle.isReady(), false)
     let tooSoon = true
-    handle.updateDoc(doc => {
+    handle.update(doc => {
       tooSoon = false
       return Automerge.change(doc, d => (d.foo = "bar"))
     })
@@ -85,7 +85,7 @@ describe("DocHandle", () => {
     assert.equal(handle.doc.foo, "bar")
   })
 
-  it("should not emit a change message if no change happens via updateDoc", done => {
+  it("should not emit a change message if no change happens via update", done => {
     const handle = new DocHandle<TestDoc>(
       "test-document-id" as DocumentId,
       true
@@ -93,7 +93,7 @@ describe("DocHandle", () => {
     handle.on("change", () => {
       done(new Error("shouldn't have changed"))
     })
-    handle.updateDoc(d => {
+    handle.update(d => {
       setTimeout(done, 0)
       return d
     })

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -5,13 +5,15 @@ import { eventPromise } from "../src/helpers/eventPromise.js"
 import { TestDoc } from "./types.js"
 
 describe("DocHandle", () => {
+  const TEST_ID = "test-document-id" as DocumentId
+
   it("should take the UUID passed into it", () => {
-    const handle = new DocHandle("test-document-id" as DocumentId)
-    assert.equal(handle.documentId, "test-document-id")
+    const handle = new DocHandle(TEST_ID)
+    assert.equal(handle.documentId, TEST_ID)
   })
 
   it("should not be ready until update is called", () => {
-    const handle = new DocHandle<TestDoc>("test-document-id" as DocumentId)
+    const handle = new DocHandle<TestDoc>(TEST_ID)
     assert.equal(handle.isReady(), false)
     // update is called by the sync / storage systems
     // this call is just to simulate loading
@@ -20,7 +22,7 @@ describe("DocHandle", () => {
   })
 
   it("should not return a value until ready()", async () => {
-    const handle = new DocHandle<TestDoc>("test-document-id" as DocumentId)
+    const handle = new DocHandle<TestDoc>(TEST_ID)
     assert.equal(handle.isReady(), false)
     let tooSoon = true as boolean
 
@@ -37,7 +39,7 @@ describe("DocHandle", () => {
   })
 
   it("should return provisionalValue following an incremental load on an existing document", async () => {
-    const handle = new DocHandle<TestDoc>("test-document-id" as DocumentId)
+    const handle = new DocHandle<TestDoc>(TEST_ID)
     assert.equal(handle.isReady(), false)
 
     handle.load(
@@ -54,7 +56,7 @@ describe("DocHandle", () => {
   })
 
   it("should block changes until ready()", done => {
-    const handle = new DocHandle<TestDoc>("test-document-id" as DocumentId)
+    const handle = new DocHandle<TestDoc>(TEST_ID)
     assert.equal(handle.isReady(), false)
     let tooSoon = true
     handle.update(doc => {
@@ -73,10 +75,7 @@ describe("DocHandle", () => {
   })
 
   it("should emit a change message when changes happen", async () => {
-    const handle = new DocHandle<TestDoc>(
-      "test-document-id" as DocumentId,
-      true
-    )
+    const handle = new DocHandle<TestDoc>(TEST_ID, true)
     handle.change(doc => {
       doc.foo = "bar"
     })
@@ -86,10 +85,7 @@ describe("DocHandle", () => {
   })
 
   it("should not emit a change message if no change happens via update", done => {
-    const handle = new DocHandle<TestDoc>(
-      "test-document-id" as DocumentId,
-      true
-    )
+    const handle = new DocHandle<TestDoc>(TEST_ID, true)
     handle.on("change", () => {
       done(new Error("shouldn't have changed"))
     })
@@ -100,10 +96,7 @@ describe("DocHandle", () => {
   })
 
   it("should emit a patch message when changes happen", async () => {
-    const handle = new DocHandle<TestDoc>(
-      "test-document-id" as DocumentId,
-      true
-    )
+    const handle = new DocHandle<TestDoc>(TEST_ID, true)
     handle.change(doc => {
       doc.foo = "bar"
     })
@@ -113,10 +106,7 @@ describe("DocHandle", () => {
   })
 
   it("should not emit a patch message if no change happens", done => {
-    const handle = new DocHandle<TestDoc>(
-      "test-document-id" as DocumentId,
-      true
-    )
+    const handle = new DocHandle<TestDoc>(TEST_ID, true)
     handle.on("patch", () => {
       done(new Error("shouldn't have patched"))
     })

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -48,14 +48,14 @@ describe("DocHandle", () => {
     const handle = new DocHandle<TestDoc>(TEST_ID)
 
     // can't make changes in LOADING state
-    assert.equal(handle.state, HandleState.LOADING)
+    assert.equal(handle.isReady(), false)
     assert.rejects(() => handle.change(d => (d.foo = "baz")))
 
     // simulate loading from storage
     handle.load(binaryFromMockStorage())
 
     // now we're in READY state so we can make changes
-    assert.equal(handle.state, HandleState.READY)
+    assert.equal(handle.isReady(), true)
     handle.change(d => (d.foo = "pizza"))
 
     const doc = await handle.value()
@@ -69,7 +69,8 @@ describe("DocHandle", () => {
     })
 
     await eventPromise(handle, "change")
-    assert.equal(handle.doc.foo, "bar")
+    const doc = await handle.value()
+    assert.equal(doc.foo, "bar")
   })
 
   it("should not emit a change message if no change happens via update", done => {

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -63,7 +63,7 @@ describe("DocHandle", () => {
   })
 
   it("should emit a change message when changes happen", async () => {
-    const handle = new DocHandle<TestDoc>(TEST_ID, true)
+    const handle = new DocHandle<TestDoc>(TEST_ID, { isNew: true })
     handle.change(doc => {
       doc.foo = "bar"
     })
@@ -74,7 +74,7 @@ describe("DocHandle", () => {
   })
 
   it("should not emit a change message if no change happens via update", done => {
-    const handle = new DocHandle<TestDoc>(TEST_ID, true)
+    const handle = new DocHandle<TestDoc>(TEST_ID, { isNew: true })
     handle.on("change", () => {
       done(new Error("shouldn't have changed"))
     })
@@ -85,7 +85,7 @@ describe("DocHandle", () => {
   })
 
   it("should emit a patch message when changes happen", async () => {
-    const handle = new DocHandle<TestDoc>(TEST_ID, true)
+    const handle = new DocHandle<TestDoc>(TEST_ID, { isNew: true })
     handle.change(doc => {
       doc.foo = "bar"
     })
@@ -95,7 +95,7 @@ describe("DocHandle", () => {
   })
 
   it("should not emit a patch message if no change happens", done => {
-    const handle = new DocHandle<TestDoc>(TEST_ID, true)
+    const handle = new DocHandle<TestDoc>(TEST_ID, { isNew: true })
     handle.on("patch", () => {
       done(new Error("shouldn't have patched"))
     })

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -44,17 +44,6 @@ describe("DocHandle", () => {
     assert.equal(doc.foo, "bar")
   })
 
-  it("should return provisionalValue following an incremental load on an existing document", async () => {
-    const handle = new DocHandle<TestDoc>(TEST_ID)
-    assert.equal(handle.isReady(), false)
-
-    handle.load(binaryFromMockStorage())
-
-    const provisionalDoc = await handle.provisionalValue()
-    assert.equal(handle.isReady(), true)
-    assert.equal(provisionalDoc.foo, "bar")
-  })
-
   it("should block changes until ready()", async () => {
     const handle = new DocHandle<TestDoc>(TEST_ID)
 

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -13,7 +13,8 @@ describe("DocSynchronizer", () => {
   let docSynchronizer: DocSynchronizer
 
   const setup = () => {
-    handle = new DocHandle<{ foo: string }>("synced-doc" as DocumentId, true)
+    const docId = "synced-doc" as DocumentId
+    handle = new DocHandle<TestDoc>(docId, { isNew: true })
     docSynchronizer = new DocSynchronizer(handle)
     return { handle, docSynchronizer }
   }

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -40,7 +40,7 @@ describe("Repo", () => {
         d.foo = "bar"
       })
       const v = await handle.value()
-      assert.equal(handle.state, HandleState.READY)
+      assert.equal(handle.isReady(), true)
 
       assert.equal(v.foo, "bar")
     })
@@ -51,12 +51,12 @@ describe("Repo", () => {
       handle.change(d => {
         d.foo = "bar"
       })
-      assert(handle.state === HandleState.READY)
+      assert.equal(handle.isReady(), true)
 
       const bobHandle = repo.find<TestDoc>(handle.documentId)
 
       assert.equal(handle, bobHandle)
-      assert.equal(handle.state, HandleState.READY)
+      assert.equal(handle.isReady(), true)
 
       const v = await bobHandle.value()
       assert.equal(v.foo, "bar")


### PR DESCRIPTION
Changes to DocHandle. See the commit messages for a summary of the changes.

Includes a functional change, which is to reject the `.value()` promise after a timeout. 