### PR TITLE
Fix timeout implementation in DocHandle

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -139,8 +139,12 @@ export class DocHandle<T> //
     return this.#machine?.getSnapshot().value
   }
 
-  #statePromise(state: HandleState) {
-    return waitFor(this.#machine, s => s.matches(state))
+  /** Returns a promise that resolves when the docHandle is in one of the given states */
+  #statePromise(awaitStates: HandleState | HandleState[]) {
+    if (!Array.isArray(awaitStates)) awaitStates = [awaitStates]
+    return Promise.any(
+      awaitStates.map(state => waitFor(this.#machine, s => s.matches(state)))
+    )
   }
 
   // PUBLIC

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -170,17 +170,7 @@ export class DocHandle<T> //
   }
 
   async loadAttemptedValue() {
-    await pause() // yield one tick because reasons
-    await Promise.race([
-      // once we're ready, we can return the document
-      this.#statePromise(REQUESTING),
-      this.#statePromise(READY),
-      // but if the delay expires and we're still not ready, we'll throw an error
-      pause(this.#timeoutDelay),
-    ])
-    if (!(this.isReady() || this.#state === REQUESTING))
-      throw new Error(`DocHandle timed out loading document ${this.documentId}`)
-    return this.#doc
+    return this.value([READY, REQUESTING])
   }
 
   /** `load` is called by the repo when the document is found in storage */

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -45,13 +45,11 @@ export class DocHandle<T> //
      * Internally we use a state machine to orchestrate document loading and/or syncing, in order to
      * avoid requesting data we already have, or surfacing intermediate values to the consumer.
      *
-     *                                                                      ┌─────────┐
-     *                                                   ┌─TIMEOUT─────────►│  error  │
-     *                      ┌─────────┐           ┌──────┴─────┐            └─────────┘
+     *                      ┌─────────┐           ┌────────────┐
      *  ┌───────┐  ┌──FIND──┤ loading ├─REQUEST──►│ requesting ├─UPDATE──┐
      *  │ idle  ├──┤        └───┬─────┘           └────────────┘         │
-     *  └───────┘  │           LOAD                                      └─►┌─────────┐
-     *             │            └──────────────────────────────────────────►│  ready  │
+     *  └───────┘  │            │                                        └─►┌─────────┐
+     *             │            └───────LOAD───────────────────────────────►│  ready  │
      *             └──CREATE───────────────────────────────────────────────►└─────────┘
      */
     this.#machine = interpret(

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -134,7 +134,7 @@ export class DocHandle<T> //
     return this.#machine?.getSnapshot().context.doc
   }
 
-  /** Returns the docHandle's state (READY, ) */
+  /** Returns the docHandle's state (READY, etc.) */
   get #state() {
     return this.#machine?.getSnapshot().value
   }

--- a/packages/automerge-repo/src/helpers/withTimeout.ts
+++ b/packages/automerge-repo/src/helpers/withTimeout.ts
@@ -1,3 +1,7 @@
+/**
+ * If `promise` is resolved before `t` ms elapse, the timeout is cleared and the result of the
+ * promise is returned. If the timeout ends first, a `TimeoutError` is thrown.
+ */
 export const withTimeout = async <T>(
   promise: Promise<T>,
   t: number
@@ -15,6 +19,7 @@ export const withTimeout = async <T>(
     clearTimeout(timeoutId!)
   }
 }
+
 export class TimeoutError extends Error {
   constructor(message: string) {
     super(message)

--- a/packages/automerge-repo/src/helpers/withTimeout.ts
+++ b/packages/automerge-repo/src/helpers/withTimeout.ts
@@ -1,0 +1,23 @@
+export const withTimeout = async <T>(
+  promise: Promise<T>,
+  t: number
+): Promise<T> => {
+  let timeoutId: ReturnType<typeof setTimeout>
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new TimeoutError(`withTimeout: timed out after ${t}ms`)),
+      t
+    )
+  })
+  try {
+    return await Promise.race([promise, timeoutPromise])
+  } finally {
+    clearTimeout(timeoutId!)
+  }
+}
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "TimeoutError"
+  }
+}


### PR DESCRIPTION
With `timeoutDelay` set to 700,000 ms 🤔 the tests were never finishing on their own, because the timeouts from `pause(this.#timeoutDelay)` were never cleared even if all tests completed. 

I've added a `withTimeout(p,t)` helper that takes a promise and a timeout. If the promise is resolved before the timeout ends, the timeout is cleared. If the timeout ends first, a `TimeoutError` is thrown. 

Since `DocHandle.value` and `DocHandle.loadAttemptedValue` only differ in the set of states they wait for, I've refactored the two so that the common logic isn't duplicated: 

```ts
  async value(awaitStates: HandleState[] = [READY]) {
      // ...
  }

  async loadAttemptedValue() {
    return this.value([READY, REQUESTING])
  }
```


