### PR TITLE
Added missing `.js` extension to a few more imports

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -13,10 +13,10 @@ import {
   StateValue,
   TypegenDisabled,
 } from "xstate"
-import { waitFor } from "xstate/lib/waitFor"
-import { headsAreSame } from "./helpers/headsAreSame"
-import { pause } from "./helpers/pause"
-import { ChannelId, DocumentId, PeerId } from "./types"
+import { waitFor } from "xstate/lib/waitFor.js"
+import { headsAreSame } from "./helpers/headsAreSame.js"
+import { pause } from "./helpers/pause.js"
+import type { ChannelId, DocumentId, PeerId } from "./types.js"
 
 /** DocHandle is a wrapper around a single Automerge document that lets us listen for changes. */
 export class DocHandle<T> //

--- a/packages/automerge-repo/src/EphemeralData.ts
+++ b/packages/automerge-repo/src/EphemeralData.ts
@@ -1,6 +1,6 @@
 import { decode, encode } from "cbor-x"
 import EventEmitter from "eventemitter3"
-import { ChannelId, PeerId } from "."
+import { ChannelId, PeerId } from "./index.js"
 import { MessagePayload } from "./network/NetworkAdapter.js"
 
 /**

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -14,7 +14,7 @@ export type {
   PeerDisconnectedPayload,
 } from "./network/NetworkAdapter.js"
 export { NetworkSubsystem } from "./network/NetworkSubsystem.js"
-export { Repo, SharePolicy } from "./Repo.js"
+export { Repo, type SharePolicy } from "./Repo.js"
 export { StorageAdapter } from "./storage/StorageAdapter.js"
 export { StorageSubsystem } from "./storage/StorageSubsystem.js"
 export { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js"


### PR DESCRIPTION
There is also the option of setting `"moduleResolution": "nodenext",` in `tsconfig` which would help enforce this, but it seems to also break some of the type imports for me in VSCode.