### PR TITLE
Fix incremental saves following a load

### DIFF
--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -38,7 +38,7 @@ export class StorageSubsystem {
     this.#changeCount[documentId] = 0
   }
 
-  async loadBinary(documentId: string): Promise<Uint8Array> {
+  async loadBinary(documentId: DocumentId): Promise<Uint8Array> {
     const result = []
     let binary = await this.#storageAdapter.load(`${documentId}.snapshot`)
     if (binary && binary.length > 0) {
@@ -51,6 +51,7 @@ export class StorageSubsystem {
         `${documentId}.incremental.${index}`
       ))
     ) {
+      this.#changeCount[documentId] = index + 1
       if (binary && binary.length > 0) result.push(binary)
       index += 1
     }

--- a/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
@@ -16,4 +16,8 @@ export class DummyStorageAdapter implements StorageAdapter {
   remove(docId: DocumentId) {
     delete this.#data[docId]
   }
+
+  keys() {
+    return Object.keys(this.#data)
+  }
 }


### PR DESCRIPTION
Currently, if a document is loaded from storage, any subsequent incremental changes start again at 0. This overwrites local data.