### PR TITLE
Fixes saving of initial change on handle creation

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -30,15 +30,15 @@ export class Repo extends DocCollection {
     // up a document by ID. We listen for it in order to wire up storage and network synchronization.
     this.on("document", async ({ handle }) => {
       if (storageSubsystem) {
-        // Try to load from disk
-        const binary = await storageSubsystem.loadBinary(handle.documentId)
-        handle.load(binary)
-
         // Save when the document changes
         handle.on("change", async ({ handle }) => {
           const doc = await handle.value()
           storageSubsystem.save(handle.documentId, doc)
         })
+
+        // Try to load from disk
+        const binary = await storageSubsystem.loadBinary(handle.documentId)
+        handle.load(binary)
       }
 
       // Advertise our interest in the document


### PR DESCRIPTION
When a document is created, attempting to load from storage was blocking attachment of the storage change listener.

The included test checks both that a created document can be written to immediately and that it is saved to storage such that a new repo (eg. on page refresh) can find the initial change properly.