### PR TITLE
Update to Automerge v2.0.3

### DIFF
--- a/packages/automerge-repo/package.json
+++ b/packages/automerge-repo/package.json
@@ -29,7 +29,7 @@
     "http-server": "^14.1.0"
   },
   "peerDependencies": {
-    "@automerge/automerge": ">=2.0.2"
+    "@automerge/automerge": ">=2.0.3"
   },
   "dependencies": {
     "cbor-x": "^1.3.0",

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -37,7 +37,7 @@ export class DocHandle<T> //
 
     // initial doc
     const doc = A.init<T>({
-      patchCallback: (patches, before, after) =>
+      patchCallback: (patches, { before, after }) =>
         this.emit("patch", { handle: this, patches, before, after }),
     })
 


### PR DESCRIPTION
The latest automerge release has changed the `PatchCallback` contract. This amends any usage of that in `automerge-repo`