### PR TITLE
Fix attempting to load empty data into a handle

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -181,7 +181,9 @@ export class DocHandle<T> //
 
   /** `load` is called by the repo when the document is found in storage */
   load(binary: Uint8Array) {
-    this.#machine.send(LOAD, { payload: { binary } })
+    if (binary.length) {
+      this.#machine.send(LOAD, { payload: { binary } })
+    }
   }
 
   /** `update` is called by the repo when we receive changes from the network */

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -47,6 +47,18 @@ describe("Repo", () => {
       assert.equal(v.foo, "bar")
     })
 
+    it("doesn't find a document that doesn't exist", async () => {
+      const { repo } = setup()
+      const handle = repo.find<TestDoc>("does-not-exist" as DocumentId)
+      assert.equal(handle.isReady(), false)
+
+      handle.value().then(() => {
+        throw new Error("This document should not exist")
+      })
+
+      await pause(500)
+    })
+
     it("can find a created document", async () => {
       const { repo } = setup()
       const handle = repo.create<TestDoc>()


### PR DESCRIPTION
Currently a handle never enters the `REQUESTING` state as empty local data us automatically loaded.

This prevents an empty `Uint8Array` being loaded into a handle and switching the handle state to `READY`