### PR TITLE
Delete documents

### DIFF
--- a/packages/automerge-repo/package.json
+++ b/packages/automerge-repo/package.json
@@ -29,7 +29,7 @@
     "http-server": "^14.1.0"
   },
   "peerDependencies": {
-    "@automerge/automerge": ">=2.0.2"
+    "@automerge/automerge": ">=2.0.3"
   },
   "dependencies": {
     "cbor-x": "^1.3.0",

--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -100,8 +100,10 @@ export class DocCollection extends EventEmitter<DocCollectionEvents> {
     /** The documentId of the handle to delete */
     documentId: DocumentId
   ) {
-    delete this.#handleCache[documentId]
+    const handle = this.#getHandle(documentId, false)
+    handle.delete()
 
+    delete this.#handleCache[documentId]
     this.emit("delete-document", { documentId })
   }
 }

--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -95,13 +95,27 @@ export class DocCollection extends EventEmitter<DocCollectionEvents> {
 
     return handle
   }
+
+  delete(
+    /** The documentId of the handle to delete */
+    documentId: DocumentId
+  ) {
+    delete this.#handleCache[documentId]
+
+    this.emit("delete-document", { documentId })
+  }
 }
 
 // events & payloads
 interface DocCollectionEvents {
   document: (arg: DocumentPayload) => void
+  "delete-document": (arg: DeleteDocumentPayload) => void
 }
 
 interface DocumentPayload {
   handle: DocHandle<any>
+}
+
+interface DeleteDocumentPayload {
+  documentId: DocumentId
 }

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -37,7 +37,7 @@ export class DocHandle<T> //
 
     // initial doc
     const doc = A.init<T>({
-      patchCallback: (patches, before, after) =>
+      patchCallback: (patches, { before, after }) =>
         this.emit("patch", { handle: this, patches, before, after }),
     })
 

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -13,10 +13,10 @@ import {
   StateValue,
   TypegenDisabled,
 } from "xstate"
-import { waitFor } from "xstate/lib/waitFor"
-import { headsAreSame } from "./helpers/headsAreSame"
-import { pause } from "./helpers/pause"
-import { ChannelId, DocumentId, PeerId } from "./types"
+import { waitFor } from "xstate/lib/waitFor.js"
+import { headsAreSame } from "./helpers/headsAreSame.js"
+import { pause } from "./helpers/pause.js"
+import type { ChannelId, DocumentId, PeerId } from "./types.js"
 
 /** DocHandle is a wrapper around a single Automerge document that lets us listen for changes. */
 export class DocHandle<T> //

--- a/packages/automerge-repo/src/EphemeralData.ts
+++ b/packages/automerge-repo/src/EphemeralData.ts
@@ -1,6 +1,6 @@
 import { decode, encode } from "cbor-x"
 import EventEmitter from "eventemitter3"
-import { ChannelId, PeerId } from "."
+import { ChannelId, PeerId } from "./index.js"
 import { MessagePayload } from "./network/NetworkAdapter.js"
 
 /**

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -48,6 +48,14 @@ export class Repo extends DocCollection {
       synchronizer.addDocument(handle.documentId)
     })
 
+    this.on("delete-document", ({ documentId }) => {
+      // synchronizer.removeDocument(documentId)
+
+      if (storageSubsystem) {
+        storageSubsystem.remove(documentId)
+      }
+    })
+
     // SYNCHRONIZER
     // The synchronizer uses the network subsystem to keep documents in sync with peers.
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -49,6 +49,7 @@ export class Repo extends DocCollection {
     })
 
     this.on("delete-document", ({ documentId }) => {
+      // TODO Pass the delete on to the network
       // synchronizer.removeDocument(documentId)
 
       if (storageSubsystem) {

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -14,7 +14,7 @@ export type {
   PeerDisconnectedPayload,
 } from "./network/NetworkAdapter.js"
 export { NetworkSubsystem } from "./network/NetworkSubsystem.js"
-export { Repo, SharePolicy } from "./Repo.js"
+export { Repo, type SharePolicy } from "./Repo.js"
 export { StorageAdapter } from "./storage/StorageAdapter.js"
 export { StorageSubsystem } from "./storage/StorageSubsystem.js"
 export { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js"

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -38,7 +38,7 @@ export class StorageSubsystem {
     this.#changeCount[documentId] = 0
   }
 
-  async loadBinary(documentId: string): Promise<Uint8Array> {
+  async loadBinary(documentId: DocumentId): Promise<Uint8Array> {
     const result = []
     let binary = await this.#storageAdapter.load(`${documentId}.snapshot`)
     if (binary && binary.length > 0) {
@@ -51,6 +51,7 @@ export class StorageSubsystem {
         `${documentId}.incremental.${index}`
       ))
     ) {
+      this.#changeCount[documentId] = index + 1
       if (binary && binary.length > 0) result.push(binary)
       index += 1
     }

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -74,6 +74,14 @@ export class StorageSubsystem {
     }
   }
 
+  remove(documentId: DocumentId) {
+    this.#storageAdapter.remove(`${documentId}.snapshot`)
+
+    for (let i = 0; i < this.#changeCount[documentId]; i++) {
+      this.#storageAdapter.remove(`${documentId}.incremental.${i}`)
+    }
+  }
+
   // TODO: make this, you know, good.
   #shouldCompact(documentId: DocumentId) {
     return this.#changeCount[documentId] >= 20

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -179,4 +179,16 @@ describe("DocHandle", () => {
     const doc = await handle.value()
     assert.equal(doc.foo, "bar")
   })
+
+  it("should emit a delete event when deleted", async () => {
+    const handle = new DocHandle<TestDoc>(TEST_ID, { isNew: true })
+
+    const p = new Promise<void>(resolve =>
+      handle.once("delete", () => resolve())
+    )
+    handle.delete()
+    await p
+
+    assert.equal(handle.isDeleted(), true)
+  })
 })

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -56,7 +56,7 @@ describe("Repo", () => {
         throw new Error("This document should not exist")
       })
 
-      await pause(500)
+      await pause(100)
     })
 
     it("can find a created document", async () => {
@@ -110,6 +110,7 @@ describe("Repo", () => {
         repo.delete(handle.documentId)
 
         assert(handle.isDeleted())
+        assert.equal(repo.handles[handle.documentId], undefined)
 
         const bobHandle = repo.find<TestDoc>(handle.documentId)
         bobHandle.value().then(() => {
@@ -247,6 +248,28 @@ describe("Repo", () => {
       assert.notEqual(aliceRepo.handles[notForCharlie], undefined, "alice yes")
       assert.notEqual(bobRepo.handles[notForCharlie], undefined, "bob yes")
       assert.equal(charlieRepo.handles[notForCharlie], undefined, "charlie no")
+
+      teardown()
+    })
+
+    it("a deleted document from charlieRepo can be refetched", async () => {
+      const { charlieRepo, aliceHandle, teardown } = await setup()
+
+      const deletePromise = eventPromise(charlieRepo, "delete-document")
+      charlieRepo.delete(aliceHandle.documentId)
+      await deletePromise
+
+      const changePromise = eventPromise(aliceHandle, "change")
+      aliceHandle.change(d => {
+        d.foo = "baz"
+      })
+      await changePromise
+
+      const handle3 = charlieRepo.find<TestDoc>(aliceHandle.documentId)
+      await eventPromise(handle3, "change")
+      const doc3 = await handle3.value()
+
+      assert.deepStrictEqual(doc3, { foo: "baz" })
 
       teardown()
     })

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -98,6 +98,42 @@ describe("Repo", () => {
       const v = await bobHandle.value()
       assert.equal(v.foo, "bar")
     })
+
+    it("can delete an existing document", async done => {
+      const { repo } = setup()
+      const handle = repo.create<TestDoc>()
+      handle.change(d => {
+        d.foo = "bar"
+      })
+      assert.equal(handle.isReady(), true)
+
+      repo.delete(handle.documentId)
+
+      const bobHandle = repo.find<TestDoc>(handle.documentId)
+
+      bobHandle.value().then(() => {
+        done(new Error("Document should have been deleted"))
+      })
+
+      await pause(500)
+    })
+
+    it("deleting a document emits an event", async done => {
+      const { repo } = setup()
+      const handle = repo.create<TestDoc>()
+      handle.change(d => {
+        d.foo = "bar"
+      })
+      assert.equal(handle.isReady(), true)
+
+      repo.on("delete-document", ({ documentId }) => {
+        assert.equal(documentId, handle.documentId)
+
+        done()
+      })
+
+      repo.delete(handle.documentId)
+    })
   })
 
   describe("sync", async () => {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -99,23 +99,27 @@ describe("Repo", () => {
       assert.equal(v.foo, "bar")
     })
 
-    it("can delete an existing document", async done => {
+    it("can delete an existing document", done => {
       const { repo } = setup()
       const handle = repo.create<TestDoc>()
       handle.change(d => {
         d.foo = "bar"
       })
       assert.equal(handle.isReady(), true)
+      handle.value().then(async () => {
+        repo.delete(handle.documentId)
 
-      repo.delete(handle.documentId)
+        assert(handle.isDeleted())
 
-      const bobHandle = repo.find<TestDoc>(handle.documentId)
+        const bobHandle = repo.find<TestDoc>(handle.documentId)
+        bobHandle.value().then(() => {
+          done(new Error("Document should have been deleted"))
+        })
+        await pause(10)
 
-      bobHandle.value().then(() => {
-        done(new Error("Document should have been deleted"))
+        assert(!bobHandle.isReady())
+        done()
       })
-
-      await pause(500)
     })
 
     it("deleting a document emits an event", async done => {

--- a/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
@@ -16,4 +16,8 @@ export class DummyStorageAdapter implements StorageAdapter {
   remove(docId: DocumentId) {
     delete this.#data[docId]
   }
+
+  keys() {
+    return Object.keys(this.#data)
+  }
 }


### PR DESCRIPTION
This adds a `delete` method to a repository which:

- Removes a handle from the cache
- Removes the underlying document data from storage
- Emits a `delete-document` event from the repo
- Emits a `delete` event from the handle
- Sets the internal handle state to `DELETED`
- closes #48 

Usage is `repo.delete(documentId)`.

At the moment, this makes no effort to communicate the deletion to the network.

Please let me know your thoughts and I will be sure to add documentation when we are happy with the API