### PR TITLE
Proposal: New signature for handle `change` event

### DIFF
--- a/packages/automerge-repo-network-messagechannel/package.json
+++ b/packages/automerge-repo-network-messagechannel/package.json
@@ -23,5 +23,8 @@
         ".ts"
       ]
     }
+  },
+  "devDependencies": {
+    "@types/chai": "^4.3.4"
   }
 }

--- a/packages/automerge-repo-network-websocket/.mocharc.json
+++ b/packages/automerge-repo-network-websocket/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "extension": ["ts"],
+  "spec": "test/*.test.ts",
+  "loader": "ts-node/esm"
+}

--- a/packages/automerge-repo-network-websocket/package.json
+++ b/packages/automerge-repo-network-websocket/package.json
@@ -10,7 +10,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "watch": "npm-watch"
+    "watch": "npm-watch",
+    "test": "mocha --no-warnings --experimental-specifier-resolution=node --exit"
   },
   "dependencies": {
     "automerge-repo": "^0.0.50",

--- a/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
@@ -110,7 +110,7 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
       senderId: this.peerId,
       targetId,
       channelId,
-      // type: "message",
+      type: "message",
       message,
       broadcast,
     }
@@ -140,9 +140,8 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   receiveMessage(message: Uint8Array) {
-    const decoded = CBOR.decode(
-      new Uint8Array(message)
-    ) as InboundMessagePayload
+    const decoded: InboundMessagePayload = CBOR.decode(new Uint8Array(message))
+
     const {
       type,
       senderId,

--- a/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
@@ -90,8 +90,17 @@ export class NodeWSServerAdapter extends NetworkAdapter {
   }
 
   receiveMessage(message: Uint8Array, socket: WebSocket) {
-    const cbor = CBOR.decode(message)
-    const { type, channelId, senderId, targetId, data, broadcast } = cbor
+    const cbor: InboundMessagePayload = CBOR.decode(message)
+
+    const {
+      type,
+      channelId,
+      senderId,
+      targetId,
+      message: data,
+      broadcast,
+    } = cbor
+
     const myPeerId = this.peerId
     if (!myPeerId) {
       throw new Error("Missing my peer ID.")

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -1,0 +1,72 @@
+import assert from "assert"
+import { PeerId, Repo } from "automerge-repo"
+import { eventPromise } from "automerge-repo/src/helpers/eventPromise"
+import ws from "isomorphic-ws"
+import { BrowserWebSocketClientAdapter } from "../src/BrowserWebSocketClientAdapter"
+import { NodeWSServerAdapter } from "../src/NodeWSServerAdapter"
+import { startServer } from "./utilities/WebSockets"
+
+describe("Websocket Tests", () => {
+  let repos: {
+    serverRepo: Repo
+    clientRepo: Repo
+    server: ws.Server
+  }
+
+  const port = 8080
+  before(async () => {
+    const { socket, server } = await startServer(port)
+
+    const serverRepo = new Repo({
+      network: [new NodeWSServerAdapter(socket)],
+      peerId: "server" as PeerId,
+      sharePolicy: async () => false,
+    })
+
+    const clientRepo = new Repo({
+      network: [new BrowserWebSocketClientAdapter("ws://localhost:" + port)],
+      peerId: "client" as PeerId,
+    })
+
+    repos = { serverRepo, clientRepo, server: server as unknown as ws.Server }
+  })
+
+  after(() => repos.server.close())
+
+  it("can sync a document from the client to the server", async () => {
+    const { serverRepo, clientRepo } = repos
+
+    const p = eventPromise(serverRepo, "document")
+
+    const handle = clientRepo.create<{ foo: string }>()
+    handle.change(d => {
+      d.foo = "bar"
+    })
+
+    await p
+
+    const serverHandle = serverRepo.find<{ foo: string }>(handle.documentId)
+    await eventPromise(serverHandle, "change")
+    const v = await serverHandle.value()
+
+    assert.equal(v.foo, "bar")
+  })
+
+  it("can sync a document from a server (with a strict share policy) to the client when requested", async () => {
+    const { serverRepo, clientRepo } = repos
+
+    const handle = serverRepo.create<{ foo: string }>()
+    const p = eventPromise(handle, "change")
+    handle.change(d => {
+      d.foo = "bach"
+    })
+
+    await p
+
+    const clientHandle = clientRepo.find<{ foo: string }>(handle.documentId)
+    await eventPromise(clientHandle, "change")
+    const v = await clientHandle.value()
+
+    assert.equal(v.foo, "bach")
+  })
+})

--- a/packages/automerge-repo-network-websocket/test/utilities/CreateWebSocketServer.ts
+++ b/packages/automerge-repo-network-websocket/test/utilities/CreateWebSocketServer.ts
@@ -1,0 +1,8 @@
+import http from "http"
+import WebSocket from "ws"
+
+function createWebSocketServer(server: http.Server) {
+  return new WebSocket.Server({ server })
+}
+
+export { createWebSocketServer }

--- a/packages/automerge-repo-network-websocket/test/utilities/WebSockets.ts
+++ b/packages/automerge-repo-network-websocket/test/utilities/WebSockets.ts
@@ -1,0 +1,34 @@
+import http from "http"
+import { createWebSocketServer } from "./CreateWebSocketServer"
+import WebSocket from "ws"
+
+function startServer(port: number) {
+  const server = http.createServer()
+  const socket = createWebSocketServer(server)
+  return new Promise<{
+    socket: WebSocket.Server
+    server: http.Server
+  }>(resolve => {
+    server.listen(port, () => resolve({ socket, server }))
+  })
+}
+
+type WebSocketState =
+  | typeof WebSocket.CONNECTING
+  | typeof WebSocket.OPEN
+  | typeof WebSocket.CLOSING
+  | typeof WebSocket.CLOSED
+
+function waitForSocketState(socket: WebSocket, state: WebSocketState) {
+  return new Promise<void>(function (resolve) {
+    setTimeout(function () {
+      if (socket.readyState === state) {
+        resolve()
+      } else {
+        waitForSocketState(socket, state).then(resolve)
+      }
+    }, 5)
+  })
+}
+
+export { startServer, waitForSocketState }

--- a/packages/automerge-repo/README.md
+++ b/packages/automerge-repo/README.md
@@ -43,38 +43,36 @@ This library provides two main components: the `Repo` itself, and the `DocHandle
 
 A `Repo` exposes these methods:
 
-- `create<T>()`  
+- `create<T>()`
   Creates a new, empty `Automerge.Doc` and returns a `DocHandle` for it.
-- `find<T>(docId: DocumentId)`  
+- `find<T>(docId: DocumentId)`
   Looks up a given document either on the local machine or (if necessary) over any configured
   networks.
-- `delete(docId: DocumentId)`  
+- `delete(docId: DocumentId)`
   Deletes the local copy of a document from the local cache and local storage. _This does not currently delete the document from any other peers_.
-- `.on("document", ({handle: DocHandle}) => void)`  
+- `.on("document", ({handle: DocHandle}) => void)`
   Registers a callback to be fired each time a new document is loaded or created.
-- `.on("delete-document", ({handle: DocHandle}) => void)`  
+- `.on("delete-document", ({handle: DocHandle}) => void)`
   Registers a callback to be fired each time a new document is loaded or created.
 
 A `DocHandle` is a wrapper around an `Automerge.Doc`. Its primary function is to dispatch changes to
 the document.
 
-- `handle.change((doc: T) => void)`  
+- `handle.change((doc: T) => void)`
   Calls the provided callback with an instrumented mutable object
   representing the document. Any changes made to the document will be recorded and distributed to
   other nodes.
-- `handle.value()`  
+- `handle.value()`
   Returns a `Promise<Doc<T>>` that will contain the current value of the document.
   it waits until the document has finished loading and/or synchronizing over the network before
   returning a value.
 
 A `DocHandle` also emits these events:
 
-- `change({handle: DocHandle})`  
+- `change({handle: DocHandle, after: Doc, before: Doc, patches: Patch[]})`
   Called any time changes are created or received on the document. Request the `value()` from the
   handle.
-- `patch({handle: DocHandle, before: Doc, after: Doc, patches: Patch[]})`  
-  Useful for manual increment maintenance of a video, most notably for text editors.
-- `delete`  
+- `delete`
   Called when the document is deleted locally.
 
 ## Creating a repo
@@ -100,7 +98,7 @@ const repo = new Repo({
 ### Share Policy
 The share policy is used to determine which document in your repo should be _automatically_ shared with other peers. **The default setting is to share all documents with all peers.**
 
-> **Warning**  
+> **Warning**
 > If your local repo has deleted a document, a connecting peer with the default share policy will still share that document with you.
 
 You can override this by providing a custom share policy. The function should return a promise resolving to a boolean value indicating whether the document should be shared with the peer.


### PR DESCRIPTION
#43 outlines the case where successive, quick changes to a handle do not currently result in distinct documents being returned in the `change` event closure.

This proposal moves the `change` event trigger to the document `patchCallback` (which is only triggered when a change causes the document `heads` to update).

The additional detail provided in the callback is forwarded on as a property of the `change` event closure argument.

If anyone knows of a way to mark the `patch` event as `@deprecated` so that it offers some guidance to editors, that might be useful.

As is stands, this **does not represent a breaking change**.

I have kept the property names the same as those used in the `patchCallback`, but I wondered if it might make more sense in our context to use `doc` (in place of `after`) and `oldDoc` (for `before`).

This would close #43 