### PR TITLE
Update package automerge

### DIFF
--- a/packages/automerge-repo-demo-counter/package.json
+++ b/packages/automerge-repo-demo-counter/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@automerge/automerge": "^2.0.1-alpha.2",
+    "@automerge/automerge": ">=2.0.3",
     "automerge-repo": "^0.0.50",
     "automerge-repo-network-broadcastchannel": "^0.0.50",
     "automerge-repo-network-websocket": "^0.0.50",

--- a/packages/automerge-repo-demo-counter/package.json
+++ b/packages/automerge-repo-demo-counter/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@automerge/automerge": ">=2.0.3",
+    "@automerge/automerge": "^2.0.3",
     "automerge-repo": "^0.0.50",
     "automerge-repo-network-broadcastchannel": "^0.0.50",
     "automerge-repo-network-websocket": "^0.0.50",

--- a/packages/automerge-repo-demo-todo/package.json
+++ b/packages/automerge-repo-demo-todo/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@automerge/automerge": "^2.0.1-alpha.2",
+    "@automerge/automerge": "^2.0.3",
     "@ibm/plex": "^6.1.1",
     "automerge-repo": "^0.0.50",
     "automerge-repo-network-broadcastchannel": "^0.0.50",

--- a/packages/automerge-repo-sync-server/package.json
+++ b/packages/automerge-repo-sync-server/package.json
@@ -8,7 +8,7 @@
     "start": "node ./src/index.js"
   },
   "dependencies": {
-    "@automerge/automerge": "^2.0.1-alpha.1",
+    "@automerge/automerge": "^2.0.3",
     "automerge-repo": "^0.0.50",
     "automerge-repo-network-websocket": "^0.0.50",
     "automerge-repo-storage-nodefs": "^0.0.50",

--- a/packages/automerge-repo/package.json
+++ b/packages/automerge-repo/package.json
@@ -29,7 +29,7 @@
     "http-server": "^14.1.0"
   },
   "peerDependencies": {
-    "@automerge/automerge": ">=2.0.3"
+    "@automerge/automerge": "^2.0.3"
   },
   "dependencies": {
     "cbor-x": "^1.3.0",


### PR DESCRIPTION
Some of the packages depended on out of date Automerge versions. This updates them to the same level across the monorepo