### PR TITLE
Fix incremental save following an incremental load

### DIFF
--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -63,7 +63,9 @@ export class StorageSubsystem {
     documentId: DocumentId,
     prevDoc: A.Doc<T> = A.init<T>()
   ): Promise<A.Doc<T>> {
-    return A.loadIncremental(prevDoc, await this.loadBinary(documentId))
+    const doc = A.loadIncremental(prevDoc, await this.loadBinary(documentId))
+    A.saveIncremental(doc)
+    return doc
   }
 
   save(documentId: DocumentId, doc: A.Doc<unknown>) {

--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -70,5 +70,9 @@ describe("StorageSubsystem", () => {
 
     // check that the storage adapter contains the correct keys
     assert(adapter.keys().some(k => k.endsWith("1")))
+
+    // check that the last incrementalSave is not a full save
+    const bin = await adapter.load((key + ".incremental.1") as DocumentId)
+    assert.throws(() => A.load(bin!))
   })
 })


### PR DESCRIPTION
Related to https://github.com/automerge/automerge/issues/592

Following a load of a document from storage, then next incremental save is of the whole document. In Automerge `2.0.2` this would throw an error. While the error no longer exists in `2.0.3` we are still bloating the local store unnecessarily.

This ensures that all incremental saves are indeed incremental.