### PR TITLE
Omit `PatchCallback` from `ChangeOptions`

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -210,7 +210,10 @@ export class DocHandle<T> //
   }
 
   /** `change` is called by the repo when the document is changed locally  */
-  async change(callback: A.ChangeFn<T>, options: A.ChangeOptions<T> = {}) {
+  async change(
+    callback: A.ChangeFn<T>,
+    options: DocHandleChangeOptions<T> = {}
+  ) {
     if (this.#state === LOADING) throw new Error("Cannot change while loading")
     this.#machine.send(UPDATE, {
       payload: {
@@ -231,6 +234,8 @@ export class DocHandle<T> //
     this.#machine.send(DELETE)
   }
 }
+
+type DocHandleChangeOptions<T> = Omit<A.ChangeOptions<T>, "patchCallback">
 
 // WRAPPER CLASS TYPES
 


### PR DESCRIPTION
If a `patchCallback` is passed to the `DocHandle` `change` method, then that callback overwrites the one created on `init`. This results in no more `patch` events being emitted.

At the moment this is just a typescript update, but it might be prudent to throw an error here, or at least log a warning to the console?