### PR TITLE
Disallow floating promises

### DIFF
--- a/packages/automerge-repo/.eslintrc
+++ b/packages/automerge-repo/.eslintrc
@@ -21,6 +21,7 @@
     "import/extensions": 0,
     "lines-between-class-members": 0,
     "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-empty-function": ["warn", { "allow": ["methods"]}],
     "no-param-reassign": 0,
     "no-use-before-define": 0
   }

--- a/packages/automerge-repo/.eslintrc
+++ b/packages/automerge-repo/.eslintrc
@@ -12,6 +12,7 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "mocha"],
   "parserOptions": {
+    "project": "./tsconfig.json",
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
@@ -19,6 +20,7 @@
     "semi": ["error", "never"],
     "import/extensions": 0,
     "lines-between-class-members": 0,
+    "@typescript-eslint/no-floating-promises": "error",
     "no-param-reassign": 0,
     "no-use-before-define": 0
   }

--- a/packages/automerge-repo/package.json
+++ b/packages/automerge-repo/package.json
@@ -26,8 +26,8 @@
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",
-    "automerge-repo-network-messagechannel": "^0.0.50",
-    "automerge-repo-storage-nodefs": "^0.0.50",
+    "@types/automerge-repo-network-messagechannel": "^0.0.50",
+    "@types/automerge-repo-storage-nodefs": "^0.0.50",
     "http-server": "^14.1.0"
   },
   "peerDependencies": {

--- a/packages/automerge-repo/package.json
+++ b/packages/automerge-repo/package.json
@@ -26,6 +26,8 @@
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",
+    "automerge-repo-network-messagechannel": "^0.0.50",
+    "automerge-repo-storage-nodefs": "^0.0.50",
     "http-server": "^14.1.0"
   },
   "peerDependencies": {

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -210,7 +210,7 @@ export class DocHandle<T> //
   }
 
   /** `change` is called by the repo when the document is changed locally  */
-  async change(callback: A.ChangeFn<T>, options: A.ChangeOptions<T> = {}) {
+  change(callback: A.ChangeFn<T>, options: A.ChangeOptions<T> = {}) {
     if (this.#state === LOADING) throw new Error("Cannot change while loading")
     this.#machine.send(UPDATE, {
       payload: {

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -45,7 +45,7 @@ export class Repo extends DocCollection {
       handle.request()
 
       // Register the document with the synchronizer
-      synchronizer.addDocument(handle.documentId)
+      await synchronizer.addDocument(handle.documentId)
     })
 
     this.on("delete-document", ({ documentId }) => {
@@ -84,9 +84,9 @@ export class Repo extends DocCollection {
     this.networkSubsystem = networkSubsystem
 
     // When we get a new peer, register it with the synchronizer
-    networkSubsystem.on("peer", ({ peerId }) => {
+    networkSubsystem.on("peer", async ({ peerId }) => {
       this.#log("peer connected", { peerId })
-      synchronizer.addPeer(peerId)
+      await synchronizer.addPeer(peerId)
     })
 
     // When a peer disconnects, remove it from the synchronizer
@@ -95,7 +95,7 @@ export class Repo extends DocCollection {
     })
 
     // Handle incoming messages
-    networkSubsystem.on("message", msg => {
+    networkSubsystem.on("message", async msg => {
       const { senderId, channelId, message } = msg
 
       // TODO: this demands a more principled way of associating channels with recipients
@@ -108,7 +108,7 @@ export class Repo extends DocCollection {
       } else {
         // Sync message
         this.#log(`receiving sync message from ${senderId}`)
-        synchronizer.receiveSyncMessage(senderId, channelId, message)
+        await synchronizer.receiveSyncMessage(senderId, channelId, message)
       }
     })
 

--- a/packages/automerge-repo/src/helpers/pause.ts
+++ b/packages/automerge-repo/src/helpers/pause.ts
@@ -1,2 +1,9 @@
 export const pause = (t = 0) =>
   new Promise<void>(resolve => setTimeout(() => resolve(), t))
+
+export function rejectOnTimeout<T>(promise: Promise<T>, millis: number): Promise<T> {
+  return Promise.race([
+    promise,
+    pause(millis).then(() => { throw new Error("timeout exceeded") }),
+  ])
+}

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -32,14 +32,13 @@ describe("CollectionSynchronizer", () => {
 
   it("starts synchronizing existing documents when a peer is added", done => {
     const handle = collection.create()
-    synchronizer.addDocument(handle.documentId).then(() => {
-      synchronizer.once("message", (event: MessagePayload) => {
-        assert(event.targetId === "peer1")
-        assert(event.channelId === (handle.documentId as unknown as ChannelId))
-        done()
-      })
-      synchronizer.addPeer("peer1" as PeerId)
+    synchronizer.addDocument(handle.documentId)
+    synchronizer.once("message", (event: MessagePayload) => {
+      assert(event.targetId === "peer1")
+      assert(event.channelId === (handle.documentId as unknown as ChannelId))
+      done()
     })
+    synchronizer.addPeer("peer1" as PeerId)
   })
 
   it("should not synchronize to a peer which is excluded from the share policy", done => {
@@ -47,12 +46,11 @@ describe("CollectionSynchronizer", () => {
 
     collection.sharePolicy = async (peerId: PeerId) => peerId !== "peer1"
 
-    synchronizer.addDocument(handle.documentId).then(() => {
-      synchronizer.once("message", () => {
-        done(new Error("Should not have sent a message"))
-      })
-      synchronizer.addPeer("peer1" as PeerId)
+    synchronizer.addDocument(handle.documentId)
+    synchronizer.once("message", () => {
+      done(new Error("Should not have sent a message"))
     })
+    synchronizer.addPeer("peer1" as PeerId)
 
     setTimeout(done)
   })

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -49,7 +49,7 @@ describe("DocHandle", () => {
 
     // can't make changes in LOADING state
     assert.equal(handle.isReady(), false)
-    assert.rejects(() => handle.change(d => (d.foo = "baz")))
+    assert.throws(() => handle.change(d => (d.foo = "baz")))
 
     // simulate loading from storage
     handle.load(binaryFromMockStorage())
@@ -134,7 +134,7 @@ describe("DocHandle", () => {
     await pause(10)
 
     // so it should time out
-    assert.rejects(handle.value, "DocHandle timed out")
+    return assert.rejects(handle.value, "DocHandle timed out")
   })
 
   it("should not time out if the document is loaded in time", async () => {
@@ -160,7 +160,7 @@ describe("DocHandle", () => {
     await pause(10)
 
     // so it should time out
-    assert.rejects(handle.value, "DocHandle timed out")
+    return assert.rejects(handle.value, "DocHandle timed out")
   })
 
   it("should not time out if the document is updated in time", async () => {

--- a/packages/automerge-repo/tsconfig.json
+++ b/packages/automerge-repo/tsconfig.json
@@ -12,5 +12,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
Ensure that all promises are either awaited or are explicitly detached (with `void`).

While working on an alternate version of #68, I found quite a few places where async functions were called without awaiting their result, making it easy to accidentally run things in parallel. Also, it was sometimes difficult to tell what the  `Promise<void>` returned by some of the internal async functions signified. For example, `CollectionSynchronizer.addDocument` returns a promise that resolves when the `sharePolicy`s for all its peers is known, it has nothing to do with when the document is synced. Finally some internal functions were `async` despite never awaiting anything.

This PR fixes the above issues and updates some tests so that `eslint` passes.