### PR TITLE
Buffer sync messages until the DocHandle is ready

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -165,6 +165,8 @@ export class DocHandle<T> //
 
   isReady = () => this.#state === READY
 
+  isReadyOrRequesting = () => this.#state === READY || this.#state === REQUESTING
+
   isDeleted = () => this.#state === DELETED
 
   /**

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -178,5 +178,7 @@ export class DocSynchronizer extends Synchronizer {
       for (const { peerId, message } of this.#pendingSyncMessages) {
         this.#processSyncMessage(peerId, message)
       }
+
+      this.#pendingSyncMessages = []
   }
 }

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -175,10 +175,10 @@ export class DocSynchronizer extends Synchronizer {
   }
 
   #processAllPendingSyncMessages() {
-      for (const { peerId, message } of this.#pendingSyncMessages) {
-        this.#processSyncMessage(peerId, message)
-      }
+    for (const { peerId, message } of this.#pendingSyncMessages) {
+      this.#processSyncMessage(peerId, message)
+    }
 
-      this.#pendingSyncMessages = []
+    this.#pendingSyncMessages = []
   }
 }


### PR DESCRIPTION
Fixes #70

I still haven't observed the bug described in #70—it's still theoretical—but this removes a `TODO` at least :smile:.