### PR TITLE
Add doc to change event

### DIFF
--- a/packages/automerge-repo/README.md
+++ b/packages/automerge-repo/README.md
@@ -69,7 +69,7 @@ the document.
 
 A `DocHandle` also emits these events:
 
-- `change({handle: DocHandle})`  
+- `change({handle: DocHandle, doc: Doc<T>})`
   Called any time changes are created or received on the document. Request the `value()` from the
   handle.
 - `patch({handle: DocHandle, before: Doc, after: Doc, patches: Patch[]})`  

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -122,7 +122,7 @@ export class DocHandle<T> //
 
               const docChanged = !headsAreSame(newDoc, oldDoc)
               if (docChanged) {
-                this.emit("change", { handle: this })
+                this.emit("change", { handle: this, doc: newDoc })
                 if (!this.isReady()) {
                   this.#machine.send(REQUEST_COMPLETE)
                 }
@@ -247,6 +247,11 @@ export interface DocHandleMessagePayload {
 
 export interface DocHandleChangePayload<T> {
   handle: DocHandle<T>
+  doc: A.Doc<T>
+}
+
+export interface DocHandleDeletePayload<T> {
+  handle: DocHandle<T>
 }
 
 export interface DocHandlePatchPayload<T> {
@@ -259,7 +264,7 @@ export interface DocHandlePatchPayload<T> {
 export interface DocHandleEvents<T> {
   change: (payload: DocHandleChangePayload<T>) => void
   patch: (payload: DocHandlePatchPayload<T>) => void
-  delete: (payload: DocHandleChangePayload<T>) => void
+  delete: (payload: DocHandleDeletePayload<T>) => void
 }
 
 // STATE MACHINE TYPES


### PR DESCRIPTION
This adds a `doc`to the change event callback, allowing sync access to the latest version of the doc on each change

Closes https://github.com/automerge/automerge-repo/issues/43