### PR TITLE
Makes `change` synchronous and prevents changes during `requesting` state

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -174,7 +174,6 @@ export class DocHandle<T> //
   // PUBLIC
 
   isReady = () => this.#state === READY
-
   isDeleted = () => this.#state === DELETED
 
   /**
@@ -220,8 +219,12 @@ export class DocHandle<T> //
   }
 
   /** `change` is called by the repo when the document is changed locally  */
-  async change(callback: A.ChangeFn<T>, options: A.ChangeOptions<T> = {}) {
-    if (this.#state === LOADING) throw new Error("Cannot change while loading")
+  change(callback: A.ChangeFn<T>, options: A.ChangeOptions<T> = {}) {
+    if (!this.isReady()) {
+      throw new Error(
+        `DocHandle#${this.documentId} is not ready. Check \`handle.isReady()\` before accessing the document.`
+      )
+    }
     this.#machine.send(UPDATE, {
       payload: {
         callback: (doc: A.Doc<T>) => {

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -67,7 +67,7 @@ describe("DocHandle", () => {
 
     // can't make changes in LOADING state
     assert.equal(handle.isReady(), false)
-    assert.rejects(() => handle.change(d => (d.foo = "baz")))
+    assert.throws(() => handle.change(d => (d.foo = "baz")))
 
     // simulate loading from storage
     handle.load(binaryFromMockStorage())
@@ -78,6 +78,17 @@ describe("DocHandle", () => {
 
     const doc = await handle.value()
     assert.equal(doc.foo, "pizza")
+  })
+
+  it("should not be ready while requesting from the network", async () => {
+    const handle = new DocHandle<TestDoc>(TEST_ID)
+
+    // we don't have it in storage, so we request it from the network
+    handle.request()
+
+    assert.throws(() => handle.doc)
+    assert.equal(handle.isReady(), false)
+    assert.throws(() => handle.change(h => {}))
   })
 
   it("should become ready if the document is updated by the network", async () => {


### PR DESCRIPTION
As described -- we might want not to change the change signature but I think it's relatively safe?