### PR TITLE
Ensure `DocHandle` state is updated before change event is emitted

### DIFF
--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -137,6 +137,24 @@ describe("DocHandle", () => {
     })
   })
 
+  it("should update the internal doc prior to emitting the change message", async () => {
+    const handle = new DocHandle<TestDoc>(TEST_ID, { isNew: true })
+
+    const p = new Promise<void>(resolve =>
+      handle.once("change", ({ handle, doc }) => {
+        assert.equal(handle.doc.foo, doc.foo)
+
+        resolve()
+      })
+    )
+
+    handle.change(doc => {
+      doc.foo = "baz"
+    })
+
+    return p
+  })
+
   it("should emit distinct change messages when consecutive changes happen", async () => {
     const handle = new DocHandle<TestDoc>(TEST_ID, { isNew: true })
 


### PR DESCRIPTION
In [this discussion on Slack](https://automerge.slack.com/archives/C61RJCM9S/p1685460896830499), @jamesgpearce noticed that checking the sync `handle.doc` within a change event callback would return the previous doc version, as the underlying document is not updated until the state event has returned the new value.

This PR alters the point at which a change event is emitted, by checking the document for changes after each state transition first.