### PR TITLE
Use Automerge's exposed `saveIncremental`

### DIFF
--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -12,7 +12,7 @@ export class StorageSubsystem {
   }
 
   #saveIncremental(documentId: DocumentId, doc: A.Doc<unknown>) {
-    const binary = A.getBackend(doc).saveIncremental()
+    const binary = A.saveIncremental(doc)
     if (binary && binary.length > 0) {
       if (!this.#changeCount[documentId]) {
         this.#changeCount[documentId] = 0


### PR DESCRIPTION
A straightforward swap. Figured it would be better to use the default exposed function to guard against any future breaking changes in the Automerge API.