### PR TITLE
Ensure docs are ready before changing in `syncs a bunch of changes` test

### DIFF
--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -348,6 +348,12 @@ describe("Repo", () => {
               repo.create<TestDoc>()
             : // tails, pick a random doc
               (getRandomItem(docs) as DocHandle<TestDoc>)
+
+        // make sure the doc is ready
+        if (!doc.isReady()) {
+          await doc.value()
+        }
+
         // make a random change to it
         doc.change(d => {
           d.foo = Math.random().toString()


### PR DESCRIPTION
This test would occasionally fail locally for me if the `docHandle was not ready. Adds an `await handle.valueI()` when needed.