### PR TITLE
Fix missing `.js` extension

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -17,7 +17,7 @@ import { waitFor } from "xstate/lib/waitFor.js"
 import { headsAreSame } from "./helpers/headsAreSame.js"
 import { pause } from "./helpers/pause.js"
 import type { ChannelId, DocumentId, PeerId } from "./types.js"
-import { withTimeout, TimeoutError } from "./helpers/withTimeout"
+import { withTimeout, TimeoutError } from "./helpers/withTimeout.js"
 
 /** DocHandle is a wrapper around a single Automerge document that lets us listen for changes. */
 export class DocHandle<T> //


### PR DESCRIPTION
One more missing extension on an import