### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,80 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+jobs:
+  check_if_version_upgraded:
+    name: Check if package version has been upgraded
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version-updated.outputs.current-package-version }}
+      has_updated: ${{ steps.version-updated.outputs.has-updated }}
+    steps:
+      - uses: JiPaix/package-json-updated-action@v1.0.5
+        id: version-updated
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish-js:
+    name: Publish package
+    runs-on: ubuntu-latest
+    needs:
+      - check_if_version_upgraded
+    # We create release only if the version in the package.json has been upgraded
+    if: |
+      needs.check_if_version_upgraded.outputs.has_updated == 'true'
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+      - name: Install Dependencies
+        id: deps
+        run: |
+          yarn install --no-lockfile
+      - name: Build Release
+        id: build_release
+        run: |
+          yarn build
+      - name: Run Tests
+        id: tests
+        run: |
+          yarn test
+      - name: Publish Release
+        if: steps.tests.outcome == 'success'
+        run: |
+          if [ "$NODE_AUTH_TOKEN" = "" ]; then
+            echo "You need a NPM_TOKEN secret in order to publish."
+            false
+          fi
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          echo //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} > .npmrc
+          EXTRA_ARGS=""
+          if [[ $VERSION == *"alpha."* ]] || [[ $VERSION == *"beta."* ]] || [[ $VERSION == *"rc."* ]]; then
+            echo "Is pre-release version"
+            EXTRA_ARGS="$EXTRA_ARGS --dist-tag next"
+          fi
+          yarn pub ${VERSION} $EXTRA_ARGS
+        env:
+          VERSION: ${{ needs.check_if_version_upgraded.outputs.version }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tag release
+        if: steps.tests.outcome == 'success'
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ needs.check_if_version_upgraded.outputs.version }}
+          tag_name: v${{ needs.check_if_version_upgraded.outputs.version }}
+          target_commitish: main
+          generate_release_notes: true
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-mocha": "^10.0.5",
-    "lerna": "^5.5.1",
+    "lerna": "^6.6.0",
     "mocha": "^10.0.0",
     "npm-run-all": "^4.1.5",
     "npm-watch": "^0.11.0",


### PR DESCRIPTION
This PR:

- Upgrades Lerna to v6
- Adds a github release action

The action requires a `NPM_TOKEN` secret to be exposed as an action secret, and it works as follows:

1. Check if the root `package.json` version has been changed. If not, the action ends there.
2. Install dependencies
3. Build all packages
4. Run tests
5. Publish to npm
    - If the version includes alpha/beta, the release is tagged as `next`
6. Tag the release on the repo

The action is configured to run on **any push to main**.

I have tested this in a fork of the repo, with a dummy `NPM_TOKEN` and all seems to function as expected.