### PR TITLE
Remove build script from demo-counter-svelte

### DIFF
--- a/packages/automerge-repo-demo-counter-svelte/package.json
+++ b/packages/automerge-repo-demo-counter-svelte/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },


### PR DESCRIPTION
This package never needs to be built. Removing the build script here means that Lerna won't include it when it builds all packages, which speeds up that task. 