### PR TITLE
Docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ This is a monorepo containing the following packages:
 
 - [automerge-repo-network-websocket](/packages/automerge-repo-network-websocket/): Network adapters
   for both sides of a client/server configuration over websocket
-- [automerge-repo-network-localfirstrelay](/packages/automerge-repo-network-localfirstrelay/): A
-  network client that uses [@localfirst/relay](https://github.com/local-first-web/relay) to relay
-  traffic between peers
 - [automerge-repo-network-messagechannel](/packages/automerge-repo-network-messagechannel/): A
   network adapter that uses the [MessageChannel
   API](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel) to communicate between tabs

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1-alpha.0",
   "description": "Automerge Repo monorepo",
   "main": "packages/automerge-repo/dist/index.js",
-  "repository": "https://github.com/pvh/automerge-repo",
+  "repository": "https://github.com/automerge/automerge-repo",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",
   "license": "MIT",
   "private": true,
@@ -40,7 +40,7 @@
     "typescript": "^4.7.4"
   },
   "engines": {
-    "node": ">= 16.x"
+    "node": ">= 18.x"
   },
   "workspaces": [
     "packages/*"

--- a/packages/automerge-repo-network-broadcastchannel/package.json
+++ b/packages/automerge-repo-network-broadcastchannel/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-network-broadcastchannel",
   "version": "0.1.1-alpha.0",
   "description": "BroadcastChannel network adapter for Automerge Repo",
-  "repository": "https://github.com/pvh/automerge-repo",
+  "repository": "https://github.com/automerge/automerge-repo",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",
   "license": "MIT",
   "private": false,

--- a/packages/automerge-repo-network-messagechannel/package.json
+++ b/packages/automerge-repo-network-messagechannel/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-network-messagechannel",
   "version": "0.1.1-alpha.0",
   "description": "MessageChannel network adapter for Automerge Repo",
-  "repository": "https://github.com/pvh/automerge-repo",
+  "repository": "https://github.com/automerge/automerge-repo",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",
   "license": "MIT",
   "private": false,

--- a/packages/automerge-repo-network-websocket/package.json
+++ b/packages/automerge-repo-network-websocket/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-network-websocket",
   "version": "0.1.1-alpha.0",
   "description": "isomorphic node/browser Websocket network adapter for Automerge Repo",
-  "repository": "https://github.com/pvh/automerge-repo",
+  "repository": "https://github.com/automerge/automerge-repo",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",
   "license": "MIT",
   "private": false,

--- a/packages/automerge-repo-react-hooks/README.md
+++ b/packages/automerge-repo-react-hooks/README.md
@@ -12,7 +12,6 @@ import localforage from "localforage"
 import { Repo, DocCollection } from "@automerge/automerge-repo"
 
 import { BroadcastChannelNetworkAdapter } from "@automerge/automerge-repo-network-broadcastchannel"
-import { LocalFirstRelayNetworkAdapter } from "@automerge/automerge-repo-network-localfirstrelay"
 
 import App, { RootDocument } from "./App.js"
 import { RepoContext } from "@automerge/automerge-repo-react-hooks"
@@ -23,11 +22,10 @@ const sharedWorker = new SharedWorker(
   { type: "module", name: "@automerge/automerge-repo-shared-worker" }
 )
 
-async function getRepo(url: string): Promise<DocCollection> {
+async function getRepo(): Promise<DocCollection> {
   return await Repo({
     network: [
       new BroadcastChannelNetworkAdapter(),
-      new LocalFirstRelayNetworkAdapter("wss://local-first-relay.glitch.me/"),
     ],
     sharePolicy: peerId => peerId.includes("shared-worker"),
   })
@@ -61,7 +59,7 @@ const queryString = window.location.search // Returns:'?q=123'
 const params = new URLSearchParams(queryString)
 const hostname = params.get("host") || "automerge-storage-demo.glitch.me"
 
-getRepo(`wss://${hostname}`).then(repo => {
+getRepo().then(repo => {
   getRootDocument(repo, initFunction).then(rootDoc => {
     const rootElem = document.getElementById("root")
     if (!rootElem) {

--- a/packages/automerge-repo-react-hooks/package.json
+++ b/packages/automerge-repo-react-hooks/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-react-hooks",
   "version": "0.1.1-alpha.0",
   "description": "Hooks to access an Automerge Repo from your react app.",
-  "repository": "https://github.com/pvh/automerge-repo",
+  "repository": "https://github.com/automerge/automerge-repo",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",
   "license": "MIT",
   "private": false,

--- a/packages/automerge-repo-storage-localforage/package.json
+++ b/packages/automerge-repo-storage-localforage/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-storage-localforage",
   "version": "0.1.1-alpha.0",
   "description": "LocalForage storage adapter for Automerge Repo",
-  "repository": "https://github.com/pvh/automerge-repo",
+  "repository": "https://github.com/automerge/automerge-repo",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",
   "license": "MIT",
   "private": false,

--- a/packages/automerge-repo-storage-nodefs/package.json
+++ b/packages/automerge-repo-storage-nodefs/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-storage-nodefs",
   "version": "0.1.1-alpha.0",
   "description": "Simple Node filesystem storage adapter for Automerge Repo",
-  "repository": "https://github.com/pvh/automerge-repo",
+  "repository": "https://github.com/automerge/automerge-repo",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",
   "license": "MIT",
   "private": false,

--- a/packages/automerge-repo-svelte-store/README.md
+++ b/packages/automerge-repo-svelte-store/README.md
@@ -48,5 +48,5 @@ For a working example, see the [Svelte counter demo](../automerge-repo-demo-coun
 </button>
 ```
 
-## Contributers
+## Contributors
 Originally written by Dylan MacKenzie ([@ecstatic-morse](https://github.com/ecstatic-morse)).

--- a/packages/automerge-repo-svelte-store/package.json
+++ b/packages/automerge-repo-svelte-store/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-svelte-store",
   "version": "0.1.1-alpha.0",
   "description": "A Svelte store containing your automerge documentsj",
-  "repository": "https://github.com/pvh/automerge-repo",
+  "repository": "https://github.com/automerge/automerge-repo",
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/packages/automerge-repo/README.md
+++ b/packages/automerge-repo/README.md
@@ -9,31 +9,31 @@ deciding which peers to connect to or when to write data out to storage.
 
 Other packages in this monorepo include:
 
-- [@automerge/automerge-repo-demo-counter](/packages/@automerge/automerge-repo-demo-counter/): A React-based demonstration
+- [@automerge/automerge-repo-demo-counter](/packages/automerge-repo-demo-counter/): A React-based demonstration
   application.
-- [@automerge/automerge-repo-react-hooks](/packages/@automerge/automerge-repo-react-hooks/): Example hooks for use with
+- [@automerge/automerge-repo-react-hooks](/packages/automerge-repo-react-hooks/): Example hooks for use with
   React.
-- [@automerge/automerge-repo-sync-server](/packages/@automerge/automerge-repo-sync-server/): A small synchronization
+- [@automerge/automerge-repo-sync-server](/packages/automerge-repo-sync-server/): A small synchronization
   server that facilitates asynchronous communication between peers
 
 #### Storage adapters
 
-- [automerge-repo-storage-localforage](/packages/automerge-repo-storage-localforage/): A storage
+- [@automerge/automerge-repo-storage-localforage](/packages/automerge-repo-storage-localforage/): A storage
   adapter to persist data in a browser
-- [automerge-repo-storage-nodefs](/packages/automerge-repo-storage-nodefs/): A storage adapter to
+- [@automerge/automerge-repo-storage-nodefs](/packages/automerge-repo-storage-nodefs/): A storage adapter to
   write changes to the filesystem
 
 #### Network adapters
 
-- [automerge-repo-network-websocket](/packages/automerge-repo-network-websocket/): Network adapters
+- [@automerge/automerge-repo-network-websocket](/packages/automerge-repo-network-websocket/): Network adapters
   for both sides of a client/server configuration over websocket
-- [automerge-repo-network-localfirstrelay](/packages/automerge-repo-network-localfirstrelay/): A
+- [@automerge/automerge-repo-network-localfirstrelay](/packages/automerge-repo-network-localfirstrelay/): A
   network client that uses [@localfirst/relay](https://github.com/local-first-web/relay) to relay
   traffic between peers
-- [automerge-repo-network-messagechannel](/packages/automerge-repo-network-messagechannel/): A
+- [@automerge/automerge-repo-network-messagechannel](/packages/automerge-repo-network-messagechannel/): A
   network adapter that uses the [MessageChannel
   API](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel) to communicate between tabs
-- [automerge-repo-network-broadcastchannel](/packages/automerge-repo-network-broadcastchannel/):
+- [@automerge/automerge-repo-network-broadcastchannel](/packages/automerge-repo-network-broadcastchannel/):
   Likely only useful for experimentation, but allows simple (inefficient) tab-to-tab data
   synchronization
 
@@ -139,7 +139,7 @@ yarn create vite
 
 cd hello-automerge-repo
 yarn
-yarn add @automerge/automerge automerge-repo automerge-repo-react-hooks automerge-repo-network-broadcastchannel automerge-repo-storage-localforage vite-plugin-wasm vite-plugin-top-level-await
+yarn add @automerge/automerge @automerge/automerge-repo-react-hooks @automerge/automerge-repo-network-broadcastchannel @automerge/automerge-repo-storage-localforage @automerge/vite-plugin-wasm @automerge/vite-plugin-top-level-await
 ```
 
 Edit the `vite.config.ts`. (This is all need to work around packaging hiccups due to WASM. We look

--- a/packages/automerge-repo/README.md
+++ b/packages/automerge-repo/README.md
@@ -27,9 +27,6 @@ Other packages in this monorepo include:
 
 - [@automerge/automerge-repo-network-websocket](/packages/automerge-repo-network-websocket/): Network adapters
   for both sides of a client/server configuration over websocket
-- [@automerge/automerge-repo-network-localfirstrelay](/packages/automerge-repo-network-localfirstrelay/): A
-  network client that uses [@localfirst/relay](https://github.com/local-first-web/relay) to relay
-  traffic between peers
 - [@automerge/automerge-repo-network-messagechannel](/packages/automerge-repo-network-messagechannel/): A
   network adapter that uses the [MessageChannel
   API](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel) to communicate between tabs
@@ -139,7 +136,7 @@ yarn create vite
 
 cd hello-automerge-repo
 yarn
-yarn add @automerge/automerge @automerge/automerge-repo-react-hooks @automerge/automerge-repo-network-broadcastchannel @automerge/automerge-repo-storage-localforage @automerge/vite-plugin-wasm @automerge/vite-plugin-top-level-await
+yarn add @automerge/automerge @automerge/automerge-repo-react-hooks @automerge/automerge-repo-network-broadcastchannel @automerge/automerge-repo-storage-localforage vite-plugin-wasm vite-plugin-top-level-await
 ```
 
 Edit the `vite.config.ts`. (This is all need to work around packaging hiccups due to WASM. We look

--- a/packages/automerge-repo/package.json
+++ b/packages/automerge-repo/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo",
   "version": "0.1.1-alpha.0",
   "description": "A repository object to manage a collection of automerge documents",
-  "repository": "https://github.com/pvh/automerge-repo",
+  "repository": "https://github.com/automerge/automerge-repo",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
A few docs fixes following the move to the `@automerge` namespace.

This also removes a few references to the old localfirst relay network adapter which were still in the react hook, and fixes the repository entry in package.json.