### PR TITLE
Refactored the server to allow testing on all platforms

### DIFF
--- a/packages/automerge-repo-sync-server/package.json
+++ b/packages/automerge-repo-sync-server/package.json
@@ -6,8 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "node ./src/index.js",
-    "test": "bash ./scripts/tests.sh",
-    "test:run": "mocha --no-warnings --experimental-specifier-resolution=node --exit"
+    "test": "mocha --no-warnings --experimental-specifier-resolution=node --exit"
   },
   "dependencies": {
     "@automerge/automerge": "^2.1.0-alpha.7",

--- a/packages/automerge-repo-sync-server/src/index.js
+++ b/packages/automerge-repo-sync-server/src/index.js
@@ -1,45 +1,5 @@
 // @ts-check
-import fs from "fs"
-import express from "express"
-import { WebSocketServer } from "ws"
-import { Repo } from "@automerge/automerge-repo"
-import { NodeWSServerAdapter } from "@automerge/automerge-repo-network-websocket"
-import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs"
-import os from "os"
 
-const dir = ".amrg"
-if (!fs.existsSync(dir)) {
-  fs.mkdirSync(dir)
-}
+import { Server } from "./server.js"
 
-var hostname = os.hostname()
-
-const wsServer = new WebSocketServer({ noServer: true })
-const PORT = process.env.PORT !== undefined ? parseInt(process.env.PORT) : 3030
-const app = express()
-app.use(express.static("public"))
-
-const config = {
-  network: [new NodeWSServerAdapter(wsServer)],
-  storage: new NodeFSStorageAdapter(),
-  /** @ts-ignore @type {(import("automerge-repo").PeerId)}  */
-  peerId: `storage-server-${hostname}`,
-  // Since this is a server, we don't share generously — meaning we only sync documents they already
-  // know about and can ask for by ID.
-  sharePolicy: async () => false,
-}
-const serverRepo = new Repo(config)
-
-app.get("/", (req, res) => {
-  res.send(`👍 automerge-repo-sync-server is running`)
-})
-
-const server = app.listen(PORT, () => {
-  console.log(`Listening on port ${PORT}`)
-})
-
-server.on("upgrade", (request, socket, head) => {
-  wsServer.handleUpgrade(request, socket, head, (socket) => {
-    wsServer.emit("connection", socket, request)
-  })
-})
+new Server()

--- a/packages/automerge-repo-sync-server/src/server.js
+++ b/packages/automerge-repo-sync-server/src/server.js
@@ -1,0 +1,79 @@
+// @ts-check
+import fs from "fs"
+import express from "express"
+import { WebSocketServer } from "ws"
+import { Repo } from "@automerge/automerge-repo"
+import { NodeWSServerAdapter } from "@automerge/automerge-repo-network-websocket"
+import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs"
+import os from "os"
+
+export class Server {
+  /** @type WebSocketServer */
+  #socket
+
+  /** @type ReturnType<import("express").Express["listen"]> */
+  #server
+
+  /** @type {((value: any) => void)[]} */
+  #readyResolvers = []
+
+  #isReady = false
+
+  constructor() {
+    const dir = ".amrg"
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir)
+    }
+
+    var hostname = os.hostname()
+
+    this.#socket = new WebSocketServer({ noServer: true })
+
+    const PORT =
+      process.env.PORT !== undefined ? parseInt(process.env.PORT) : 3030
+    const app = express()
+    app.use(express.static("public"))
+
+    const config = {
+      network: [new NodeWSServerAdapter(this.#socket)],
+      storage: new NodeFSStorageAdapter(),
+      /** @ts-ignore @type {(import("automerge-repo").PeerId)}  */
+      peerId: `storage-server-${hostname}`,
+      // Since this is a server, we don't share generously — meaning we only sync documents they already
+      // know about and can ask for by ID.
+      sharePolicy: async () => false,
+    }
+    const serverRepo = new Repo(config)
+
+    app.get("/", (req, res) => {
+      res.send(`👍 @automerge/automerge-repo-sync-server is running`)
+    })
+
+    this.#server = app.listen(PORT, () => {
+      console.log(`Listening on port ${PORT}`)
+      this.#isReady = true
+      this.#readyResolvers.forEach((resolve) => resolve(true))
+    })
+
+    this.#server.on("upgrade", (request, socket, head) => {
+      this.#socket.handleUpgrade(request, socket, head, (socket) => {
+        this.#socket.emit("connection", socket, request)
+      })
+    })
+  }
+
+  async ready() {
+    if (this.#isReady) {
+      return true
+    }
+
+    return new Promise((resolve) => {
+      this.#readyResolvers.push(resolve)
+    })
+  }
+
+  close() {
+    this.#socket.close()
+    this.#server.close()
+  }
+}

--- a/packages/automerge-repo-sync-server/test/Server.test.js
+++ b/packages/automerge-repo-sync-server/test/Server.test.js
@@ -1,17 +1,27 @@
 // @ts-check
 
 import assert from "assert"
-import { beforeEach } from "mocha"
+import { before, after } from "mocha"
 import { WebSocket } from "ws"
 
 import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket"
 import { Repo } from "@automerge/automerge-repo"
+import { Server } from "../src/server.js"
 
 describe("Sync Server Tests", () => {
+  let server
+
   const PORT =
     process.env.PORT !== undefined ? parseInt(process.env.PORT) : 3030
+  before(async () => {
+    server = new Server()
 
-  beforeEach(() => {})
+    await server.ready()
+  })
+
+  after(() => {
+    server.close()
+  })
 
   it("runs the server correctly", (done) => {
     const ws = new WebSocket(`ws://localhost:${PORT}`)


### PR DESCRIPTION
This refactors the sync server so that the tests should be able to run on all platforms, not just those based on *nix.

It also opens up the possibility of perhaps at some point making this importable so that a simple server could be easily customised.

Fixes #99