### PR TITLE
Compaction intervals [draft]

### DIFF
--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -6,6 +6,7 @@ import { StorageAdapter } from "./StorageAdapter.js"
 export class StorageSubsystem {
   #storageAdapter: StorageAdapter
   #changeCount: Record<DocumentId, number> = {}
+  #compactedAt: number = 0
 
   constructor(storageAdapter: StorageAdapter) {
     this.#storageAdapter = storageAdapter
@@ -35,6 +36,7 @@ export class StorageSubsystem {
       this.#storageAdapter.remove(`${documentId}.incremental.${i}`)
     }
 
+    this.#compactedAt = Date.now().valueOf()
     this.#changeCount[documentId] = 0
   }
 
@@ -84,8 +86,11 @@ export class StorageSubsystem {
     }
   }
 
-  // TODO: make this, you know, good.
+  // compact after a minute or a thousand changes, whichever comes first
   #shouldCompact(documentId: DocumentId) {
-    return this.#changeCount[documentId] >= 20
+    return (
+      this.#changeCount[documentId] >= 1000 &&
+      this.#compactedAt < Date.now().valueOf() - 6000
+    )
   }
 }


### PR DESCRIPTION
At the I&S lab summit we prototyped a little drawing toy which produces data at ~60hZ. This makes the current "every 20 changes" `saveTotal()` call pretty gratuitous (3Hz). This PR changes the default compaction interval to 1000 changes or 1m, whichever is longer. 

I started writing a test for it but the private methods stymied the approach I took and I got distracted from the work. That said, I think this (or something like this) is a better design than the current "every 20 changes" model and we should land something along these lines.

If anyone else has an idea how to test, I'm all ears.