### PR TITLE
Use the same "type" for sync messages in WS client and server

### DIFF
--- a/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
@@ -110,7 +110,7 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
       senderId: this.peerId,
       targetId,
       channelId,
-      type: "message",
+      type: "sync",
       message,
       broadcast,
     }

--- a/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
@@ -126,7 +126,12 @@ export class NodeWSServerAdapter extends NetworkAdapter {
         // TODO: confirm this
         // ?
         break
+
+      // We accept both "message" and "sync" because a previous version of this
+      // codebase sent sync messages in the BrowserWebSocketClientAdapter as
+      // type "message" and we want to stay backwards compatible
       case "message":
+      case "sync":
         this.emit("message", {
           senderId,
           targetId,
@@ -136,7 +141,7 @@ export class NodeWSServerAdapter extends NetworkAdapter {
         })
         break
       default:
-        // log("unrecognized message type")
+        log(`unrecognized message type ${type}`)
         break
     }
   }


### PR DESCRIPTION
The websocket adapter wraps sync messages in an envelope which looks like this:

{
  senderId: string,
  targetId: string,
  channelId: string,
  type: string,
  message: UInt8Array,
  broadcast: boolean,
}

The `type` field is common across all message types and is used to dispatch the message internally. In the `NodeWSServerAdapter` the type used when _sending_ a sync message was "sync", but the type expected when receiving a sync message was "message". This is because the `BrowserWebSocketClientAdapter` was sending sync messages with type "message" and didn't examine the type field at all when dispatching received sync messages. This in turn led to some confusion when implementing interoperable clients.

Modify the `BrowserWebSocketClientAdapter` to send messages with type "sync" and modify `NodeWSServerAdapter` to accept messages with type of both "sync" and "message" as sync messages. Thus making the message type consistent but maintaining backwards compatiblity.