### PR TITLE
feat(changeDoc): add option parameter changeDoc

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -1,4 +1,4 @@
-import { Doc, ChangeFn } from "@automerge/automerge"
+import { Doc, ChangeFn, ChangeOptions } from "@automerge/automerge"
 import { DocumentId, DocHandlePatchPayload } from "@automerge/automerge-repo"
 import { useEffect, useState } from "react"
 import { useRepo } from "./useRepo"
@@ -23,9 +23,9 @@ export function useDocument<T>(documentId?: DocumentId) {
     return cleanup
   }, [handle])
 
-  const changeDoc = (changeFn: ChangeFn<T>) => {
+  const changeDoc = (changeFn: ChangeFn<T>, options?: ChangeOptions<T> | undefined) => {
     if (!handle) return
-    handle.change(changeFn)
+    handle.change(changeFn, options)
   }
 
   return [doc, changeDoc] as [Doc<T>, (changeFn: ChangeFn<T>) => void]


### PR DESCRIPTION
Add the optional `ChangeOptions<T>` `options` parameter to `useDocument:changeDoc` function so it can pass it to the `DocHandle<T>:change` function.

This would be useful for example to pass along a message with the changes.