### PR TITLE
Rename `.doc` to `.syncValue` and return `undefined` when not ready

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -1,5 +1,5 @@
 import { Doc, ChangeFn, ChangeOptions } from "@automerge/automerge"
-import { DocumentId, DocHandlePatchPayload } from "@automerge/automerge-repo"
+import { DocumentId, DocHandleChangePayload } from "@automerge/automerge-repo"
 import { useEffect, useState } from "react"
 import { useRepo } from "./useRepo"
 
@@ -12,18 +12,21 @@ export function useDocument<T>(documentId?: DocumentId) {
   useEffect(() => {
     if (!handle) return
 
-    handle.value().then(v => setDoc(v))
+    handle.doc().then(v => setDoc(v))
 
-    const onPatch = (h: DocHandlePatchPayload<T>) => setDoc(h.patchInfo.after)
-    handle.on("patch", onPatch)
+    const onChange = (h: DocHandleChangePayload<T>) => setDoc(h.doc)
+    handle.on("change", onChange)
     const cleanup = () => {
-      handle.removeListener("patch", onPatch)
+      handle.removeListener("change", onChange)
     }
 
     return cleanup
   }, [handle])
 
-  const changeDoc = (changeFn: ChangeFn<T>, options?: ChangeOptions<T> | undefined) => {
+  const changeDoc = (
+    changeFn: ChangeFn<T>,
+    options?: ChangeOptions<T> | undefined
+  ) => {
     if (!handle) return
     handle.change(changeFn, options)
   }

--- a/packages/automerge-repo-svelte-store/src/index.ts
+++ b/packages/automerge-repo-svelte-store/src/index.ts
@@ -4,7 +4,7 @@ import { writable } from "svelte/store"
 import {
   Repo,
   DocumentId,
-  DocHandlePatchPayload,
+  DocHandleChangePayload,
 } from "@automerge/automerge-repo"
 
 const ContextRepoKey = Symbol("svelte-context-automerge-repo")
@@ -21,9 +21,9 @@ export function document<T>(documentId: DocumentId) {
   const repo = getContextRepo()
   const handle = repo.find<T>(documentId)
   const { set, subscribe } = writable<Doc<T>>(null, () => {
-    const onPatch = (h: DocHandlePatchPayload<T>) => set(h.patchInfo.after)
-    handle.addListener("patch", onPatch)
-    return () => handle.removeListener("patch", onPatch)
+    const onChange = (h: DocHandleChangePayload<T>) => set(h.doc)
+    handle.addListener("change", onChange)
+    return () => handle.removeListener("change", onChange)
   })
 
   return {

--- a/packages/automerge-repo/README.md
+++ b/packages/automerge-repo/README.md
@@ -53,34 +53,19 @@ A `Repo` exposes these methods:
 A `DocHandle` is a wrapper around an `Automerge.Doc`. Its primary function is to dispatch changes to
 the document.
 
+- `handle.doc()` or `handle.docSync()`
+  Returns a `Promise<Doc<T>>` that will contain the current value of the document.
+  it waits until the document has finished loading and/or synchronizing over the network before
+  returning a value.
 - `handle.change((doc: T) => void)`  
   Calls the provided callback with an instrumented mutable object
   representing the document. Any changes made to the document will be recorded and distributed to
   other nodes.
-- `handle.value()`  
-  Returns a `Promise<Doc<T>>` that will contain the current value of the document.
-  it waits until the document has finished loading and/or synchronizing over the network before
-  returning a value.
-
-When required, you can also access the underlying document directly, but only after the handle is ready:
-
-```ts
-if (handle.ready()) {
-  doc = handle.doc
-} else {
-  handle.value().then(d => {
-    doc = d
-  })
-}
-```
 
 A `DocHandle` also emits these events:
 
-- `change({handle: DocHandle, doc: Doc<T>})`  
-  Called any time changes are created or received on the document. Request the `value()` from the
-  handle.
-- `patch({handle: DocHandle, patches: Patch[], patchInfo: PatchInfo})` 
-  Useful for manual increment maintenance of a video, most notably for text editors.
+- `change({handle: DocHandle, patches: Patch[], patchInfo: PatchInfo})` 
+  Called whenever the document changes, the handle's .doc
 - `delete`  
   Called when the document is deleted locally.
 

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -147,11 +147,9 @@ export class DocHandle<T> //
     this.#machine.send(isNew ? CREATE : FIND)
   }
 
-  get doc() {
+  get syncValue() {
     if (!this.isReady()) {
-      throw new Error(
-        `DocHandle#${this.documentId} is not ready. Check \`handle.isReady()\` before accessing the document.`
-      )
+      return undefined
     }
 
     return this.#doc

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -285,7 +285,7 @@ export class DocHandle<T> //
     }
     this.#machine.send(UPDATE, {
       payload: {
-        DocHandleChangePayload: (doc: A.Doc<T>) => {
+        callback: (doc: A.Doc<T>) => {
           return A.changeAt(doc, heads, options, callback)
         },
       },

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -32,7 +32,7 @@ export class Repo extends DocCollection {
     this.on("document", async ({ handle }) => {
       if (storageSubsystem) {
         // Save when the document changes
-        handle.on("binaryChange", async ({ handle, doc }) => {
+        handle.on("heads-changed", async ({ handle, doc }) => {
           storageSubsystem.save(handle.documentId, doc)
         })
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -8,6 +8,7 @@ import { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js
 import { ChannelId, DocumentId, PeerId } from "./types.js"
 
 import debug from "debug"
+import { waitFor } from "xstate/lib/waitFor.js"
 
 const SYNC_CHANNEL = "sync_channel" as ChannelId
 
@@ -31,8 +32,7 @@ export class Repo extends DocCollection {
     this.on("document", async ({ handle }) => {
       if (storageSubsystem) {
         // Save when the document changes
-        handle.on("change", async ({ handle }) => {
-          const doc = await handle.value()
+        handle.on("binaryChange", async ({ handle, doc }) => {
           storageSubsystem.save(handle.documentId, doc)
         })
 

--- a/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
@@ -46,7 +46,7 @@ export function runAdapterTests(_setup: SetupFn, title?: string): void {
 
         // Bob receives the change
         await eventPromise(bobHandle, "change")
-        assert.equal((await bobHandle.value()).foo, "bar")
+        assert.equal((await bobHandle.doc()).foo, "bar")
 
         // Bob changes the document
         bobHandle.change(d => {
@@ -55,7 +55,7 @@ export function runAdapterTests(_setup: SetupFn, title?: string): void {
 
         // Alice receives the change
         await eventPromise(aliceHandle, "change")
-        assert.equal((await aliceHandle.value()).foo, "baz")
+        assert.equal((await aliceHandle.doc()).foo, "baz")
       }
 
       // Run the test in both directions, in case they're different types of adapters
@@ -97,8 +97,8 @@ export function runAdapterTests(_setup: SetupFn, title?: string): void {
 
       // Bob and Charlie receive the change
       await eventPromises([bobHandle, charlieHandle], "change")
-      assert.equal((await bobHandle.value()).foo, "bar")
-      assert.equal((await charlieHandle.value()).foo, "bar")
+      assert.equal((await bobHandle.doc()).foo, "bar")
+      assert.equal((await charlieHandle.doc()).foo, "bar")
 
       // Charlie changes the document
       charlieHandle.change(d => {
@@ -107,8 +107,8 @@ export function runAdapterTests(_setup: SetupFn, title?: string): void {
 
       // Alice and Bob receive the change
       await eventPromises([aliceHandle, bobHandle], "change")
-      assert.equal((await bobHandle.value()).foo, "baz")
-      assert.equal((await charlieHandle.value()).foo, "baz")
+      assert.equal((await bobHandle.doc()).foo, "baz")
+      assert.equal((await charlieHandle.doc()).foo, "baz")
 
       teardown()
     })

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -1,9 +1,6 @@
 export { DocCollection } from "./DocCollection.js"
 export { DocHandle, HandleState } from "./DocHandle.js"
-export type {
-  DocHandleChangePayload,
-  DocHandlePatchPayload,
-} from "./DocHandle.js"
+export type { DocHandleChangePayload } from "./DocHandle.js"
 export { NetworkAdapter } from "./network/NetworkAdapter.js"
 export type {
   InboundMessagePayload,

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -40,13 +40,13 @@ describe("DocHandle", () => {
 
     assert.equal(handle.isReady(), true)
     const doc = await handle.value()
-    assert.deepEqual(doc, handle.doc)
+    assert.deepEqual(doc, handle.syncValue)
   })
 
-  it("should throws an error if we accessing the doc before ready", async () => {
+  it("should return undefined if we accessing the doc before ready", async () => {
     const handle = new DocHandle<TestDoc>(TEST_ID)
 
-    assert.throws(() => handle.doc)
+    assert.equal(handle.syncValue, undefined)
   })
 
   it("should not return a value until ready", async () => {
@@ -86,7 +86,7 @@ describe("DocHandle", () => {
     // we don't have it in storage, so we request it from the network
     handle.request()
 
-    assert.throws(() => handle.doc)
+    assert.equal(handle.syncValue, undefined)
     assert.equal(handle.isReady(), false)
     assert.throws(() => handle.change(h => {}))
   })
@@ -142,7 +142,7 @@ describe("DocHandle", () => {
 
     const p = new Promise<void>(resolve =>
       handle.once("change", ({ handle, doc }) => {
-        assert.equal(handle.doc.foo, doc.foo)
+        assert.equal(handle.syncValue?.foo, doc.foo)
 
         resolve()
       })
@@ -282,7 +282,7 @@ describe("DocHandle", () => {
       doc.foo = "bar"
     })
 
-    const headsBefore = A.getHeads(handle.doc)
+    const headsBefore = A.getHeads(handle.syncValue!)
 
     handle.change(doc => {
       doc.foo = "rab"

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -41,7 +41,7 @@ describe("Repo", () => {
       handle.change(d => {
         d.foo = "bar"
       })
-      const v = await handle.value()
+      const v = await handle.doc()
       assert.equal(handle.isReady(), true)
 
       assert.equal(v.foo, "bar")
@@ -53,7 +53,7 @@ describe("Repo", () => {
       assert.equal(handle.isReady(), false)
 
       return assert.rejects(
-        rejectOnTimeout(handle.value(), 100),
+        rejectOnTimeout(handle.doc(), 100),
         "This document should not exist"
       )
     })
@@ -71,7 +71,7 @@ describe("Repo", () => {
       assert.equal(handle, bobHandle)
       assert.equal(handle.isReady(), true)
 
-      const v = await bobHandle.value()
+      const v = await bobHandle.doc()
       assert.equal(v.foo, "bar")
     })
 
@@ -94,7 +94,7 @@ describe("Repo", () => {
 
       const bobHandle = repo2.find<TestDoc>(handle.documentId)
 
-      const v = await bobHandle.value()
+      const v = await bobHandle.doc()
       assert.equal(v.foo, "bar")
     })
 
@@ -105,7 +105,7 @@ describe("Repo", () => {
         d.foo = "bar"
       })
       assert.equal(handle.isReady(), true)
-      await handle.value()
+      await handle.doc()
       repo.delete(handle.documentId)
 
       assert(handle.isDeleted())
@@ -113,7 +113,7 @@ describe("Repo", () => {
 
       const bobHandle = repo.find<TestDoc>(handle.documentId)
       await assert.rejects(
-        rejectOnTimeout(bobHandle.value(), 10),
+        rejectOnTimeout(bobHandle.doc(), 10),
         "document should have been deleted"
       )
 
@@ -234,7 +234,7 @@ describe("Repo", () => {
 
       const bobHandle = bobRepo.find<TestDoc>(aliceHandle.documentId)
       await eventPromise(bobHandle, "change")
-      const bobDoc = await bobHandle.value()
+      const bobDoc = await bobHandle.doc()
       assert.deepStrictEqual(bobDoc, { foo: "bar" })
       teardown()
     })
@@ -244,7 +244,7 @@ describe("Repo", () => {
 
       const handle3 = charlieRepo.find<TestDoc>(aliceHandle.documentId)
       await eventPromise(handle3, "change")
-      const doc3 = await handle3.value()
+      const doc3 = await handle3.doc()
       assert.deepStrictEqual(doc3, { foo: "bar" })
       teardown()
     })
@@ -269,7 +269,7 @@ describe("Repo", () => {
       const { charlieRepo, notForCharlie, teardown } = await setup()
 
       const handle = charlieRepo.find<TestDoc>(notForCharlie)
-      const doc = await handle.value()
+      const doc = await handle.doc()
 
       assert.deepStrictEqual(doc, { foo: "baz" })
 
@@ -280,7 +280,7 @@ describe("Repo", () => {
       const { charlieRepo, notForBob, teardown } = await setup()
 
       const handle = charlieRepo.find<TestDoc>(notForBob)
-      const doc = await handle.value()
+      const doc = await handle.doc()
       assert.deepStrictEqual(doc, { foo: "bap" })
 
       teardown()
@@ -292,7 +292,7 @@ describe("Repo", () => {
       assert.equal(handle.isReady(), false)
 
       return assert.rejects(
-        rejectOnTimeout(handle.value(), 100),
+        rejectOnTimeout(handle.doc(), 100),
         "This document should not exist"
       )
     })
@@ -312,7 +312,7 @@ describe("Repo", () => {
 
       const handle3 = charlieRepo.find<TestDoc>(aliceHandle.documentId)
       await eventPromise(handle3, "change")
-      const doc3 = await handle3.value()
+      const doc3 = await handle3.doc()
 
       assert.deepStrictEqual(doc3, { foo: "baz" })
 
@@ -351,7 +351,7 @@ describe("Repo", () => {
 
         // make sure the doc is ready
         if (!doc.isReady()) {
-          await doc.value()
+          await doc.doc()
         }
 
         // make a random change to it


### PR DESCRIPTION
This is a pretty big behavioural change but should work nicely for environments where the value is checked frequently. If it's only read once, the user will be confused by getting undefined back but maybe that's okay?