### PR TITLE
Automerge URLs

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useBootstrap.ts
+++ b/packages/automerge-repo-react-hooks/src/useBootstrap.ts
@@ -2,7 +2,7 @@ import {
   DocHandle,
   DocumentId,
   Repo,
-  StringDocumentId,
+  EncodedDocumentId,
   generateAutomergeUrl,
 } from "@automerge/automerge-repo"
 import { useEffect, useState, useMemo } from "react"
@@ -87,16 +87,16 @@ export const useBootstrap = <T>({
 
   // Try to get existing document; else create a new one
   const handle = useMemo((): DocHandle<T> => {
-    const stringDocumentId = getDocumentId(key, hash) as
-      | StringDocumentId
+    const encodedDocumentId = getDocumentId(key, hash) as
+      | EncodedDocumentId
       | undefined
     try {
-      return stringDocumentId
-        ? repo.find(generateAutomergeUrl({ stringDocumentId }))
+      return encodedDocumentId
+        ? repo.find(generateAutomergeUrl({ encodedDocumentId }))
         : onNoDocument(repo)
     } catch (error) {
       // Presumably the documentId was invalid
-      if (stringDocumentId && onInvalidDocumentId)
+      if (encodedDocumentId && onInvalidDocumentId)
         return onInvalidDocumentId(repo, error)
       // Forward other errors
       throw error

--- a/packages/automerge-repo-react-hooks/src/useBootstrap.ts
+++ b/packages/automerge-repo-react-hooks/src/useBootstrap.ts
@@ -1,4 +1,10 @@
-import { DocHandle, DocumentId, Repo } from "@automerge/automerge-repo"
+import {
+  DocHandle,
+  DocumentId,
+  Repo,
+  StringDocumentId,
+  generateAutomergeUrl,
+} from "@automerge/automerge-repo"
 import { useEffect, useState, useMemo } from "react"
 import { useRepo } from "./useRepo.js"
 
@@ -81,14 +87,16 @@ export const useBootstrap = <T>({
 
   // Try to get existing document; else create a new one
   const handle = useMemo((): DocHandle<T> => {
-    const existingDocumentId = getDocumentId(key, hash)
+    const stringDocumentId = getDocumentId(key, hash) as
+      | StringDocumentId
+      | undefined
     try {
-      return existingDocumentId
-        ? repo.find(existingDocumentId as DocumentId)
+      return stringDocumentId
+        ? repo.find(generateAutomergeUrl({ stringDocumentId }))
         : onNoDocument(repo)
     } catch (error) {
       // Presumably the documentId was invalid
-      if (existingDocumentId && onInvalidDocumentId)
+      if (stringDocumentId && onInvalidDocumentId)
         return onInvalidDocumentId(repo, error)
       // Forward other errors
       throw error

--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -1,9 +1,9 @@
-import { Doc, ChangeFn, ChangeOptions } from "@automerge/automerge"
-import { DocumentId, DocHandleChangePayload } from "@automerge/automerge-repo"
+import { ChangeFn, ChangeOptions, Doc } from "@automerge/automerge"
+import { AutomergeUrl, DocHandleChangePayload } from "@automerge/automerge-repo"
 import { useEffect, useState } from "react"
 import { useRepo } from "./useRepo"
 
-export function useDocument<T>(documentId?: DocumentId) {
+export function useDocument<T>(documentId?: AutomergeUrl) {
   const [doc, setDoc] = useState<Doc<T>>()
   const repo = useRepo()
 

--- a/packages/automerge-repo-react-hooks/src/useHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useHandle.ts
@@ -1,9 +1,9 @@
-import { DocHandle, DocumentId } from "@automerge/automerge-repo"
+import { AutomergeUrl, DocHandle } from "@automerge/automerge-repo"
 import { useState } from "react"
 import { useRepo } from "./useRepo.js"
 
-export function useHandle<T>(documentId: DocumentId): DocHandle<T> {
+export function useHandle<T>(automergeUrl: AutomergeUrl): DocHandle<T> {
   const repo = useRepo()
-  const [handle] = useState<DocHandle<T>>(repo.find(documentId))
+  const [handle] = useState<DocHandle<T>>(repo.find(automergeUrl))
   return handle
 }

--- a/packages/automerge-repo-svelte-store/src/index.ts
+++ b/packages/automerge-repo-svelte-store/src/index.ts
@@ -1,11 +1,11 @@
-import type { Doc, ChangeFn } from "@automerge/automerge"
-import { setContext, getContext } from "svelte"
-import { writable } from "svelte/store"
+import type { ChangeFn, Doc } from "@automerge/automerge"
 import {
-  Repo,
-  DocumentId,
+  AutomergeUrl,
   DocHandleChangePayload,
+  Repo,
 } from "@automerge/automerge-repo"
+import { getContext, setContext } from "svelte"
+import { writable } from "svelte/store"
 
 const ContextRepoKey = Symbol("svelte-context-automerge-repo")
 
@@ -17,7 +17,7 @@ export function setContextRepo(repo: Repo) {
   setContext(ContextRepoKey, repo)
 }
 
-export function document<T>(documentId: DocumentId) {
+export function document<T>(documentId: AutomergeUrl) {
   const repo = getContextRepo()
   const handle = repo.find<T>(documentId)
   const { set, subscribe } = writable<Doc<T>>(null, () => {

--- a/packages/automerge-repo/package.json
+++ b/packages/automerge-repo/package.json
@@ -32,6 +32,7 @@
     "@automerge/automerge": "^2.1.0-alpha.8"
   },
   "dependencies": {
+    "bs58check": "^3.0.1",
     "cbor-x": "^1.3.0",
     "debug": "^4.3.4",
     "eventemitter3": "^5.0.1",

--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -64,7 +64,8 @@ export class DocCollection extends EventEmitter<DocCollectionEvents> {
     // or
     // - pass a "reify" function that takes a `<any>` and returns `<T>`
 
-    const documentId = uuid() as DocumentId
+    // Generate a new UUID and store it in the buffer
+
     const handle = this.#getHandle<T>(documentId, true) as DocHandle<T>
     this.emit("document", { handle })
     return handle

--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -6,6 +6,7 @@ import {
   decodeDocumentId,
   encodeDocumentId,
   generateAutomergeUrl,
+  isValidAutomergeUrl,
   parseAutomergeUrl,
 } from "./DocUrl.js"
 
@@ -87,6 +88,10 @@ export class DocCollection extends EventEmitter<DocCollectionEvents> {
     /** The documentId of the handle to retrieve */
     automergeUrl: AutomergeUrl
   ): DocHandle<T> {
+    if (!isValidAutomergeUrl(automergeUrl)) {
+      throw new Error(`Invalid AutomergeUrl: '${automergeUrl}'`)
+    }
+
     const { encodedDocumentId } = parseAutomergeUrl(automergeUrl)
     // If we have the handle cached, return it
     if (this.#handleCache[encodedDocumentId])

--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -106,7 +106,7 @@ export class DocCollection extends EventEmitter<DocCollectionEvents> {
 
     delete this.#handleCache[encodedDocumentId]
     this.emit("delete-document", {
-      documentId: decodeDocumentId(encodedDocumentId)!,
+      encodedDocumentId: encodedDocumentId,
     })
   }
 }
@@ -122,5 +122,5 @@ interface DocumentPayload {
 }
 
 interface DeleteDocumentPayload {
-  documentId: DocumentId
+  encodedDocumentId: EncodedDocumentId
 }

--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -88,6 +88,10 @@ export class DocCollection extends EventEmitter<DocCollectionEvents> {
     automergeUrl: AutomergeUrl
   ): DocHandle<T> {
     const { encodedDocumentId } = parseAutomergeUrl(automergeUrl)
+    // If we have the handle cached, return it
+    if (this.#handleCache[encodedDocumentId])
+      return this.#handleCache[encodedDocumentId]
+
     const handle = this.#getHandle<T>(encodedDocumentId, false) as DocHandle<T>
     this.emit("document", { handle })
     return handle

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -22,8 +22,9 @@ import type {
   ChannelId,
   StringDocumentId,
   PeerId,
+  AutomergeUrl,
 } from "./types.js"
-import { encode } from "./DocUrl.js"
+import { encode, generateAutomergeUrl } from "./DocUrl.js"
 
 /** DocHandle is a wrapper around a single Automerge document that lets us listen for changes. */
 export class DocHandle<T> //
@@ -36,6 +37,10 @@ export class DocHandle<T> //
 
   get stringDocumentId(): StringDocumentId {
     return encode(this.documentId) as StringDocumentId
+  }
+
+  get url(): AutomergeUrl {
+    return generateAutomergeUrl({ documentId: this.documentId })
   }
 
   constructor(

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -20,11 +20,11 @@ import { TimeoutError, withTimeout } from "./helpers/withTimeout.js"
 import type {
   DocumentId,
   ChannelId,
-  StringDocumentId,
+  EncodedDocumentId,
   PeerId,
   AutomergeUrl,
 } from "./types.js"
-import { encode, generateAutomergeUrl } from "./DocUrl.js"
+import { encodeDocumentId, stringifyAutomergeUrl } from "./DocUrl.js"
 
 /** DocHandle is a wrapper around a single Automerge document that lets us listen for changes. */
 export class DocHandle<T> //
@@ -34,13 +34,14 @@ export class DocHandle<T> //
 
   #machine: DocHandleXstateMachine<T>
   #timeoutDelay: number
+  #encodedDocumentId: EncodedDocumentId
 
-  get stringDocumentId(): StringDocumentId {
-    return encode(this.documentId) as StringDocumentId
+  get encodedDocumentId(): EncodedDocumentId {
+    return this.#encodedDocumentId
   }
 
   get url(): AutomergeUrl {
-    return generateAutomergeUrl({ documentId: this.documentId })
+    return stringifyAutomergeUrl({ documentId: this.documentId })
   }
 
   constructor(
@@ -48,9 +49,12 @@ export class DocHandle<T> //
     { isNew = false, timeoutDelay = 60_000 }: DocHandleOptions = {}
   ) {
     super()
+    this.#encodedDocumentId = encodeDocumentId(
+      this.documentId
+    ) as EncodedDocumentId
     this.#timeoutDelay = timeoutDelay
     this.#log = debug(
-      `automerge-repo:dochandle:${this.stringDocumentId.slice(0, 5)}`
+      `automerge-repo:dochandle:${this.encodedDocumentId.slice(0, 5)}`
     )
 
     // initial doc

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -1,7 +1,6 @@
 import * as A from "@automerge/automerge"
 import debug from "debug"
 import EventEmitter from "eventemitter3"
-import * as bs58check from "bs58check"
 import {
   assign,
   BaseActionObject,
@@ -19,11 +18,12 @@ import { headsAreSame } from "./helpers/headsAreSame.js"
 import { pause } from "./helpers/pause.js"
 import { TimeoutError, withTimeout } from "./helpers/withTimeout.js"
 import type {
-  BinaryDocumentId,
-  ChannelId,
   DocumentId,
+  ChannelId,
+  StringDocumentId,
   PeerId,
 } from "./types.js"
+import { encode } from "./DocUrl.js"
 
 /** DocHandle is a wrapper around a single Automerge document that lets us listen for changes. */
 export class DocHandle<T> //
@@ -34,17 +34,19 @@ export class DocHandle<T> //
   #machine: DocHandleXstateMachine<T>
   #timeoutDelay: number
 
-  get documentId(): DocumentId {
-    return bs58check.encode(this.binaryDocumentId) as DocumentId
+  get stringDocumentId(): StringDocumentId {
+    return encode(this.documentId) as StringDocumentId
   }
 
   constructor(
-    public binaryDocumentId: BinaryDocumentId,
+    public documentId: DocumentId,
     { isNew = false, timeoutDelay = 60_000 }: DocHandleOptions = {}
   ) {
     super()
     this.#timeoutDelay = timeoutDelay
-    this.#log = debug(`automerge-repo:dochandle:${this.documentId.slice(0, 5)}`)
+    this.#log = debug(
+      `automerge-repo:dochandle:${this.stringDocumentId.slice(0, 5)}`
+    )
 
     // initial doc
     const doc = A.init<T>()
@@ -398,7 +400,7 @@ type DocHandleMachineState = {
 // context
 
 interface DocHandleContext<T> {
-  documentId: string
+  documentId: DocumentId
   doc: A.Doc<T>
 }
 

--- a/packages/automerge-repo/src/DocUrl.ts
+++ b/packages/automerge-repo/src/DocUrl.ts
@@ -1,51 +1,80 @@
-import { AutomergeUrl, DocumentId, StringDocumentId } from "./types"
+import { AutomergeUrl, DocumentId, EncodedDocumentId } from "./types"
 import { v4 as uuid } from "uuid"
 import bs58check from "bs58check"
 
-export const parseAutomergeUrl = (link: AutomergeUrl) => {
-  const { stringDocumentId } = parts(link)
-  const documentId = bs58check.decodeUnsafe(stringDocumentId) as
-    | DocumentId
-    | undefined
-  if (!documentId) throw new Error("Invalid document URL: " + link)
-  return { documentId }
+/**
+ * given an Automerge URL, return a decoded DocumentId (and the encoded DocumentId)
+ *
+ * @param url
+ * @returns { documentId: Uint8Array(16), encodedDocumentId: bs58check.encode(documentId) }
+ */
+export const parseAutomergeUrl = (url: AutomergeUrl) => {
+  const { documentId, encodedDocumentId } = parts(url)
+  if (!documentId) throw new Error("Invalid document URL: " + url)
+  return { documentId, encodedDocumentId }
 }
 
-interface GenerateAutomergeUrlOptions {
-  documentId: StringDocumentId | DocumentId
+interface StringifyAutomergeUrlOptions {
+  documentId: EncodedDocumentId | DocumentId
 }
 
-export const generateAutomergeUrl = ({
+/**
+ * Given a documentId in either canonical form, return an Automerge URL
+ * Throws on invalid input.
+ * Note: this is an object because we anticipate adding fields in the future.
+ * @param { documentId: EncodedDocumentId | DocumentId }
+ * @returns AutomergeUrl
+ */
+export const stringifyAutomergeUrl = ({
   documentId,
-}: GenerateAutomergeUrlOptions): AutomergeUrl => {
+}: StringifyAutomergeUrlOptions): AutomergeUrl => {
   if (documentId instanceof Uint8Array)
-    return ("automerge:" + bs58check.encode(documentId)) as AutomergeUrl
+    return ("automerge:" +
+      encodeDocumentId(documentId as DocumentId)) as AutomergeUrl
   else if (typeof documentId === "string") {
     return ("automerge:" + documentId) as AutomergeUrl
   }
   throw new Error("Invalid documentId: " + documentId)
 }
 
+/**
+ * Given a string, return true if it is a valid Automerge URL
+ * also acts as a type discriminator in Typescript.
+ * @param str: URL candidate
+ * @returns boolean
+ */
 export const isValidAutomergeUrl = (str: string): str is AutomergeUrl => {
-  const { stringDocumentId } = parts(str)
-  const documentId = bs58check.decodeUnsafe(stringDocumentId)
+  const { documentId } = parts(str)
   return documentId ? true : false
 }
 
-export const parts = (str: string) => {
-  const [m, stringDocumentId] = str.match(/^automerge:(\w+)$/) || []
-  return { stringDocumentId }
-}
+/**
+ * generateAutomergeUrl produces a new AutomergeUrl.
+ * generally only called by create(), but used in tests as well.
+ * @returns a new Automerge URL with a random UUID documentId
+ */
+export const generateAutomergeUrl = (): AutomergeUrl =>
+  stringifyAutomergeUrl({
+    documentId: uuid(null, new Uint8Array(16)) as DocumentId,
+  })
 
-export const generate = (): DocumentId =>
-  Uint8Array.from(uuid(null, new Uint8Array(16))) as DocumentId
+export const decodeDocumentId = (
+  docId: EncodedDocumentId
+): DocumentId | undefined =>
+  bs58check.decodeUnsafe(docId) as DocumentId | undefined
 
-export const encode = (id: DocumentId): StringDocumentId => {
-  return bs58check.encode(id) as StringDocumentId
-}
+export const encodeDocumentId = (docId: DocumentId): EncodedDocumentId =>
+  bs58check.encode(docId) as EncodedDocumentId
 
-export const decode = (id: StringDocumentId): DocumentId => {
-  const decoded: DocumentId = bs58check.decode(id) as DocumentId
-  if (decoded.length != 16) throw new Error("Invalid document ID: " + id)
-  return decoded
+/**
+ * parts breaks up the URL into constituent pieces,
+ * eventually this could include things like heads, so we use this structure
+ * @param str
+ * @returns
+ */
+const parts = (str: string) => {
+  const [m, docMatch] = str.match(/^automerge:(\w+)$/) || []
+  const encodedDocumentId = docMatch as EncodedDocumentId
+  const documentId = decodeDocumentId(encodedDocumentId)
+  return { documentId, encodedDocumentId }
 }

--- a/packages/automerge-repo/src/DocUrl.ts
+++ b/packages/automerge-repo/src/DocUrl.ts
@@ -1,0 +1,41 @@
+import { DocumentUrl, DocumentId, StringDocumentId } from "./types"
+import { v4 as uuid } from "uuid"
+import Base58 from "bs58check"
+
+export const documentIdFromUrl = (link: DocumentUrl) => {
+  const { stringDocumentId } = parts(link)
+  const documentId = Base58.decodeUnsafe(stringDocumentId)
+  if (!documentId) throw new Error("Invalid document URL: " + link)
+  return documentId as DocumentId
+}
+
+export const isValidAutomergeUrl = (str: string): str is DocumentUrl => {
+  const { stringDocumentId } = parts(str)
+  const documentId = Base58.decodeUnsafe(stringDocumentId)
+  return documentId ? true : false
+}
+
+export const parts = (str: string) => {
+  const [m, stringDocumentId] = str.match(/^automerge:(\w+)$/) || []
+  return { stringDocumentId }
+}
+
+export const generate = (): DocumentId =>
+  Uint8Array.from(uuid(null, new Uint8Array(16))) as DocumentId
+
+export const encode = (id: DocumentId): StringDocumentId => {
+  if (id.length != 16) {
+    console.trace("encode", id)
+  }
+
+  return Base58.encode(id) as StringDocumentId
+}
+
+export const decode = (id: StringDocumentId): DocumentId => {
+  const decoded = Base58.decode(id) as DocumentId
+  if (decoded.length != 16) throw new Error("Invalid document ID: " + id)
+  return decoded
+}
+
+export const urlForDocumentId = (id: DocumentId): DocumentUrl =>
+  ("automerge:" + encode(id)) as DocumentUrl

--- a/packages/automerge-repo/src/DocUrl.ts
+++ b/packages/automerge-repo/src/DocUrl.ts
@@ -2,6 +2,8 @@ import { AutomergeUrl, DocumentId, EncodedDocumentId } from "./types"
 import { v4 as uuid } from "uuid"
 import bs58check from "bs58check"
 
+export const urlPrefix = "automerge:"
+
 /**
  * given an Automerge URL, return a decoded DocumentId (and the encoded DocumentId)
  *
@@ -29,10 +31,10 @@ export const stringifyAutomergeUrl = ({
   documentId,
 }: StringifyAutomergeUrlOptions): AutomergeUrl => {
   if (documentId instanceof Uint8Array)
-    return ("automerge:" +
+    return (urlPrefix +
       encodeDocumentId(documentId as DocumentId)) as AutomergeUrl
   else if (typeof documentId === "string") {
-    return ("automerge:" + documentId) as AutomergeUrl
+    return (urlPrefix + documentId) as AutomergeUrl
   }
   throw new Error("Invalid documentId: " + documentId)
 }
@@ -44,6 +46,8 @@ export const stringifyAutomergeUrl = ({
  * @returns boolean
  */
 export const isValidAutomergeUrl = (str: string): str is AutomergeUrl => {
+  if (!str.startsWith(urlPrefix)) return false
+
   const { documentId } = parts(str)
   return documentId ? true : false
 }
@@ -73,7 +77,8 @@ export const encodeDocumentId = (docId: DocumentId): EncodedDocumentId =>
  * @returns
  */
 const parts = (str: string) => {
-  const [m, docMatch] = str.match(/^automerge:(\w+)$/) || []
+  const regex = new RegExp(`^${urlPrefix}(\\w+)$`)
+  const [m, docMatch] = str.match(regex) || []
   const encodedDocumentId = docMatch as EncodedDocumentId
   const documentId = decodeDocumentId(encodedDocumentId)
   return { documentId, encodedDocumentId }

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -48,12 +48,12 @@ export class Repo extends DocCollection {
       synchronizer.addDocument(handle.documentId)
     })
 
-    this.on("delete-document", ({ documentId }) => {
+    this.on("delete-document", ({ encodedDocumentId }) => {
       // TODO Pass the delete on to the network
       // synchronizer.removeDocument(documentId)
 
       if (storageSubsystem) {
-        storageSubsystem.remove(encodeDocumentId(documentId))
+        storageSubsystem.remove(encodedDocumentId)
       }
     })
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -8,8 +8,6 @@ import { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js
 import { ChannelId, DocumentId, PeerId } from "./types.js"
 
 import debug from "debug"
-import { waitFor } from "xstate/lib/waitFor.js"
-
 const SYNC_CHANNEL = "sync_channel" as ChannelId
 
 /** A Repo is a DocCollection with networking, syncing, and storage capabilities. */

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -1,4 +1,5 @@
 import { DocCollection } from "./DocCollection.js"
+import { encodeDocumentId } from "./DocUrl.js"
 import { EphemeralData } from "./EphemeralData.js"
 import { NetworkAdapter } from "./network/NetworkAdapter.js"
 import { NetworkSubsystem } from "./network/NetworkSubsystem.js"
@@ -31,11 +32,13 @@ export class Repo extends DocCollection {
       if (storageSubsystem) {
         // Save when the document changes
         handle.on("heads-changed", async ({ handle, doc }) => {
-          storageSubsystem.save(handle.documentId, doc)
+          storageSubsystem.save(handle.encodedDocumentId, doc)
         })
 
         // Try to load from disk
-        const binary = await storageSubsystem.loadBinary(handle.documentId)
+        const binary = await storageSubsystem.loadBinary(
+          handle.encodedDocumentId
+        )
         handle.load(binary)
       }
 
@@ -50,7 +53,7 @@ export class Repo extends DocCollection {
       // synchronizer.removeDocument(documentId)
 
       if (storageSubsystem) {
-        storageSubsystem.remove(documentId)
+        storageSubsystem.remove(encodeDocumentId(documentId))
       }
     })
 

--- a/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
@@ -37,7 +37,7 @@ export function runAdapterTests(_setup: SetupFn, title?: string): void {
 
         // Bob receives the document
         await eventPromise(bobRepo, "document")
-        const bobHandle = bobRepo.find<TestDoc>(aliceHandle.documentId)
+        const bobHandle = bobRepo.find<TestDoc>(aliceHandle.url)
 
         // Alice changes the document
         aliceHandle.change(d => {
@@ -83,12 +83,12 @@ export function runAdapterTests(_setup: SetupFn, title?: string): void {
 
       // Alice creates a document
       const aliceHandle = aliceRepo.create<TestDoc>()
-      const documentId = aliceHandle.documentId
+      const docUrl = aliceHandle.url
 
       // Bob and Charlie receive the document
       await eventPromises([bobRepo, charlieRepo], "document")
-      const bobHandle = bobRepo.find<TestDoc>(documentId)
-      const charlieHandle = charlieRepo.find<TestDoc>(documentId)
+      const bobHandle = bobRepo.find<TestDoc>(docUrl)
+      const charlieHandle = charlieRepo.find<TestDoc>(docUrl)
 
       // Alice changes the document
       aliceHandle.change(d => {

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -17,6 +17,6 @@ export { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js
 export {
   parseAutomergeUrl,
   isValidAutomergeUrl,
-  generateAutomergeUrl,
+  stringifyAutomergeUrl as generateAutomergeUrl,
 } from "./DocUrl"
 export * from "./types.js"

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -14,4 +14,9 @@ export { Repo, type SharePolicy } from "./Repo.js"
 export { StorageAdapter } from "./storage/StorageAdapter.js"
 export { StorageSubsystem } from "./storage/StorageSubsystem.js"
 export { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js"
+export {
+  parseAutomergeUrl,
+  isValidAutomergeUrl,
+  generateAutomergeUrl,
+} from "./DocUrl"
 export * from "./types.js"

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -1,6 +1,6 @@
 import { DocCollection } from "../DocCollection.js"
 import { DocHandle } from "../DocHandle.js"
-import { decode, encode } from "../DocUrl.js"
+import { decode, encode, generateAutomergeUrl } from "../DocUrl.js"
 import { ChannelId, DocumentId, PeerId, StringDocumentId } from "../types.js"
 import { DocSynchronizer } from "./DocSynchronizer.js"
 import { Synchronizer } from "./Synchronizer.js"
@@ -24,7 +24,7 @@ export class CollectionSynchronizer extends Synchronizer {
   #fetchDocSynchronizer(documentId: DocumentId) {
     const stringDocumentId = encode(documentId)
     if (!this.#docSynchronizers[stringDocumentId]) {
-      const handle = this.repo.find(documentId)
+      const handle = this.repo.find(generateAutomergeUrl({ documentId }))
       this.#docSynchronizers[stringDocumentId] =
         this.#initDocSynchronizer(handle)
     }

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -24,7 +24,7 @@ export class DocSynchronizer extends Synchronizer {
 
   constructor(private handle: DocHandle<any>) {
     super()
-    const docId = handle.stringDocumentId.slice(0, 5)
+    const docId = handle.encodedDocumentId.slice(0, 5)
     this.#conciseLog = debug(`automerge-repo:concise:docsync:${docId}`) // Only logs one line per receive/send
     this.#log = debug(`automerge-repo:docsync:${docId}`)
     this.#opsLog = debug(`automerge-repo:ops:docsync:${docId}`) // Log list of ops of each message
@@ -77,7 +77,7 @@ export class DocSynchronizer extends Synchronizer {
     if (message) {
       this.#logMessage(`sendSyncMessage 🡒 ${peerId}`, message)
 
-      const channelId = this.handle.stringDocumentId as string as ChannelId
+      const channelId = this.handle.encodedDocumentId as string as ChannelId
 
       this.emit("message", {
         targetId: peerId,
@@ -144,7 +144,7 @@ export class DocSynchronizer extends Synchronizer {
     channelId: ChannelId,
     message: Uint8Array
   ) {
-    if ((channelId as string) !== (this.handle.stringDocumentId as string))
+    if ((channelId as string) !== (this.handle.encodedDocumentId as string))
       throw new Error(`channelId doesn't match documentId`)
 
     // We need to block receiving the syncMessages until we've checked local storage

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -24,7 +24,7 @@ export class DocSynchronizer extends Synchronizer {
 
   constructor(private handle: DocHandle<any>) {
     super()
-    const docId = handle.documentId.slice(0, 5)
+    const docId = handle.stringDocumentId.slice(0, 5)
     this.#conciseLog = debug(`automerge-repo:concise:docsync:${docId}`) // Only logs one line per receive/send
     this.#log = debug(`automerge-repo:docsync:${docId}`)
     this.#opsLog = debug(`automerge-repo:ops:docsync:${docId}`) // Log list of ops of each message
@@ -77,7 +77,8 @@ export class DocSynchronizer extends Synchronizer {
     if (message) {
       this.#logMessage(`sendSyncMessage 🡒 ${peerId}`, message)
 
-      const channelId = this.handle.documentId as string as ChannelId
+      const channelId = this.handle.stringDocumentId as string as ChannelId
+
       this.emit("message", {
         targetId: peerId,
         channelId,
@@ -143,7 +144,7 @@ export class DocSynchronizer extends Synchronizer {
     channelId: ChannelId,
     message: Uint8Array
   ) {
-    if ((channelId as string) !== (this.documentId as string))
+    if ((channelId as string) !== (this.handle.stringDocumentId as string))
       throw new Error(`channelId doesn't match documentId`)
 
     // We need to block receiving the syncMessages until we've checked local storage

--- a/packages/automerge-repo/src/types.ts
+++ b/packages/automerge-repo/src/types.ts
@@ -1,6 +1,6 @@
-export type StringDocumentId = string & { __documentId: true } // for logging
+export type EncodedDocumentId = string & { __encodedDocumentId: true } // for logging
 export type AutomergeUrl = string & { __documentUrl: true } // for opening / linking
-export type DocumentId = Uint8Array & { __binaryDocumentId: true } // for storing / syncing
+export type DocumentId = Uint8Array & { __documentId: true } // for storing / syncing
 
 export type PeerId = string & { __peerId: false }
 export type ChannelId = string & { __channelId: false }

--- a/packages/automerge-repo/src/types.ts
+++ b/packages/automerge-repo/src/types.ts
@@ -1,5 +1,5 @@
 export type StringDocumentId = string & { __documentId: true } // for logging
-export type DocumentUrl = string & { __documentUrl: true } // for opening / linking
+export type AutomergeUrl = string & { __documentUrl: true } // for opening / linking
 export type DocumentId = Uint8Array & { __binaryDocumentId: true } // for storing / syncing
 
 export type PeerId = string & { __peerId: false }

--- a/packages/automerge-repo/src/types.ts
+++ b/packages/automerge-repo/src/types.ts
@@ -1,4 +1,6 @@
-export type StringDocumentId = string & { __documentId: true }
-export type DocumentId = Uint8Array & { __binaryDocumentId: true }
+export type StringDocumentId = string & { __documentId: true } // for logging
+export type DocumentUrl = string & { __documentUrl: true } // for opening / linking
+export type DocumentId = Uint8Array & { __binaryDocumentId: true } // for storing / syncing
+
 export type PeerId = string & { __peerId: false }
 export type ChannelId = string & { __channelId: false }

--- a/packages/automerge-repo/src/types.ts
+++ b/packages/automerge-repo/src/types.ts
@@ -1,3 +1,4 @@
-export type DocumentId = string & { __documentId: true }
+export type StringDocumentId = string & { __documentId: true }
+export type DocumentId = Uint8Array & { __binaryDocumentId: true }
 export type PeerId = string & { __peerId: false }
 export type ChannelId = string & { __channelId: false }

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -23,7 +23,9 @@ describe("CollectionSynchronizer", () => {
 
     synchronizer.once("message", (event: MessagePayload) => {
       assert(event.targetId === "peer1")
-      assert(event.channelId === (handle.documentId as unknown as ChannelId))
+      assert(
+        event.channelId === (handle.stringDocumentId as unknown as ChannelId)
+      )
       done()
     })
 
@@ -35,7 +37,9 @@ describe("CollectionSynchronizer", () => {
     synchronizer.addDocument(handle.documentId)
     synchronizer.once("message", (event: MessagePayload) => {
       assert(event.targetId === "peer1")
-      assert(event.channelId === (handle.documentId as unknown as ChannelId))
+      assert(
+        event.channelId === (handle.stringDocumentId as unknown as ChannelId)
+      )
       done()
     })
     synchronizer.addPeer("peer1" as PeerId)

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -24,7 +24,7 @@ describe("CollectionSynchronizer", () => {
     synchronizer.once("message", (event: MessagePayload) => {
       assert(event.targetId === "peer1")
       assert(
-        event.channelId === (handle.stringDocumentId as unknown as ChannelId)
+        event.channelId === (handle.encodedDocumentId as unknown as ChannelId)
       )
       done()
     })
@@ -38,7 +38,7 @@ describe("CollectionSynchronizer", () => {
     synchronizer.once("message", (event: MessagePayload) => {
       assert(event.targetId === "peer1")
       assert(
-        event.channelId === (handle.stringDocumentId as unknown as ChannelId)
+        event.channelId === (handle.encodedDocumentId as unknown as ChannelId)
       )
       done()
     })

--- a/packages/automerge-repo/test/DocCollection.test.ts
+++ b/packages/automerge-repo/test/DocCollection.test.ts
@@ -1,8 +1,9 @@
 import assert from "assert"
 import { DocCollection, DocumentId } from "../src"
 import { TestDoc } from "./types.js"
+import { generate } from "../src/DocUrl"
 
-const MISSING_DOCID = "non-existent-docID" as DocumentId
+const MISSING_DOCID = generate()
 
 describe("DocCollection", () => {
   it("can create documents which are ready to go", async () => {

--- a/packages/automerge-repo/test/DocCollection.test.ts
+++ b/packages/automerge-repo/test/DocCollection.test.ts
@@ -1,9 +1,9 @@
 import assert from "assert"
 import { DocCollection, DocumentId } from "../src"
 import { TestDoc } from "./types.js"
-import { generate, generateAutomergeUrl } from "../src/DocUrl"
+import { generate, stringifyAutomergeUrl } from "../src/DocUrl"
 
-const MISSING_DOCID = generateAutomergeUrl({ documentId: generate() })
+const MISSING_DOCID = stringifyAutomergeUrl({ documentId: generate() })
 
 describe("DocCollection", () => {
   it("can create documents which are ready to go", async () => {

--- a/packages/automerge-repo/test/DocCollection.test.ts
+++ b/packages/automerge-repo/test/DocCollection.test.ts
@@ -1,9 +1,9 @@
 import assert from "assert"
 import { DocCollection, DocumentId } from "../src"
 import { TestDoc } from "./types.js"
-import { generate } from "../src/DocUrl"
+import { generate, generateAutomergeUrl } from "../src/DocUrl"
 
-const MISSING_DOCID = generate()
+const MISSING_DOCID = generateAutomergeUrl({ documentId: generate() })
 
 describe("DocCollection", () => {
   it("can create documents which are ready to go", async () => {

--- a/packages/automerge-repo/test/DocCollection.test.ts
+++ b/packages/automerge-repo/test/DocCollection.test.ts
@@ -1,9 +1,9 @@
 import assert from "assert"
 import { DocCollection, DocumentId } from "../src"
 import { TestDoc } from "./types.js"
-import { generate, stringifyAutomergeUrl } from "../src/DocUrl"
+import { generateAutomergeUrl, stringifyAutomergeUrl } from "../src/DocUrl"
 
-const MISSING_DOCID = stringifyAutomergeUrl({ documentId: generate() })
+const MISSING_DOCID = generateAutomergeUrl()
 
 describe("DocCollection", () => {
   it("can create documents which are ready to go", async () => {

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -4,11 +4,11 @@ import { it } from "mocha"
 import { DocHandle, DocHandleChangePayload, DocumentId } from "../src"
 import { pause } from "../src/helpers/pause"
 import { TestDoc } from "./types.js"
-import { generate } from "../src/DocUrl"
+import { generateAutomergeUrl, parseAutomergeUrl } from "../src/DocUrl"
 
 describe("DocHandle", () => {
-  const TEST_ID = generate()
-  const BOGUS_ID = generate()
+  const TEST_ID = parseAutomergeUrl(generateAutomergeUrl()).documentId
+  const BOGUS_ID = parseAutomergeUrl(generateAutomergeUrl()).documentId
 
   const binaryFromMockStorage = () => {
     const doc = A.change<{ foo: string }>(A.init(), d => (d.foo = "bar"))

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -4,10 +4,11 @@ import { it } from "mocha"
 import { DocHandle, DocHandleChangePayload, DocumentId } from "../src"
 import { pause } from "../src/helpers/pause"
 import { TestDoc } from "./types.js"
+import { generate } from "../src/DocUrl"
 
 describe("DocHandle", () => {
-  const TEST_ID = "test-document-id" as DocumentId
-  const BOGUS_ID = "AN INVALID ID" as DocumentId
+  const TEST_ID = generate()
+  const BOGUS_ID = generate()
 
   const binaryFromMockStorage = () => {
     const doc = A.change<{ foo: string }>(A.init(), d => (d.foo = "bar"))

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -90,7 +90,7 @@ describe("DocHandle", () => {
 
     assert.equal(handle.docSync(), undefined)
     assert.equal(handle.isReady(), false)
-    assert.throws(() => handle.change(h => {}))
+    assert.throws(() => handle.change(h => { }))
   })
 
   it("should become ready if the document is updated by the network", async () => {
@@ -209,15 +209,6 @@ describe("DocHandle", () => {
       // do nothing
       setTimeout(done, 0)
     })
-  })
-
-  it.skip("should fail if the documentId is invalid", async () => {
-    // set docHandle time out after 5 ms
-    const handle = new DocHandle<TestDoc>(BOGUS_ID)
-    assert.equal(handle.state, "failed")
-
-    // so it should time out
-    return assert.rejects(handle.doc, "DocHandle timed out")
   })
 
   it("should time out if the document is not loaded", async () => {

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -4,7 +4,7 @@ import { DocHandle } from "../src/DocHandle.js"
 import { DocSynchronizer } from "../src/synchronizer/DocSynchronizer.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { TestDoc } from "./types.js"
-import { generate } from "../src/DocUrl.js"
+import { parseAutomergeUrl, generateAutomergeUrl } from "../src/DocUrl.js"
 
 const alice = "alice" as PeerId
 const bob = "bob" as PeerId
@@ -14,7 +14,7 @@ describe("DocSynchronizer", () => {
   let docSynchronizer: DocSynchronizer
 
   const setup = () => {
-    const docId = generate()
+    const docId = parseAutomergeUrl(generateAutomergeUrl()).documentId
     handle = new DocHandle<TestDoc>(docId, { isNew: true })
     docSynchronizer = new DocSynchronizer(handle)
     return { handle, docSynchronizer }

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -4,6 +4,7 @@ import { DocHandle } from "../src/DocHandle.js"
 import { DocSynchronizer } from "../src/synchronizer/DocSynchronizer.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { TestDoc } from "./types.js"
+import { generate } from "../src/DocUrl.js"
 
 const alice = "alice" as PeerId
 const bob = "bob" as PeerId
@@ -13,7 +14,7 @@ describe("DocSynchronizer", () => {
   let docSynchronizer: DocSynchronizer
 
   const setup = () => {
-    const docId = "synced-doc" as DocumentId
+    const docId = generate()
     handle = new DocHandle<TestDoc>(docId, { isNew: true })
     docSynchronizer = new DocSynchronizer(handle)
     return { handle, docSynchronizer }

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1,7 +1,14 @@
 import assert from "assert"
 import { MessageChannelNetworkAdapter } from "@automerge/automerge-repo-network-messagechannel"
 
-import { ChannelId, DocHandle, DocumentId, PeerId, SharePolicy } from "../src"
+import {
+  AutomergeUrl,
+  ChannelId,
+  DocHandle,
+  DocumentId,
+  PeerId,
+  SharePolicy,
+} from "../src"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause, rejectOnTimeout } from "../src/helpers/pause.js"
 import { Repo } from "../src/Repo.js"
@@ -50,6 +57,15 @@ describe("Repo", () => {
       assert.equal(handle.isReady(), true)
 
       assert.equal(v.foo, "bar")
+    })
+
+    it("throws an error if we try to find a handle with an invalid AutomergeUrl", async () => {
+      const { repo } = setup()
+      try {
+        repo.find<TestDoc>("invalid-url" as unknown as AutomergeUrl)
+      } catch (e: any) {
+        assert.equal(e.message, "Invalid AutomergeUrl: 'invalid-url'")
+      }
     })
 
     it("doesn't find a document that doesn't exist", async () => {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -133,8 +133,8 @@ describe("Repo", () => {
       })
       assert.equal(handle.isReady(), true)
 
-      repo.on("delete-document", ({ documentId }) => {
-        assert.equal(documentId, handle.documentId)
+      repo.on("delete-document", ({ encodedDocumentId }) => {
+        assert.equal(encodedDocumentId, handle.encodedDocumentId)
 
         done()
       })

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -9,6 +9,7 @@ import { DummyNetworkAdapter } from "./helpers/DummyNetworkAdapter.js"
 import { DummyStorageAdapter } from "./helpers/DummyStorageAdapter.js"
 import { getRandomItem } from "./helpers/getRandomItem.js"
 import { TestDoc } from "./types.js"
+import { encode, generate } from "../src/DocUrl"
 
 describe("Repo", () => {
   describe("single repo", () => {
@@ -49,7 +50,7 @@ describe("Repo", () => {
 
     it("doesn't find a document that doesn't exist", async () => {
       const { repo } = setup()
-      const handle = repo.find<TestDoc>("does-not-exist" as DocumentId)
+      const handle = repo.find<TestDoc>(generate())
       assert.equal(handle.isReady(), false)
 
       return assert.rejects(
@@ -109,7 +110,7 @@ describe("Repo", () => {
       repo.delete(handle.documentId)
 
       assert(handle.isDeleted())
-      assert.equal(repo.handles[handle.documentId], undefined)
+      assert.equal(repo.handles[encode(handle.documentId)], undefined)
 
       const bobHandle = repo.find<TestDoc>(handle.documentId)
       await assert.rejects(
@@ -258,9 +259,21 @@ describe("Repo", () => {
         eventPromise(charlieRepo.networkSubsystem, "message"),
       ])
 
-      assert.notEqual(aliceRepo.handles[notForCharlie], undefined, "alice yes")
-      assert.notEqual(bobRepo.handles[notForCharlie], undefined, "bob yes")
-      assert.equal(charlieRepo.handles[notForCharlie], undefined, "charlie no")
+      assert.notEqual(
+        aliceRepo.handles[encode(notForCharlie)],
+        undefined,
+        "alice yes"
+      )
+      assert.notEqual(
+        bobRepo.handles[encode(notForCharlie)],
+        undefined,
+        "bob yes"
+      )
+      assert.equal(
+        charlieRepo.handles[encode(notForCharlie)],
+        undefined,
+        "charlie no"
+      )
 
       teardown()
     })
@@ -288,7 +301,7 @@ describe("Repo", () => {
 
     it("doesn't find a document which doesn't exist anywhere on the network", async () => {
       const { charlieRepo } = await setup()
-      const handle = charlieRepo.find<TestDoc>("does-not-exist" as DocumentId)
+      const handle = charlieRepo.find<TestDoc>(generate())
       assert.equal(handle.isReady(), false)
 
       return assert.rejects(

--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -11,6 +11,7 @@ import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs"
 
 import { DocumentId, StorageSubsystem } from "../src"
 import { TestDoc } from "./types.js"
+import { generate } from "../src/DocUrl.js"
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "automerge-repo-tests"))
 
@@ -30,7 +31,7 @@ describe("StorageSubsystem", () => {
         })
 
         // save it to storage
-        const key = "test-key" as DocumentId
+        const key = generate()
         storage.save(key, doc)
 
         // reload it from storage
@@ -51,7 +52,7 @@ describe("StorageSubsystem", () => {
     })
 
     // save it to storage
-    const key = "test-key" as DocumentId
+    const key = generate()
     storage.save(key, doc)
 
     // create new storage subsystem to simulate a new process
@@ -72,7 +73,7 @@ describe("StorageSubsystem", () => {
     assert(adapter.keys().some(k => k.endsWith("1")))
 
     // check that the last incrementalSave is not a full save
-    const bin = await adapter.load((key + ".incremental.1") as DocumentId)
+    const bin = await adapter.load(key + ".incremental.1")
     assert.throws(() => A.load(bin!))
   })
 })

--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -11,7 +11,7 @@ import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs"
 
 import { DocumentId, StorageSubsystem } from "../src"
 import { TestDoc } from "./types.js"
-import { generate } from "../src/DocUrl.js"
+import { generateAutomergeUrl, parseAutomergeUrl } from "../src/DocUrl.js"
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "automerge-repo-tests"))
 
@@ -31,7 +31,7 @@ describe("StorageSubsystem", () => {
         })
 
         // save it to storage
-        const key = generate()
+        const key = parseAutomergeUrl(generateAutomergeUrl()).encodedDocumentId
         storage.save(key, doc)
 
         // reload it from storage
@@ -52,7 +52,7 @@ describe("StorageSubsystem", () => {
     })
 
     // save it to storage
-    const key = generate()
+    const key = parseAutomergeUrl(generateAutomergeUrl()).encodedDocumentId
     storage.save(key, doc)
 
     // create new storage subsystem to simulate a new process

--- a/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
@@ -1,19 +1,19 @@
-import { DocumentId, StorageAdapter } from "../../src"
+import { StorageAdapter } from "../../src"
 
 export class DummyStorageAdapter implements StorageAdapter {
-  #data: Record<DocumentId, Uint8Array> = {}
+  #data: Record<string, Uint8Array> = {}
 
-  load(docId: DocumentId) {
+  load(docId: string) {
     return new Promise<Uint8Array | null>(resolve =>
       resolve(this.#data[docId] || null)
     )
   }
 
-  save(docId: DocumentId, binary: Uint8Array) {
+  save(docId: string, binary: Uint8Array) {
     this.#data[docId] = binary
   }
 
-  remove(docId: DocumentId) {
+  remove(docId: string) {
     delete this.#data[docId]
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -938,6 +938,11 @@
     write-pkg "4.0.0"
     yargs "16.2.0"
 
+"@noble/hashes@^1.2.0":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
+  integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -2167,6 +2172,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-x@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
+  integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -2254,6 +2264,21 @@ browserslist@^4.21.9:
     electron-to-chromium "^1.4.477"
     node-releases "^2.0.13"
     update-browserslist-db "^1.0.11"
+
+bs58@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
+  integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==
+  dependencies:
+    base-x "^4.0.0"
+
+bs58check@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-3.0.1.tgz#2094d13720a28593de1cba1d8c4e48602fdd841c"
+  integrity sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==
+  dependencies:
+    "@noble/hashes" "^1.2.0"
+    bs58 "^5.0.0"
 
 buffer-crc32@^0.2.5:
   version "0.2.13"


### PR DESCRIPTION
Here we have it -- the first draft of Automerge URLs. Most of the patch is working towards making the guts of Automerge-Repo use binary byte arrays internally. It's not "worked through" in the sense that we still have a bit of a hodgepodge of string keys for objects and byte arrays being encoded and decoded all over. But it's progress!

Key changes: `find<T>(automergeUrl: AutomergeUrl)` and `handle.url`.  Are there other places we want to expose or accept URLs at the moment? .changeAt could take a URL-with-heads for example.