### PR TITLE
Fix CI tests for automerge-repo-react-hooks

### DIFF
--- a/packages/automerge-repo-react-hooks/package.json
+++ b/packages/automerge-repo-react-hooks/package.json
@@ -10,7 +10,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test-browser": "vitest",
+    "test": "vitest run",
     "watch": "npm-watch"
   },
   "dependencies": {


### PR DESCRIPTION
This PR fixes the test command for react-hooks, and adds it to the automated tests for the monorepo CI.

It "works fine on my machine", but I don't think I have perms to run jobs or check the output of Github actions, to confirm it actually works.