### PR TITLE
Make storage concurrent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{ts,js}]
+indent_style = space
+indent_size = 2

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+export default {
+    "workingDirectories": ["./packages/*"]
+}

--- a/examples/automerge-repo-demo-counter/src/main.tsx
+++ b/examples/automerge-repo-demo-counter/src/main.tsx
@@ -40,7 +40,7 @@ function createSharedWorker(): Promise<SharedWorker> {
   })
 }
 
-function setupSharedWorkerAndRepo() {
+function setupSharedWorkerAndRepo(): Repo {
   const repoNetworkChannel = new MessageChannel()
   sharedWorker.port.postMessage({ repoNetworkPort: repoNetworkChannel.port2 }, [
     repoNetworkChannel.port2,

--- a/packages/automerge-repo-storage-nodefs/package.json
+++ b/packages/automerge-repo-storage-nodefs/package.json
@@ -13,7 +13,8 @@
     "watch": "npm-watch"
   },
   "dependencies": {
-    "@automerge/automerge-repo": "^0.2.1"
+    "@automerge/automerge-repo": "^0.2.1",
+    "rimraf": "^5.0.1"
   },
   "watch": {
     "build": {

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -271,7 +271,7 @@ export class DocHandle<T> //
 
   /** `load` is called by the repo when the document is found in storage */
   load(binary: Uint8Array) {
-    if (binary.length) {
+    if (binary.length && binary.length > 0) {
       this.#machine.send(LOAD, { payload: { binary } })
     }
   }

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -33,12 +33,12 @@ export class Repo extends DocCollection {
       if (storageSubsystem) {
         // Save when the document changes
         handle.on("heads-changed", async ({ handle, doc }) => {
-          storageSubsystem.save(handle.documentId, doc)
+          await storageSubsystem.save(handle.documentId, doc)
         })
 
         // Try to load from disk
-        const binary = await storageSubsystem.loadBinary(handle.documentId)
-        handle.load(binary)
+        const data = await storageSubsystem.loadBinary(handle.documentId)
+        handle.load(data)
       }
 
       handle.request()

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -11,7 +11,7 @@ export type {
 } from "./network/NetworkAdapter.js"
 export { NetworkSubsystem } from "./network/NetworkSubsystem.js"
 export { Repo, type SharePolicy } from "./Repo.js"
-export { StorageAdapter } from "./storage/StorageAdapter.js"
+export { StorageAdapter, type StorageKey } from "./storage/StorageAdapter.js"
 export { StorageSubsystem } from "./storage/StorageSubsystem.js"
 export { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js"
 export * from "./types.js"

--- a/packages/automerge-repo/src/storage/StorageAdapter.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapter.ts
@@ -4,15 +4,17 @@ export abstract class StorageAdapter {
   // [documentId, "snapshot"] or [documentId, "incremental", "0"]
   // but the storage adapter is agnostic to the meaning of the key
   // and we expect to store other data in the future such as syncstates
-  abstract load(key: string[]): Promise<Uint8Array | undefined>
-  abstract save(key: string[], data: Uint8Array): Promise<void>
-  abstract remove(key: string[]): Promise<void>
+  abstract load(key: StorageKey): Promise<Uint8Array | undefined>
+  abstract save(key: StorageKey, data: Uint8Array): Promise<void>
+  abstract remove(key: StorageKey): Promise<void>
 
   // the keyprefix will match any key that starts with the given array
   // for example, [documentId, "incremental"] will match all incremental saves
   // or [documentId] will match all data for a given document
   // be careful! this will also match [documentId, "syncState"]!
   // (we aren't using this yet but keep it in mind.)
-  abstract loadRange(keyPrefix: string[]): Promise<Uint8Array[]>
-  abstract removeRange(keyPrefix: string[]): Promise<void>
+  abstract loadRange(keyPrefix: StorageKey): Promise<{key: StorageKey, data: Uint8Array}[]>
+  abstract removeRange(keyPrefix: StorageKey): Promise<void>
 }
+
+export type  StorageKey = string[]

--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -34,7 +34,8 @@ describe("StorageSubsystem", () => {
         await storage.save(key, doc)
 
         // reload it from storage
-        const reloadedDoc = await storage.load<TestDoc>(key)
+        const reloadedDocBinary = await storage.loadBinary(key)
+        const reloadedDoc = A.load<TestDoc>(reloadedDocBinary)
 
         // check that it's the same doc
         assert.deepStrictEqual(reloadedDoc, doc)
@@ -58,10 +59,11 @@ describe("StorageSubsystem", () => {
     const storage2 = new StorageSubsystem(adapter)
 
     // reload it from storage
-    const reloadedDoc = await storage2.load<TestDoc>(key)
+    const reloadedDocBinary = await storage2.loadBinary(key)
+    const reloadedDoc = A.load<TestDoc>(reloadedDocBinary)
 
     // make a change
-    const changedDoc = A.change(reloadedDoc, "test 2", d => {
+    const changedDoc = A.change<any>(reloadedDoc, "test 2", d => {
       d.foo = "baz"
     })
 

--- a/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
@@ -1,16 +1,20 @@
-import { StorageAdapter } from "../../src"
+import { StorageAdapter, type StorageKey } from "../../src"
 
 export class DummyStorageAdapter implements StorageAdapter {
   #data: Record<string, Uint8Array> = {}
 
-  #keyToString(key: string[]) {
+  #keyToString(key: string[]): string {
     return key.join(".")
   }
 
-  async loadRange(keyPrefix: string[]): Promise<Uint8Array[]> {
+  #stringToKey(key: string): string[] {
+    return key.split(".")
+  }
+
+  async loadRange(keyPrefix: StorageKey): Promise<{data: Uint8Array, key: StorageKey}[]> {
     const range = Object.entries(this.#data)
       .filter(([key, _]) => key.startsWith(this.#keyToString(keyPrefix)))
-      .map(([_, value]) => value)
+      .map(([key, data]) => ({key: this.#stringToKey(key), data}))
     return Promise.resolve(range)
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4133,6 +4133,17 @@ glob@^10.2.2:
     minipass "^5.0.0 || ^6.0.2"
     path-scurry "^1.7.0"
 
+glob@^10.2.5:
+  version "10.3.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.3.tgz#8360a4ffdd6ed90df84aa8d52f21f452e86a123b"
+  integrity sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^2.0.3"
+    minimatch "^9.0.1"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+    path-scurry "^1.10.1"
+
 glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -5280,6 +5291,11 @@ lru-cache@^9.1.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-9.1.2.tgz#255fdbc14b75589d6d0e73644ca167a8db506835"
   integrity sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==
 
+"lru-cache@^9.1.1 || ^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.0.tgz#b9e2a6a72a129d81ab317202d93c7691df727e61"
+  integrity sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==
+
 lz-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
@@ -5600,6 +5616,11 @@ minipass@^5.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-6.0.2.tgz#542844b6c4ce95b202c0995b0a471f1229de4c81"
   integrity sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.2.tgz#58a82b7d81c7010da5bd4b2c0c85ac4b4ec5131e"
+  integrity sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==
 
 minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
@@ -6474,6 +6495,14 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-scurry@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.10.1.tgz#9ba6bf5aa8500fe9fd67df4f0d9483b2b0bfc698"
+  integrity sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==
+  dependencies:
+    lru-cache "^9.1.1 || ^10.0.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
 path-scurry@^1.6.1, path-scurry@^1.7.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.9.2.tgz#90f9d296ac5e37e608028e28a447b11d385b3f63"
@@ -7077,6 +7106,13 @@ rimraf@^4.4.1:
   integrity sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==
   dependencies:
     glob "^9.2.0"
+
+rimraf@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.1.tgz#0881323ab94ad45fec7c0221f27ea1a142f3f0d0"
+  integrity sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==
+  dependencies:
+    glob "^10.2.5"
 
 rollup@^2.79.1:
   version "2.79.1"


### PR DESCRIPTION
Track the keys used to load or append to a DocHandle and then use this information to only remove keys which were used in the doc we just compacted.