### PR TITLE
websockets: Add protocol negotiations

### DIFF
--- a/packages/automerge-repo-network-websocket/src/message.ts
+++ b/packages/automerge-repo-network-websocket/src/message.ts
@@ -1,0 +1,10 @@
+import {type InboundMessagePayload} from "@automerge/automerge-repo"
+import {ProtocolVersion} from "./protocolVersion"
+
+export interface InboundWebSocketMessage extends InboundMessagePayload {
+  supportedProtocolVersions?: ProtocolVersion[]
+}
+
+export interface OutboundWebSocketMessage extends InboundMessagePayload {
+  errorMessage?: string
+}

--- a/packages/automerge-repo-network-websocket/src/protocolVersion.ts
+++ b/packages/automerge-repo-network-websocket/src/protocolVersion.ts
@@ -1,0 +1,2 @@
+export const ProtocolV1 = "1"
+export type ProtocolVersion = typeof ProtocolV1

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -2,6 +2,11 @@ import { runAdapterTests } from "../../automerge-repo/src/helpers/tests/network-
 import { BrowserWebSocketClientAdapter } from "../src/BrowserWebSocketClientAdapter"
 import { NodeWSServerAdapter } from "../src/NodeWSServerAdapter"
 import { startServer } from "./utilities/WebSockets"
+import * as CBOR from "cbor-x"
+import WebSocket, {AddressInfo}  from "ws"
+import { assert } from "chai"
+import {ChannelId, PeerId, Repo} from "@automerge/automerge-repo"
+import { once } from "events"
 
 describe("Websocket adapters", async () => {
   let port = 8080
@@ -23,3 +28,97 @@ describe("Websocket adapters", async () => {
     return { adapters: [serverAdapter, aliceAdapter, bobAdapter], teardown }
   })
 })
+
+describe("The BrowserWebSocketClientAdapter", () => {
+  it("should advertise the protocol versions it supports in its join message", async () => {
+    const  { socket, server } = await startServer(0)
+    let port = (server.address()!! as AddressInfo).port
+    const serverUrl = `ws://localhost:${port}`
+    const helloPromise = firstMessage(socket)
+
+    const client = new BrowserWebSocketClientAdapter(serverUrl)
+    const repo = new Repo({network: [client], peerId: "browser" as PeerId})
+
+    const hello = await helloPromise
+
+    const message = CBOR.decode(hello as Uint8Array)
+    assert.deepEqual(message, {
+      type: "join",
+      senderId: "browser",
+      supportedProtocolVersions: ["1"]
+    }) 
+  })
+})
+
+describe("The NodeWSServerAdapter", () => {
+  it("should send the negotiated protocol version in its hello message", async () => {
+    const response = await serverHelloGivenClientHello({
+      type: "join",
+      senderId: "browser",
+      supportedProtocolVersions: ["1"]
+    })
+    assert.deepEqual<any>(response, {
+      type: "peer",
+      senderId: "server",
+      selectedProtocolVersion: "1"
+    })
+  })
+
+  it("should return an error message if the protocol version is not supported", async () => {
+    const response = await serverHelloGivenClientHello({
+      type: "join",
+      senderId: "browser",
+      supportedProtocolVersions: ["fake"]
+    })
+    assert.deepEqual<any>(response, {
+      type: "error",
+      errorMessage: "unsupported protocol version",
+    })
+  })
+
+  it("should respond with protocol v1 if no protocol version is specified", async () => {
+    const response = await serverHelloGivenClientHello({
+      type: "join",
+      senderId: "browser",
+    })
+    assert.deepEqual<any>(response, {
+      type: "peer",
+      senderId: "server",
+      selectedProtocolVersion: "1"
+    })
+  })
+})
+
+async function serverHelloGivenClientHello(clientHello: Object): Promise<Object | null> {
+  const  { socket, server } = await startServer(0)
+  let port = (server.address()!! as AddressInfo).port
+  const serverUrl = `ws://localhost:${port}`
+  const adapter = new NodeWSServerAdapter(socket)
+  const repo = new Repo({network: [adapter], peerId: "server" as PeerId})
+
+  const clientSocket = new WebSocket(serverUrl)
+  await once(clientSocket, "open")
+  const serverHelloPromise = once(clientSocket, "message")
+
+  clientSocket.send(CBOR.encode(clientHello))
+
+  const serverHello = await serverHelloPromise
+  const message = CBOR.decode(serverHello[0] as Uint8Array)
+  return message
+}
+
+async function firstMessage(socket: WebSocket.Server<any>): Promise<Object | null> {
+  return new Promise((resolve, reject) => {
+    socket.once("connection", (ws) => {
+      ws.once("message", (message: any) => {
+        resolve(message)
+      })
+      ws.once("error", (error: any) => {
+        reject(error)
+      })
+    })
+    socket.once("error", (error) => {
+      reject(error)
+    })
+  })
+}


### PR DESCRIPTION
This works by including a `supportedProtocolVersions` field in the join message from the client and then the server either returns a `selectedProtocolVersion` in it's `peer` message or returns a new `error` message.

Fixes #127 