### PR TITLE
Remove `ChannelId` from the initial NetworkSubsystem join call

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -21,10 +21,10 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
             targetId: senderId,
             type: "welcome",
           })
-          this.#announceConnection(channelId, senderId)
+          this.#announceConnection(senderId)
           break
         case "welcome":
-          this.#announceConnection(channelId, senderId)
+          this.#announceConnection(senderId)
           break
         case "message":
           this.emit("message", {
@@ -41,8 +41,8 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
     })
   }
 
-  #announceConnection(channelId: ChannelId, peerId: PeerId) {
-    this.emit("peer-candidate", { peerId, channelId })
+  #announceConnection(peerId: PeerId) {
+    this.emit("peer-candidate", { peerId })
   }
 
   sendMessage(
@@ -65,19 +65,16 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
     })
   }
 
-  join(joinChannelId: ChannelId) {
+  join() {
     this.#broadcastChannel.postMessage({
       senderId: this.peerId,
-      channelId: joinChannelId,
       type: "arrive",
       broadcast: true,
     })
   }
 
-  leave(channelId: ChannelId) {
+  leave() {
     // TODO
-    throw new Error(
-      "Unimplemented: leave on BroadcastChannelNetworkAdapter: " + channelId
-    )
+    throw new Error("Unimplemented: leave on BroadcastChannelNetworkAdapter")
   }
 }

--- a/packages/automerge-repo-network-messagechannel/src/index.ts
+++ b/packages/automerge-repo-network-messagechannel/src/index.ts
@@ -43,10 +43,10 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
             destination: origin,
             type: "welcome",
           })
-          this.announceConnection(channelId, origin)
+          this.announceConnection(origin)
           break
         case "welcome":
-          this.announceConnection(channelId, origin)
+          this.announceConnection(origin)
           break
         case "message":
           this.emit("message", {
@@ -90,23 +90,20 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
     )
   }
 
-  announceConnection(channelId: ChannelId, peerId: PeerId) {
-    this.emit("peer-candidate", { peerId, channelId })
+  announceConnection(peerId: PeerId) {
+    this.emit("peer-candidate", { peerId })
   }
 
-  join(channelId: string) {
+  join() {
     this.messagePortRef.postMessage({
       origin: this.peerId,
-      channelId,
       type: "arrive",
     })
   }
 
-  leave(docId: string) {
+  leave() {
     // TODO
-    throw new Error(
-      "Unimplemented: leave on MessagePortNetworkAdapter: " + docId
-    )
+    throw new Error("Unimplemented: leave on MessagePortNetworkAdapter")
   }
 }
 

--- a/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
@@ -39,11 +39,11 @@ export class NodeWSServerAdapter extends NetworkAdapter {
     })
   }
 
-  join(docId: ChannelId) {
+  join() {
     // throw new Error("The server doesn't join channels.")
   }
 
-  leave(docId: ChannelId) {
+  leave() {
     // throw new Error("The server doesn't join channels.")
   }
 
@@ -111,14 +111,12 @@ export class NodeWSServerAdapter extends NetworkAdapter {
     switch (type) {
       case "join":
         // Let the rest of the system know that we have a new connection.
-        this.emit("peer-candidate", { peerId: senderId, channelId })
+        this.emit("peer-candidate", { peerId: senderId })
         this.sockets[senderId] = socket
 
         // In this client-server connection, there's only ever one peer: us!
         // (and we pretend to be joined to every channel)
-        socket.send(
-          CBOR.encode({ type: "peer", senderId: this.peerId, channelId })
-        )
+        socket.send(CBOR.encode({ type: "peer", senderId: this.peerId }))
         break
       case "leave":
         // It doesn't seem like this gets called;

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -5,10 +5,9 @@ import { NetworkSubsystem } from "./network/NetworkSubsystem.js"
 import { StorageAdapter } from "./storage/StorageAdapter.js"
 import { StorageSubsystem } from "./storage/StorageSubsystem.js"
 import { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js"
-import { ChannelId, DocumentId, PeerId } from "./types.js"
+import { DocumentId, PeerId } from "./types.js"
 
 import debug from "debug"
-const SYNC_CHANNEL = "sync_channel" as ChannelId
 
 /** A Repo is a DocCollection with networking, syncing, and storage capabilities. */
 export class Repo extends DocCollection {
@@ -110,7 +109,7 @@ export class Repo extends DocCollection {
     })
 
     // We establish a special channel for sync messages
-    networkSubsystem.join(SYNC_CHANNEL)
+    networkSubsystem.join()
 
     // EPHEMERAL DATA
     // The ephemeral data subsystem uses the network to send and receive messages that are not

--- a/packages/automerge-repo/src/network/NetworkAdapter.ts
+++ b/packages/automerge-repo/src/network/NetworkAdapter.ts
@@ -13,9 +13,9 @@ export abstract class NetworkAdapter extends EventEmitter<NetworkAdapterEvents> 
     broadcast: boolean
   ): void
 
-  abstract join(channelId: ChannelId): void
+  abstract join(): void
 
-  abstract leave(channelId: ChannelId): void
+  abstract leave(): void
 }
 
 // events & payloads
@@ -34,7 +34,6 @@ export interface OpenPayload {
 
 export interface PeerCandidatePayload {
   peerId: PeerId
-  channelId: ChannelId
 }
 
 export interface MessagePayload {

--- a/packages/automerge-repo/test/helpers/DummyNetworkAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyNetworkAdapter.ts
@@ -3,6 +3,6 @@ import { NetworkAdapter } from "../../src"
 export class DummyNetworkAdapter extends NetworkAdapter {
   sendMessage() {}
   connect(_: string) {}
-  join(_: string) {}
-  leave(_: string) {}
+  join() {}
+  leave() {}
 }


### PR DESCRIPTION
In its current form, there are no channels to join on any of the network adapters. We simply trigger the network setup using  a `join` command.

This PR keeps all the logic the same, but removes references to the concept of a `sync channel` ChannelId, as it is never referred to again.

Next step would be looking how to scope messages by `DocumentId` instead of `ChannelId` and to address the `ChannelId` used for ephemeral messaging.