### PR TITLE
Messaging system upgrade

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples/automerge-repo-sync-server"]
+	path = examples/automerge-repo-sync-server
+	url = git@github.com:automerge/automerge-repo-sync-server.git

--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -1,10 +1,4 @@
-import {
-  ChannelId,
-  NetworkAdapter,
-  PeerId,
-  Message,
-} from "@automerge/automerge-repo"
-import { isEphemeralMessage } from "@automerge/automerge-repo/dist/network/NetworkAdapter"
+import { Message, NetworkAdapter, PeerId } from "@automerge/automerge-repo"
 
 export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
   #broadcastChannel: BroadcastChannel

--- a/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
@@ -4,12 +4,8 @@ import { WebSocket, type WebSocketServer } from "isomorphic-ws"
 import debug from "debug"
 const log = debug("WebsocketServer")
 
-import {
-  ChannelId,
-  InboundMessagePayload,
-  NetworkAdapter,
-  PeerId,
-} from "@automerge/automerge-repo"
+import { Message, NetworkAdapter, PeerId } from "@automerge/automerge-repo"
+import { FromClientMessage, FromServerMessage } from "./messages"
 
 export class NodeWSServerAdapter extends NetworkAdapter {
   server: WebSocketServer
@@ -47,34 +43,13 @@ export class NodeWSServerAdapter extends NetworkAdapter {
     // throw new Error("The server doesn't join channels.")
   }
 
-  sendMessage(
-    targetId: PeerId,
-    channelId: ChannelId,
-    message: Uint8Array,
-    broadcast: boolean
-  ) {
-    if (message.byteLength === 0) {
-      throw new Error("tried to send a zero-length message")
-    }
-    const senderId = this.peerId
-    if (!senderId) {
-      throw new Error("No peerId set for the websocket server network adapter.")
-    }
+  private transmit(targetId: PeerId, message: FromServerMessage) {
     if (this.sockets[targetId] === undefined) {
       log(`Tried to send message to disconnected peer: ${targetId}`)
       return
     }
 
-    const decoded: InboundMessagePayload = {
-      senderId,
-      targetId,
-      channelId,
-      type: "sync",
-      message,
-      broadcast,
-    }
-    const encoded = CBOR.encode(decoded)
-
+    const encoded = CBOR.encode(message)
     // This incantation deals with websocket sending the whole
     // underlying buffer even if we just have a uint8array view on it
     const arrayBuf = encoded.buffer.slice(
@@ -82,32 +57,35 @@ export class NodeWSServerAdapter extends NetworkAdapter {
       encoded.byteOffset + encoded.byteLength
     )
 
-    log(
-      `[${senderId}->${targetId}@${channelId}] "sync" | ${arrayBuf.byteLength} bytes`
-    )
+    this.sockets[targetId]?.send(arrayBuf)
+  }
 
-    this.sockets[targetId].send(arrayBuf)
+  send(message: Message) {
+    if (message.data.byteLength === 0) {
+      throw new Error("tried to send a zero-length message")
+    }
+    const senderId = this.peerId
+    if (!senderId) {
+      throw new Error("No peerId set for the websocket server network adapter.")
+    }
+
+    if ("targetId" in message) {
+      this.transmit(message.targetId, message)
+    }
   }
 
   receiveMessage(message: Uint8Array, socket: WebSocket) {
-    const cbor: InboundMessagePayload = CBOR.decode(message)
+    const cbor: FromClientMessage = CBOR.decode(message)
 
-    const {
-      type,
-      channelId,
-      senderId,
-      targetId,
-      message: data,
-      broadcast,
-    } = cbor
+    const { type, senderId } = cbor
 
     const myPeerId = this.peerId
     if (!myPeerId) {
       throw new Error("Missing my peer ID.")
     }
-    log(
-      `[${senderId}->${myPeerId}@${channelId}] ${type} | ${message.byteLength} bytes`
-    )
+    // log(
+    //   `[${senderId}->${myPeerId}@${channelId}] ${type} | ${message.byteLength} bytes`
+    // )
     switch (type) {
       case "join":
         // Let the rest of the system know that we have a new connection.
@@ -116,7 +94,7 @@ export class NodeWSServerAdapter extends NetworkAdapter {
 
         // In this client-server connection, there's only ever one peer: us!
         // (and we pretend to be joined to every channel)
-        socket.send(CBOR.encode({ type: "peer", senderId: this.peerId }))
+        this.transmit(senderId, { type: "peer", senderId: this.peerId! })
         break
       case "leave":
         // It doesn't seem like this gets called;
@@ -125,21 +103,8 @@ export class NodeWSServerAdapter extends NetworkAdapter {
         // ?
         break
 
-      // We accept both "message" and "sync" because a previous version of this
-      // codebase sent sync messages in the BrowserWebSocketClientAdapter as
-      // type "message" and we want to stay backwards compatible
-      case "message":
-      case "sync":
-        this.emit("message", {
-          senderId,
-          targetId,
-          channelId,
-          message: new Uint8Array(data),
-          broadcast,
-        })
-        break
       default:
-        log(`unrecognized message type ${type}`)
+        this.emit("message", cbor)
         break
     }
   }

--- a/packages/automerge-repo-network-websocket/src/messages.ts
+++ b/packages/automerge-repo-network-websocket/src/messages.ts
@@ -1,0 +1,20 @@
+import { Message, PeerId } from "@automerge/automerge-repo"
+
+export type LeaveMessage = {
+  type: "leave"
+  senderId: PeerId
+}
+
+export type JoinMessage = {
+  type: "join"
+  senderId: PeerId
+}
+
+export type PeerMessage = {
+  type: "peer"
+  senderId: PeerId
+}
+
+export type FromClientMessage = JoinMessage | LeaveMessage | Message
+
+export type FromServerMessage = PeerMessage | Message

--- a/packages/automerge-repo/src/EphemeralData.ts
+++ b/packages/automerge-repo/src/EphemeralData.ts
@@ -21,7 +21,7 @@ export class EphemeralData extends EventEmitter<EphemeralDataMessageEvents> {
 
     this.emit("message", {
       type: "broadcast",
-      count: this.#count++,
+      count: ++this.#count,
       channelId,
       sessionId: this.#sessionId,
       data: messageBytes,

--- a/packages/automerge-repo/src/EphemeralData.ts
+++ b/packages/automerge-repo/src/EphemeralData.ts
@@ -1,38 +1,47 @@
 import { decode, encode } from "cbor-x"
 import EventEmitter from "eventemitter3"
-import { ChannelId, PeerId } from "./index.js"
-import { MessagePayload } from "./network/NetworkAdapter.js"
+import { ChannelId, NetworkSubsystem, PeerId } from "./index.js"
+import { EphemeralMessage, MessagePayload } from "./network/NetworkAdapter.js"
 
 /**
  * EphemeralData provides a mechanism to broadcast short-lived data — cursor positions, presence,
  * heartbeats, etc. — that is useful in the moment but not worth persisting.
  */
 export class EphemeralData extends EventEmitter<EphemeralDataMessageEvents> {
+  #count = 0
+  #sessionId: SessionId = Math.random().toString(36).slice(2) as SessionId
+
+  get sessionId() {
+    return this.#sessionId
+  }
+
   /** Broadcast an ephemeral message */
   broadcast(channelId: ChannelId, message: unknown) {
     const messageBytes = encode(message)
 
     this.emit("message", {
-      targetId: "*" as PeerId, // TODO: we don't really need a targetId for broadcast
-      channelId: ("m/" + channelId) as ChannelId,
-      message: messageBytes,
-      broadcast: true,
+      type: "broadcast",
+      count: this.#count++,
+      channelId,
+      sessionId: this.#sessionId,
+      data: messageBytes,
     })
   }
 
   /** Receive an ephemeral message */
-  receive(senderId: PeerId, grossChannelId: ChannelId, message: Uint8Array) {
-    const data = decode(message)
-    const channelId = grossChannelId.slice(2) as ChannelId
+  receive(message: EphemeralMessage) {
+    const data = decode(message.data)
     this.emit("data", {
-      peerId: senderId,
-      channelId,
+      peerId: message.senderId,
+      channelId: message.channelId,
       data,
     })
   }
 }
 
 // types
+
+export type SessionId = string & { __SessionId: false }
 
 export interface EphemeralDataPayload {
   channelId: ChannelId
@@ -41,6 +50,6 @@ export interface EphemeralDataPayload {
 }
 
 export type EphemeralDataMessageEvents = {
-  message: (event: MessagePayload) => void
+  message: (event: Omit<EphemeralMessage, "senderId">) => void
   data: (event: EphemeralDataPayload) => void
 }

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -1,11 +1,11 @@
 import { DocCollection } from "./DocCollection.js"
 import { EphemeralData } from "./EphemeralData.js"
-import { NetworkAdapter } from "./network/NetworkAdapter.js"
+import { isEphemeralMessage, NetworkAdapter } from "./network/NetworkAdapter.js"
 import { NetworkSubsystem } from "./network/NetworkSubsystem.js"
 import { StorageAdapter } from "./storage/StorageAdapter.js"
 import { StorageSubsystem } from "./storage/StorageSubsystem.js"
 import { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js"
-import { DocumentId, PeerId } from "./types.js"
+import { ChannelId, DocumentId, PeerId } from "./types.js"
 
 import debug from "debug"
 
@@ -59,13 +59,10 @@ export class Repo extends DocCollection {
     const synchronizer = new CollectionSynchronizer(this)
 
     // When the synchronizer emits sync messages, send them to peers
-    synchronizer.on(
-      "message",
-      ({ targetId, channelId, message, broadcast }) => {
-        this.#log(`sending sync message to ${targetId}`)
-        networkSubsystem.sendMessage(targetId, channelId, message, broadcast)
-      }
-    )
+    synchronizer.on("message", message => {
+      this.#log(`sending sync message to ${message.targetId}`)
+      networkSubsystem.send(message)
+    })
 
     // STORAGE
     // The storage subsystem has access to some form of persistence, and deals with save and loading documents.
@@ -92,19 +89,14 @@ export class Repo extends DocCollection {
 
     // Handle incoming messages
     networkSubsystem.on("message", async msg => {
-      const { senderId, channelId, message } = msg
-
-      // TODO: this demands a more principled way of associating channels with recipients
-
-      // Ephemeral channel ids start with "m/"
-      if (channelId.startsWith("m/")) {
+      if (isEphemeralMessage(msg)) {
         // Ephemeral message
-        this.#log(`receiving ephemeral message from ${senderId}`)
-        ephemeralData.receive(senderId, channelId, message)
+        this.#log(`receiving ephemeral message from ${msg.senderId}`)
+        ephemeralData.receive(msg)
       } else {
         // Sync message
-        this.#log(`receiving sync message from ${senderId}`)
-        await synchronizer.receiveSyncMessage(senderId, channelId, message)
+        this.#log(`receiving sync message from ${msg.senderId}`)
+        await synchronizer.receiveSyncMessage(msg)
       }
     })
 
@@ -119,13 +111,10 @@ export class Repo extends DocCollection {
     this.ephemeralData = ephemeralData
 
     // Send ephemeral messages to peers
-    ephemeralData.on(
-      "message",
-      ({ targetId, channelId, message, broadcast }) => {
-        this.#log(`sending ephemeral message to ${targetId}`)
-        networkSubsystem.sendMessage(targetId, channelId, message, broadcast)
-      }
-    )
+    ephemeralData.on("message", message => {
+      this.#log(`sending ephemeral message`)
+      networkSubsystem.send(message)
+    })
   }
 }
 

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -3,6 +3,9 @@ export { DocHandle, HandleState } from "./DocHandle.js"
 export type { DocHandleChangePayload } from "./DocHandle.js"
 export { NetworkAdapter } from "./network/NetworkAdapter.js"
 export type {
+  Message,
+  EphemeralMessage,
+  SyncMessage,
   InboundMessagePayload,
   MessagePayload,
   OpenPayload,

--- a/packages/automerge-repo/src/network/NetworkAdapter.ts
+++ b/packages/automerge-repo/src/network/NetworkAdapter.ts
@@ -1,21 +1,38 @@
 import EventEmitter from "eventemitter3"
-import { PeerId, ChannelId } from "../types.js"
+import { SessionId } from "../EphemeralData.js"
+import { ChannelId, DocumentId, PeerId } from "../types.js"
 
 export abstract class NetworkAdapter extends EventEmitter<NetworkAdapterEvents> {
   peerId?: PeerId // hmmm, maybe not
 
   abstract connect(url?: string): void
 
-  abstract sendMessage(
-    peerId: PeerId,
-    channelId: ChannelId,
-    message: Uint8Array,
-    broadcast: boolean
-  ): void
+  abstract send(message: Message): void
 
   abstract join(): void
 
   abstract leave(): void
+}
+
+// utilities
+
+export function isValidMessage(message: Message): boolean {
+  return (
+    typeof message === "object" &&
+    typeof message.type === "string" &&
+    typeof message.senderId === "string" &&
+    (isSyncMessage(message) || isEphemeralMessage(message))
+  )
+}
+
+export function isSyncMessage(message: Message): message is SyncMessage {
+  return message.type === "sync"
+}
+
+export function isEphemeralMessage<T extends { type: string }>(
+  message: Message
+): message is EphemeralMessage {
+  return message.type === "broadcast"
 }
 
 // events & payloads
@@ -25,8 +42,27 @@ export interface NetworkAdapterEvents {
   close: () => void
   "peer-candidate": (payload: PeerCandidatePayload) => void
   "peer-disconnected": (payload: PeerDisconnectedPayload) => void
-  message: (payload: InboundMessagePayload) => void
+  message: (payload: Message) => void
 }
+
+export interface SyncMessage {
+  type: "sync"
+  data: Uint8Array
+  targetId: PeerId
+  documentId: DocumentId
+  senderId: PeerId
+}
+
+export interface EphemeralMessage {
+  type: "broadcast"
+  count: number
+  channelId: ChannelId
+  senderId: PeerId
+  sessionId: SessionId
+  data: Uint8Array
+}
+
+export type Message = SyncMessage | EphemeralMessage
 
 export interface OpenPayload {
   network: NetworkAdapter

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -63,7 +63,6 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
           this.#ephemeralSessionCounts[msg.sessionId] === undefined ||
           msg.count > this.#ephemeralSessionCounts[msg.sessionId]
         ) {
-          console.log(this.peerId, this.#adaptersByPeer, msg)
           Object.entries(this.#adaptersByPeer)
             .filter(([id]) => id !== msg.senderId)
             .forEach(([_, peer]) => {

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -59,15 +59,21 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
       // If we receive a broadcast message from a network adapter we need to re-broadcast it to all
       // our other peers. This is the world's worst gossip protocol.
       if (isEphemeralMessage(msg)) {
-        if (msg.count > this.#ephemeralSessionCounts[msg.sessionId]) {
+        if (
+          this.#ephemeralSessionCounts[msg.sessionId] === undefined ||
+          msg.count > this.#ephemeralSessionCounts[msg.sessionId]
+        ) {
+          console.log(this.peerId, this.#adaptersByPeer, msg)
           Object.entries(this.#adaptersByPeer)
             .filter(([id]) => id !== msg.senderId)
             .forEach(([_, peer]) => {
               peer.send(msg)
             })
+          this.#ephemeralSessionCounts[msg.sessionId] = msg.count
+          this.emit("message", msg)
         }
 
-        this.#ephemeralSessionCounts[msg.sessionId] = msg.count
+        return
       }
 
       this.emit("message", msg)

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -4,6 +4,7 @@ import { ChannelId, PeerId } from "../types.js"
 import { Synchronizer } from "./Synchronizer.js"
 
 import debug from "debug"
+import { SyncMessage } from "../network/NetworkAdapter.js"
 
 /**
  * DocSynchronizer takes a handle to an Automerge document, and receives & dispatches sync messages
@@ -20,7 +21,7 @@ export class DocSynchronizer extends Synchronizer {
   /** Sync state for each peer we've communicated with (including inactive peers) */
   #syncStates: Record<PeerId, A.SyncState> = {}
 
-  #pendingSyncMessages: Array<{ peerId: PeerId; message: Uint8Array }> = []
+  #pendingSyncMessages: Array<SyncMessage> = []
 
   constructor(private handle: DocHandle<any>) {
     super()
@@ -77,13 +78,11 @@ export class DocSynchronizer extends Synchronizer {
     if (message) {
       this.#logMessage(`sendSyncMessage 🡒 ${peerId}`, message)
 
-      const channelId = this.handle.documentId as string as ChannelId
-
       this.emit("message", {
+        type: "sync",
         targetId: peerId,
-        channelId,
-        message,
-        broadcast: false,
+        data: message,
+        documentId: this.handle.documentId,
       })
     } else {
       this.#log(`sendSyncMessage ->${peerId} [no message generated]`)
@@ -139,43 +138,39 @@ export class DocSynchronizer extends Synchronizer {
     this.#peers = this.#peers.filter(p => p !== peerId)
   }
 
-  receiveSyncMessage(
-    peerId: PeerId,
-    channelId: ChannelId,
-    message: Uint8Array
-  ) {
-    if ((channelId as string) !== (this.handle.documentId as string))
+  receiveSyncMessage(message: SyncMessage) {
+    if (message.documentId !== this.handle.documentId)
       throw new Error(`channelId doesn't match documentId`)
 
     // We need to block receiving the syncMessages until we've checked local storage
     if (!this.handle.inState([READY, REQUESTING])) {
-      this.#pendingSyncMessages.push({ peerId, message })
+      this.#pendingSyncMessages.push(message)
       return
     }
 
     this.#processAllPendingSyncMessages()
-    this.#processSyncMessage(peerId, message)
+    this.#processSyncMessage(message)
   }
 
-  #processSyncMessage(peerId: PeerId, message: Uint8Array) {
+  #processSyncMessage(message: SyncMessage) {
     this.handle.update(doc => {
       const [newDoc, newSyncState] = A.receiveSyncMessage(
         doc,
-        this.#getSyncState(peerId),
-        message
+        this.#getSyncState(message.senderId),
+        message.data
       )
 
-      this.#setSyncState(peerId, newSyncState)
+      this.#setSyncState(message.senderId, newSyncState)
 
       // respond to just this peer (as required)
-      this.#sendSyncMessage(peerId, doc)
+      this.#sendSyncMessage(message.senderId, doc)
       return newDoc
     })
   }
 
   #processAllPendingSyncMessages() {
-    for (const { peerId, message } of this.#pendingSyncMessages) {
-      this.#processSyncMessage(peerId, message)
+    for (const message of this.#pendingSyncMessages) {
+      this.#processSyncMessage(message)
     }
 
     this.#pendingSyncMessages = []

--- a/packages/automerge-repo/src/synchronizer/Synchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/Synchronizer.ts
@@ -1,15 +1,10 @@
 import EventEmitter from "eventemitter3"
-import { ChannelId, PeerId } from "../types.js"
-import { MessagePayload } from "../network/NetworkAdapter.js"
+import { SyncMessage } from "../network/NetworkAdapter.js"
 
 export abstract class Synchronizer extends EventEmitter<SynchronizerEvents> {
-  abstract receiveSyncMessage(
-    peerId: PeerId,
-    channelId: ChannelId,
-    message: Uint8Array
-  ): void
+  abstract receiveSyncMessage(message: SyncMessage): void
 }
 
 export interface SynchronizerEvents {
-  message: (arg: MessagePayload) => void
+  message: (arg: Omit<SyncMessage, "senderId">) => void
 }

--- a/packages/automerge-repo/src/types.ts
+++ b/packages/automerge-repo/src/types.ts
@@ -4,3 +4,7 @@ export type BinaryDocumentId = Uint8Array & { __binaryDocumentId: true } // for 
 
 export type PeerId = string & { __peerId: false }
 export type ChannelId = string & { __channelId: false }
+
+export type DistributiveOmit<T, K extends keyof any> = T extends any
+  ? Omit<T, K>
+  : never

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -1,8 +1,7 @@
-import { CollectionSynchronizer } from "../src/synchronizer/CollectionSynchronizer.js"
-import { ChannelId, DocCollection, BinaryDocumentId, PeerId } from "../src"
 import assert from "assert"
 import { beforeEach } from "mocha"
-import { MessagePayload } from "../src/network/NetworkAdapter.js"
+import { DocCollection, PeerId } from "../src"
+import { CollectionSynchronizer } from "../src/synchronizer/CollectionSynchronizer.js"
 
 describe("CollectionSynchronizer", () => {
   let collection: DocCollection
@@ -21,9 +20,9 @@ describe("CollectionSynchronizer", () => {
     const handle = collection.create()
     synchronizer.addPeer("peer1" as PeerId)
 
-    synchronizer.once("message", (event: MessagePayload) => {
+    synchronizer.once("message", event => {
       assert(event.targetId === "peer1")
-      assert(event.channelId === (handle.documentId as unknown as ChannelId))
+      assert(event.documentId === handle.documentId)
       done()
     })
 
@@ -33,9 +32,9 @@ describe("CollectionSynchronizer", () => {
   it("starts synchronizing existing documents when a peer is added", done => {
     const handle = collection.create()
     synchronizer.addDocument(handle.documentId)
-    synchronizer.once("message", (event: MessagePayload) => {
+    synchronizer.once("message", event => {
       assert(event.targetId === "peer1")
-      assert(event.channelId === (handle.documentId as unknown as ChannelId))
+      assert(event.documentId === handle.documentId)
       done()
     })
     synchronizer.addPeer("peer1" as PeerId)

--- a/packages/automerge-repo/test/EphemeralData.test.ts
+++ b/packages/automerge-repo/test/EphemeralData.test.ts
@@ -10,12 +10,11 @@ describe("EphemeralData", () => {
   const messageData = { foo: "bar" }
 
   it("should emit a network message on broadcast()", done => {
-    ephemeral.on("message", event => {
+    ephemeral.on("message", message => {
       try {
-        const { targetId, channelId, message, broadcast } = event
-        assert.deepStrictEqual(CBOR.decode(message), messageData)
-        assert.strictEqual(broadcast, true)
-        assert.strictEqual(channelId, channelId)
+        assert.deepStrictEqual(CBOR.decode(message.data), messageData)
+        assert.strictEqual(message.type, "broadcast")
+        assert.strictEqual(message.channelId, destinationChannelId)
         done()
       } catch (e) {
         done(e)
@@ -35,10 +34,13 @@ describe("EphemeralData", () => {
         done(e)
       }
     })
-    ephemeral.receive(
-      otherPeerId,
-      ("m/" + destinationChannelId) as ChannelId, // TODO: this is nonsense
-      CBOR.encode(messageData)
-    )
+    ephemeral.receive({
+      senderId: otherPeerId,
+      channelId: destinationChannelId,
+      data: CBOR.encode(messageData),
+      type: "broadcast",
+      count: 0,
+      sessionId: ephemeral.sessionId,
+    })
   })
 })

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert"
 import { MessageChannelNetworkAdapter } from "@automerge/automerge-repo-network-messagechannel"
+import { BroadcastChannelNetworkAdapter } from "@automerge/automerge-repo-network-broadcastchannel"
 
 import {
   AutomergeUrl,
@@ -377,6 +378,40 @@ describe("Repo", () => {
 
       assert.deepStrictEqual(d.data, data)
       teardown()
+    })
+
+    it.only("can broadcast a message without entering into an infinite loop", async () => {
+      const aliceRepo = new Repo({
+        network: [new BroadcastChannelNetworkAdapter()],
+      })
+
+      const bobRepo = new Repo({
+        network: [new BroadcastChannelNetworkAdapter()],
+      })
+
+      // pause to let the network set up
+      await pause(50)
+
+      const channelId = "broadcast" as ChannelId
+      const data = { presence: "alex" }
+
+      aliceRepo.ephemeralData.broadcast(channelId, data)
+
+      const aliceDoesntGetIt = new Promise<void>((resolve, reject) => {
+        setTimeout(() => {
+          resolve()
+        }, 100)
+
+        aliceRepo.ephemeralData.on("data", () => {
+          reject("alice got the message")
+        })
+      })
+
+      const bobGotIt = eventPromise(bobRepo.ephemeralData, "data")
+
+      const [bob] = await Promise.all([bobGotIt, aliceDoesntGetIt])
+
+      assert.deepStrictEqual(bob.data, data)
     })
 
     it("syncs a bunch of changes", async () => {

--- a/packages/automerge-repo/test/helpers/DummyNetworkAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyNetworkAdapter.ts
@@ -1,7 +1,7 @@
 import { NetworkAdapter } from "../../src"
 
 export class DummyNetworkAdapter extends NetworkAdapter {
-  sendMessage() {}
+  send() {}
   connect(_: string) {}
   join() {}
   leave() {}


### PR DESCRIPTION
This augments the messaging system so that it uses fixed message types for `sync` and `broadcast`.

It replaces `channelId`s on the sync message type with `documentId`s, but keeps them on broadcast messages.

More importantly, it fixes ephemeral messaging so that it won’t loop when the network is a mesh rather than a tree.