### PR TITLE
cbor: Don't use typed array tags

### DIFF
--- a/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
@@ -1,5 +1,4 @@
-import { NetworkAdapter, PeerId } from "@automerge/automerge-repo"
-import * as CBOR from "cbor-x"
+import { NetworkAdapter, PeerId, cbor } from "@automerge/automerge-repo"
 import WebSocket from "isomorphic-ws"
 
 import debug from "debug"
@@ -100,7 +99,7 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
       throw new Error("Websocket Socket not ready!")
     }
 
-    const encoded = CBOR.encode(message)
+    const encoded = cbor.encode(message)
     // This incantation deals with websocket sending the whole
     // underlying buffer even if we just have a uint8array view on it
     const arrayBuf = encoded.buffer.slice(
@@ -122,7 +121,7 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   receiveMessage(message: Uint8Array) {
-    const decoded: FromServerMessage = CBOR.decode(new Uint8Array(message))
+    const decoded: FromServerMessage = cbor.decode(new Uint8Array(message))
 
     const { type, senderId } = decoded
 

--- a/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
@@ -1,4 +1,3 @@
-import * as CBOR from "cbor-x"
 import { WebSocket, type WebSocketServer } from "isomorphic-ws"
 
 import debug from "debug"
@@ -7,10 +6,13 @@ const log = debug("WebsocketServer")
 import { ProtocolV1, ProtocolVersion } from "./protocolVersion.js"
 import {
   NetworkAdapter,
+  cbor as cborHelpers,
   type NetworkAdapterMessage,
   type PeerId,
 } from "@automerge/automerge-repo"
 import { FromClientMessage, FromServerMessage } from "./messages.js"
+
+const { encode, decode } = cborHelpers
 
 export class NodeWSServerAdapter extends NetworkAdapter {
   server: WebSocketServer
@@ -62,7 +64,7 @@ export class NodeWSServerAdapter extends NetworkAdapter {
       return
     }
 
-    const encoded = CBOR.encode(message)
+    const encoded = encode(message)
     // This incantation deals with websocket sending the whole
     // underlying buffer even if we just have a uint8array view on it
     const arrayBuf = encoded.buffer.slice(
@@ -74,7 +76,7 @@ export class NodeWSServerAdapter extends NetworkAdapter {
   }
 
   receiveMessage(message: Uint8Array, socket: WebSocket) {
-    const cbor: FromClientMessage = CBOR.decode(message)
+    const cbor: FromClientMessage = decode(message)
 
     const { type, senderId } = cbor
 

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -19,7 +19,7 @@ import { pause } from "./helpers/pause.js"
 import { TimeoutError, withTimeout } from "./helpers/withTimeout.js"
 import type { DocumentId, PeerId, AutomergeUrl } from "./types.js"
 import { stringifyAutomergeUrl } from "./DocUrl.js"
-import { encode } from "cbor-x"
+import { encode } from "./helpers/cbor.js"
 
 /** DocHandle is a wrapper around a single Automerge document that lets us listen for changes. */
 export class DocHandle<T> //

--- a/packages/automerge-repo/src/helpers/cbor.ts
+++ b/packages/automerge-repo/src/helpers/cbor.ts
@@ -1,0 +1,10 @@
+import { Encoder, decode as cborXdecode } from "cbor-x";
+
+export function encode(obj: any): Buffer {
+  let encoder = new Encoder({tagUint8Array: false})
+  return encoder.encode(obj)
+}
+
+export function decode(buf: Buffer | Uint8Array): any {
+  return cborXdecode(buf)
+}

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -30,3 +30,5 @@ export {
   stringifyAutomergeUrl as generateAutomergeUrl,
 } from "./DocUrl.js"
 export * from "./types.js"
+
+export * as cbor from "./helpers/cbor"


### PR DESCRIPTION
cbor-x by default tags Uint8Arrays with `64`, which is the tag from [RFC8746][1] for an array of uint8. This is a nice idea but actually really irritating when implementing an interoperable implementation on a platform which doesn't support this extension to CBOR. Disable this feature to make interoperability easier.

[1]: https://www.rfc-editor.org/rfc/rfc8746.html