### PR TITLE
Save documents to storage as soon as we create them

### DIFF
--- a/packages/automerge-repo/src/DocCollection.ts
+++ b/packages/automerge-repo/src/DocCollection.ts
@@ -74,7 +74,7 @@ export class DocCollection extends EventEmitter<DocCollectionEvents> {
     // Generate a new UUID and store it in the buffer
     const { documentId } = parseAutomergeUrl(generateAutomergeUrl())
     const handle = this.#getHandle<T>(documentId, true) as DocHandle<T>
-    this.emit("document", { handle })
+    this.emit("document", { handle, isNew: true })
     return handle
   }
 
@@ -105,7 +105,7 @@ export class DocCollection extends EventEmitter<DocCollectionEvents> {
     }
 
     const handle = this.#getHandle<T>(documentId, false) as DocHandle<T>
-    this.emit("document", { handle })
+    this.emit("document", { handle, isNew: false })
     return handle
   }
 
@@ -136,6 +136,7 @@ interface DocCollectionEvents {
 
 interface DocumentPayload {
   handle: DocHandle<any>
+  isNew: boolean
 }
 
 interface DeleteDocumentPayload {

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -43,7 +43,12 @@ export class DocHandle<T> //
     this.#log = debug(`automerge-repo:dochandle:${this.documentId.slice(0, 5)}`)
 
     // initial doc
-    const doc = A.init<T>()
+    let doc = A.init<T>()
+
+    // Make an empty change so that we have something to save to disk
+    if (isNew) {
+      doc = A.emptyChange(doc, {})
+    }
 
     /**
      * Internally we use a state machine to orchestrate document loading and/or syncing, in order to

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -100,6 +100,21 @@ describe("Repo", () => {
       assert.equal(v?.foo, "bar")
     })
 
+    it("saves the document when creating it", async () => {
+      const { repo, storageAdapter } = setup()
+      const handle = repo.create<TestDoc>()
+
+      const repo2 = new Repo({
+        storage: storageAdapter,
+        network: [],
+      })
+
+      const bobHandle = repo2.find<TestDoc>(handle.url)
+      await bobHandle.whenReady()
+      assert.equal(bobHandle.isReady(), true)
+
+    })
+
     it("saves the document when changed and can find it again", async () => {
       const { repo, storageAdapter } = setup()
       const handle = repo.create<TestDoc>()


### PR DESCRIPTION
Problem: currently it is possible to create a DocHandle, obtain the URl to that dochandle, and then never save anything to the dochandle (e.g. by closing the browser window) and therefore never save anything to storage. This means that you have a URL which points at a document which can _never_ be resolved. This is not a theoretical problem. In several example applications we have this pattern of creating a `DocHandle`, then immediately adding the URL to the window location. Because many of these applications don't call `DocHandle.change` until the user has pressed a button (e.g. to incrementa counter) it is possible to refresh the browser window before any call to `DocHandle.change` and end up in a situation where the `Repo` is trying to find a document which never existed.

Solution: Save the document as soon as the handle is created. This might waste a few bytes of storage but it means we never hand out URLs to documents which don't exist.