### PR TITLE
Add a setup phase for network adapters

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -47,6 +47,7 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
         }
       }
     )
+    this.emit("ready", { network: this })
   }
 
   #announceConnection(peerId: PeerId) {

--- a/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
@@ -39,6 +39,7 @@ export class NodeWSServerAdapter extends NetworkAdapter {
       socket.on("message", message =>
         this.receiveMessage(message as Uint8Array, socket)
       )
+      this.emit("ready", {network: this})
     })
   }
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -49,7 +49,16 @@ export class Repo extends DocCollection {
         })
       })
 
-      handle.request()
+      if (this.networkSubsystem.isReady()) {
+        handle.request()
+      } else {
+        handle.awaitNetwork()
+        this.networkSubsystem.whenReady().then(() => {
+          handle.networkReady()
+        }).catch(err => {
+          this.#log("error waiting for network", { err })
+        })
+      }
 
       // Register the document with the synchronizer. This advertises our interest in the document.
       synchronizer.addDocument(handle.documentId)
@@ -60,7 +69,9 @@ export class Repo extends DocCollection {
       // synchronizer.removeDocument(documentId)
 
       if (storageSubsystem) {
-        storageSubsystem.remove(documentId)
+        storageSubsystem.remove(documentId).catch(err => {
+          this.#log("error deleting document", { documentId, err })
+        })
       }
     })
 

--- a/packages/automerge-repo/src/network/NetworkAdapter.ts
+++ b/packages/automerge-repo/src/network/NetworkAdapter.ts
@@ -17,7 +17,7 @@ export abstract class NetworkAdapter extends EventEmitter<NetworkAdapterEvents> 
 // events & payloads
 
 export interface NetworkAdapterEvents {
-  open: (payload: OpenPayload) => void
+  ready: (payload: OpenPayload) => void
   close: () => void
   "peer-candidate": (payload: PeerCandidatePayload) => void
   "peer-disconnected": (payload: PeerDisconnectedPayload) => void

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -1,5 +1,6 @@
 import * as A from "@automerge/automerge/next"
 import {
+  AWAITING_NETWORK,
   DocHandle,
   DocHandleOutboundEphemeralMessagePayload,
   READY,
@@ -190,20 +191,19 @@ export class DocSynchronizer extends Synchronizer {
   beginSync(peerIds: PeerId[]) {
     this.#log(`beginSync: ${peerIds.join(", ")}`)
 
+    // HACK: if we have a sync state already, we round-trip it through the encoding system to make
+    // sure state is preserved. This prevents an infinite loop caused by failed attempts to send
+    // messages during disconnection.
+    // TODO: cover that case with a test and remove this hack
+    peerIds.forEach(peerId => {
+      const syncStateRaw = this.#getSyncState(peerId)
+      const syncState = A.decodeSyncState(A.encodeSyncState(syncStateRaw))
+      this.#setSyncState(peerId, syncState)
+    })
+
     // At this point if we don't have anything in our storage, we need to use an empty doc to sync
     // with; but we don't want to surface that state to the front end
     void this.handle.doc([READY, REQUESTING, UNAVAILABLE]).then(doc => {
-      // if we don't have any peers, then we can say the document is unavailable
-
-      // HACK: if we have a sync state already, we round-trip it through the encoding system to make
-      // sure state is preserved. This prevents an infinite loop caused by failed attempts to send
-      // messages during disconnection.
-      // TODO: cover that case with a test and remove this hack
-      peerIds.forEach(peerId => {
-        const syncStateRaw = this.#getSyncState(peerId)
-        const syncState = A.decodeSyncState(A.encodeSyncState(syncStateRaw))
-        this.#setSyncState(peerId, syncState)
-      })
 
       // we register out peers first, then say that sync has started
       this.#syncStarted = true

--- a/packages/automerge-repo/test/helpers/DummyNetworkAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyNetworkAdapter.ts
@@ -1,8 +1,17 @@
 import { NetworkAdapter } from "../../src/index.js"
 
 export class DummyNetworkAdapter extends NetworkAdapter {
+  #startReady = true
+  constructor(startReady: boolean) {
+    super()
+    this.#startReady = startReady
+  }
   send() {}
-  connect(_: string) {}
+  connect(_: string) {
+    if (this.#startReady) {
+      this.emit("ready", { network: this })
+    }
+  }
   join() {}
   leave() {}
 }


### PR DESCRIPTION
Problem: `Repo.find` can return a `DocHandle` which is unavailable when the document is not in storage even if the document _is_ available from connected peerrs. The issue is that the network subsystem takes some time to set up connections to it's peers. For example, a `BrowserWebSocketClientAdapter` starts without a Peer ID from the server. This means that if the user requests a `DocHandle` whilst we are still waiting for the server to respond with it's peer ID then the `Repo` decides that we have no peers and consequently immediately marks the `DocHandle` as unavailable. This is bad because it's extremely surprising to the user and requires them to do awkward things like "wait ten seconds for the websocket to start up".

Solution: Add a setup phase to the `NetworkSubsystem`. Each `NetworkAdapter` now emits a "ready" event. The `NetworkSubsystem` emits a "ready" event once all it's adapters have done so. To communicate this to the `DocHandle` we add a state to the `DocHandle` state machine for "awaiting network". When the Repo creates a `DocHandle` in `find` it checks if the `NetworkSubsystem` is ready and if not it puts the handle in the `AWAITING_NETWORK` state and once the `NetworkSubsystem` tells the `Repo` it's ready the `Repo` puts the `DocHandle` into the `REQUESTING` state.