### PR TITLE
Merge join into connect on network adapters

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -47,6 +47,12 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
         }
       }
     )
+
+    this.#broadcastChannel.postMessage({
+      senderId: this.peerId,
+      type: "arrive",
+    })
+
     this.emit("ready", { network: this })
   }
 
@@ -68,15 +74,8 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
     }
   }
 
-  join() {
-    this.#broadcastChannel.postMessage({
-      senderId: this.peerId,
-      type: "arrive",
-    })
-  }
-
-  leave() {
-    // TODO
+  disconnect() {
+    // TODO:
     throw new Error("Unimplemented: leave on BroadcastChannelNetworkAdapter")
   }
 }

--- a/packages/automerge-repo-network-messagechannel/src/index.ts
+++ b/packages/automerge-repo-network-messagechannel/src/index.ts
@@ -76,9 +76,13 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
     this.messagePortRef.addListener("close", () => {
       this.emit("close")
     })
-    this.join()
 
-    // Mark this messagechannel as ready after 50 ms, at this point there 
+    this.messagePortRef.postMessage({
+      senderId: this.peerId,
+      type: "arrive",
+    })
+
+    // Mark this messagechannel as ready after 50 ms, at this point there
     // must be something weird going on on the other end to cause us to receive
     // no response
     setTimeout(() => {
@@ -116,14 +120,7 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
     this.emit("peer-candidate", { peerId })
   }
 
-  join() {
-    this.messagePortRef.postMessage({
-      senderId: this.peerId,
-      type: "arrive",
-    })
-  }
-
-  leave() {
+  disconnect() {
     // TODO
     throw new Error("Unimplemented: leave on MessagePortNetworkAdapter")
   }

--- a/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
@@ -68,6 +68,8 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
         this.emit("ready", { network: this })
       }
     }, 1000)
+
+    this.join()
   }
 
   join() {
@@ -90,7 +92,7 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
     }
   }
 
-  leave() {
+  disconnect() {
     if (!this.socket) {
       throw new Error("WTF, get a socket")
     }

--- a/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
@@ -3,14 +3,13 @@ import { WebSocket, type WebSocketServer } from "isomorphic-ws"
 import debug from "debug"
 const log = debug("WebsocketServer")
 
-import { ProtocolV1, ProtocolVersion } from "./protocolVersion.js"
 import {
-  NetworkAdapter,
   cbor as cborHelpers,
-  type NetworkAdapterMessage,
+  NetworkAdapter,
   type PeerId,
 } from "@automerge/automerge-repo"
 import { FromClientMessage, FromServerMessage } from "./messages.js"
+import { ProtocolV1, ProtocolVersion } from "./protocolVersion.js"
 
 const { encode, decode } = cborHelpers
 
@@ -39,15 +38,11 @@ export class NodeWSServerAdapter extends NetworkAdapter {
       socket.on("message", message =>
         this.receiveMessage(message as Uint8Array, socket)
       )
-      this.emit("ready", {network: this})
+      this.emit("ready", { network: this })
     })
   }
 
-  join() {
-    // throw new Error("The server doesn't join channels.")
-  }
-
-  leave() {
+  disconnect() {
     // throw new Error("The server doesn't join channels.")
   }
 

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -101,7 +101,7 @@ export class DocHandle<T> //
             awaitingNetwork: {
               on: {
                 NETWORK_READY: { target: REQUESTING },
-              }
+              },
             },
             requesting: {
               on: {
@@ -501,7 +501,7 @@ type DocHandleEvent<T> =
   | TimeoutEvent
   | DeleteEvent
   | MarkUnavailableEvent
-  | AwaitNetworkEvent 
+  | AwaitNetworkEvent
   | NetworkReadyEvent
 
 type DocHandleXstateMachine<T> = Interpreter<
@@ -541,5 +541,5 @@ const {
   REQUEST_COMPLETE,
   MARK_UNAVAILABLE,
   AWAIT_NETWORK,
-  NETWORK_READY
+  NETWORK_READY,
 } = Event

--- a/packages/automerge-repo/src/network/NetworkAdapter.ts
+++ b/packages/automerge-repo/src/network/NetworkAdapter.ts
@@ -5,13 +5,11 @@ import { Message } from "./messages.js"
 export abstract class NetworkAdapter extends EventEmitter<NetworkAdapterEvents> {
   peerId?: PeerId // hmmm, maybe not
 
-  abstract connect(url?: string): void
+  abstract connect(peerId: PeerId): void
 
   abstract send(message: Message): void
 
-  abstract join(): void
-
-  abstract leave(): void
+  abstract disconnect(): void
 }
 
 // events & payloads

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -25,13 +25,10 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
   #count = 0
   #sessionId: SessionId = Math.random().toString(36).slice(2) as SessionId
   #ephemeralSessionCounts: Record<EphemeralMessageSource, number> = {}
-  #readyAdapterCount = 0 
+  #readyAdapterCount = 0
   #adapters: NetworkAdapter[] = []
 
-  constructor(
-    adapters: NetworkAdapter[],
-    public peerId = randomPeerId()
-  ) {
+  constructor(adapters: NetworkAdapter[], public peerId = randomPeerId()) {
     super()
     this.#log = debug(`automerge-repo:network:${this.peerId}`)
     adapters.forEach(a => this.addNetworkAdapter(a))
@@ -41,7 +38,12 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
     this.#adapters.push(networkAdapter)
     networkAdapter.once("ready", () => {
       this.#readyAdapterCount++
-      this.#log("Adapters ready: ", this.#readyAdapterCount, "/", this.#adapters.length)
+      this.#log(
+        "Adapters ready: ",
+        this.#readyAdapterCount,
+        "/",
+        this.#adapters.length
+      )
       if (this.#readyAdapterCount === this.#adapters.length) {
         this.emit("ready")
       }
@@ -100,7 +102,6 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
     })
 
     networkAdapter.connect(this.peerId)
-    networkAdapter.join()
   }
 
   send(message: MessageContents) {
@@ -130,14 +131,9 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
     }
   }
 
-  join() {
-    this.#log(`Joining network`)
-    this.#adapters.forEach(a => a.join())
-  }
-
   leave() {
     this.#log(`Leaving network`)
-    this.#adapters.forEach(a => a.leave())
+    this.#adapters.forEach(a => a.disconnect())
   }
 
   isReady = () => {
@@ -167,7 +163,7 @@ export interface NetworkSubsystemEvents {
   peer: (payload: PeerPayload) => void
   "peer-disconnected": (payload: PeerDisconnectedPayload) => void
   message: (payload: Message) => void
-  "ready": () => void
+  ready: () => void
 }
 
 export interface PeerPayload {

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -117,11 +117,11 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
         "count" in message
           ? message
           : {
-              ...message,
-              count: ++this.#count,
-              sessionId: this.#sessionId,
-              senderId: this.peerId,
-            }
+            ...message,
+            count: ++this.#count,
+            sessionId: this.#sessionId,
+            senderId: this.peerId,
+          }
       this.#log("Ephemeral message", outbound)
       peer.send(outbound)
     } else {
@@ -129,11 +129,6 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
       this.#log("Sync message", outbound)
       peer.send(outbound)
     }
-  }
-
-  leave() {
-    this.#log(`Leaving network`)
-    this.#adapters.forEach(a => a.disconnect())
   }
 
   isReady = () => {

--- a/packages/automerge-repo/test/helpers/DummyNetworkAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyNetworkAdapter.ts
@@ -6,12 +6,11 @@ export class DummyNetworkAdapter extends NetworkAdapter {
     super()
     this.#startReady = startReady
   }
-  send() {}
+  send() { }
   connect(_: string) {
     if (this.#startReady) {
       this.emit("ready", { network: this })
     }
   }
-  join() {}
-  leave() {}
+  disconnect() { }
 }


### PR DESCRIPTION
#156 resulted in a refactor which highlighted that when we set up each network adapter, we essentially call `adapter.connect()` followed immediately by `adapter.join()`. The join is superfluous.

This also renames `leave` to disconnect and removes the unused `join` on the network subsystem.

We could also perhaps remove `leave` from the subsystem too? It isn't used anywhere yet.