### PR TITLE
Fix snapshots

### DIFF
--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -157,7 +157,7 @@ export class StorageSubsystem {
         incrementalSize += chunk.size
       }
     }
-    return incrementalSize > snapshotSize
+    return incrementalSize >= snapshotSize
   }
 }
 

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -35,6 +35,8 @@ export class StorageSubsystem {
   #storedHeads: Map<DocumentId, A.Heads> = new Map()
   #log = debug(`automerge-repo:storage-subsystem`)
 
+  #snapshotting = false
+
   constructor(storageAdapter: StorageAdapter) {
     this.#storageAdapter = storageAdapter
   }
@@ -67,6 +69,7 @@ export class StorageSubsystem {
     doc: A.Doc<unknown>,
     sourceChunks: StorageChunkInfo[]
   ): Promise<void> {
+    this.#snapshotting = true
     const binary = A.save(doc)
     const snapshotHash = headsHash(A.getHeads(doc))
     const key = [documentId, "snapshot", snapshotHash]
@@ -86,6 +89,7 @@ export class StorageSubsystem {
       this.#chunkInfos.get(documentId)?.filter(c => !oldKeys.has(c.key)) ?? []
     newChunkInfos.push({ key, type: "snapshot", size: binary.length })
     this.#chunkInfos.set(documentId, newChunkInfos)
+    this.#snapshotting = false
   }
 
   async loadDoc(documentId: DocumentId): Promise<A.Doc<unknown> | null> {
@@ -147,6 +151,9 @@ export class StorageSubsystem {
   }
 
   #shouldCompact(sourceChunks: StorageChunkInfo[]) {
+    if (this.#snapshotting) {
+      return false
+    }
     // compact if the incremental size is greater than the snapshot size
     let snapshotSize = 0
     let incrementalSize = 0

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -128,7 +128,7 @@ export class StorageSubsystem {
   }
 
   async remove(documentId: DocumentId) {
-    this.#storageAdapter.remove([documentId, "snapshot"])
+    this.#storageAdapter.removeRange([documentId, "snapshot"])
     this.#storageAdapter.removeRange([documentId, "incremental"])
   }
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -162,6 +162,7 @@ describe("Repo", () => {
       handle.change(d => {
         d.foo = "bar"
       })
+      // we now have a snapshot and an incremental change in storage
       assert.equal(handle.isReady(), true)
       await handle.doc()
       repo.delete(handle.documentId)

--- a/packages/automerge-repo/test/helpers/generate-large-object.ts
+++ b/packages/automerge-repo/test/helpers/generate-large-object.ts
@@ -1,0 +1,13 @@
+export type LargeObject = { [key: string]: number }
+
+export function generateLargeObject(size: number): LargeObject {
+  const largeObject: LargeObject = {}
+
+  for (let i = 0; i < size; i++) {
+    const key = `key${i}`
+    const value = Math.random()
+    largeObject[key] = value
+  }
+
+  return largeObject
+}


### PR DESCRIPTION
This PR has 3 main effects:

1. Ensures that the first save in any handle (when the document is created) is a snapshot.
2. Checks that when a handle is deleted, snapshots and incremental saves are removed properly from storage.
3. Previously when a snapshot was being created, a subsequent change hot on the heels of it would trigger the creation of an additional snapshot, resulting in multiple snapshots in storage and slowing load times down significantly. This prevents additional snapshots being created while the storage subsystem is still creating one.