### PR TITLE
Allow broadcastchannel channel name to be configured

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -5,12 +5,23 @@ import {
   Message,
 } from "@automerge/automerge-repo"
 
+export type BroadcastChannelNetworkAdapterOptions = {
+  channelName: string
+}
+
 export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
   #broadcastChannel: BroadcastChannel
 
+  #options: BroadcastChannelNetworkAdapterOptions
+
+  constructor(options?: BroadcastChannelNetworkAdapterOptions) {
+    super()
+    this.#options = { ...(options ?? {}), channelName: "broadcast" }
+  }
+
   connect(peerId: PeerId) {
     this.peerId = peerId
-    this.#broadcastChannel = new BroadcastChannel(`broadcast`)
+    this.#broadcastChannel = new BroadcastChannel(this.#options.channelName)
 
     this.#broadcastChannel.addEventListener(
       "message",

--- a/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
+++ b/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
@@ -3,6 +3,7 @@ import {
   type SetupFn,
   runAdapterTests,
 } from "../../automerge-repo/src/helpers/tests/network-adapter-tests.js"
+import { PeerId } from "@automerge/automerge-repo"
 
 describe("BroadcastChannel", () => {
   const setup: SetupFn = async () => {
@@ -14,4 +15,29 @@ describe("BroadcastChannel", () => {
   }
 
   runAdapterTests(setup)
+
+  it("should allow a channel name to be specified in the options", async () => {
+    const a = new BroadcastChannelNetworkAdapter({ channelName: "test" })
+    const b = new BroadcastChannelNetworkAdapter({ channelName: "test" })
+
+    // this adapter should never connect
+    const c = new BroadcastChannelNetworkAdapter()
+
+    const aConnect = new Promise<void>(resolve => {
+      a.once("peer-candidate", () => resolve())
+    })
+
+    const cShouldNotConnect = new Promise<void>((resolve, reject) => {
+      c.once("peer-candidate", () => reject("c should not connect"))
+
+      setTimeout(() => {
+        resolve()
+      }, 100)
+    })
+
+    a.connect("a" as PeerId)
+    b.connect("b" as PeerId)
+
+    return Promise.all([aConnect, cShouldNotConnect])
+  })
 })

--- a/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
+++ b/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
@@ -16,7 +16,7 @@ describe("BroadcastChannel", () => {
 
   runAdapterTests(setup)
 
-  it("should allow a channel name to be specified in the options", async () => {
+  it("allows a channel name to be specified in the options and limits messages to that channel", async () => {
     const a = new BroadcastChannelNetworkAdapter({ channelName: "test" })
     const b = new BroadcastChannelNetworkAdapter({ channelName: "test" })
 


### PR DESCRIPTION
I am using the BroadcastChannel adapter to locally sync 2 different repos managing different docs: one which only syncs locally and the other which also has a connection to the outside world. To keep the docs separate, we need separate channels.

This PR allows a `channelName` option to be passed in to the adapter construction as part of an optional `options` object.