### PR TITLE
Return undefined if the document load time out

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -277,9 +277,8 @@ export class DocHandle<T> //
       // wait for the document to enter one of the desired states
       await this.#statePromise(awaitStates)
     } catch (error) {
-      if (error instanceof TimeoutError)
-        throw new Error(`DocHandle: timed out loading ${this.documentId}`)
-      else throw error
+      // if we timed out (or the load has already failed), return undefined
+      return undefined
     }
     // Return the document
     return !this.isUnavailable() ? this.#doc : undefined

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -211,17 +211,15 @@ describe("DocHandle", () => {
     })
   })
 
-  it("should time out if the document is not loaded", async () => {
+  it("should be undefined if loading the document times out", async () => {
     // set docHandle time out after 5 ms
     const handle = new DocHandle<TestDoc>(TEST_ID, { timeoutDelay: 5 })
 
-    // we're not going to load
-    await pause(10)
+    const doc = await handle.doc()
+
+    assert.equal(doc, undefined)
 
     assert.equal(handle.state, "failed")
-
-    // so it should time out
-    return assert.rejects(handle.doc, "DocHandle timed out")
   })
 
   it("should not time out if the document is loaded in time", async () => {
@@ -236,7 +234,7 @@ describe("DocHandle", () => {
     assert.equal(doc?.foo, "bar")
   })
 
-  it("should time out if the document is not updated from the network", async () => {
+  it("should be undefined if loading from the network times out", async () => {
     // set docHandle time out after 5 ms
     const handle = new DocHandle<TestDoc>(TEST_ID, { timeoutDelay: 5 })
 
@@ -246,8 +244,8 @@ describe("DocHandle", () => {
     // there's no update
     await pause(10)
 
-    // so it should time out
-    return assert.rejects(handle.doc, "DocHandle timed out")
+    const doc = await handle.doc()
+    assert.equal(doc, undefined)
   })
 
   it("should not time out if the document is updated in time", async () => {


### PR DESCRIPTION
This removes the promise rejection when accessing `handle.doc()`, which now returns undefined on error.

Prior to this we were attempting to check for a `TimeoutError`, which was never thrown in this codepath. The state machine is set up so that it times out automatically once the `loading` or `requesting` states have been entered and the timeout period elapses.

It should be noted that the `waitFor` function will throw an error if the state machine enters a state marked as final. It was actually this error which was causing the promise to reject prior to this PR. This is used for the `whenReady` method, so it might be worth revisiting this at some point.