### PR TITLE
.gitignore automerge-sync-server-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ build
 vite.config.ts.timestamp-*
 coverage
 docs
-automerge-sync-server-data

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 vite.config.ts.timestamp-*
 coverage
 docs
+automerge-sync-server-data

--- a/examples/sync-server/.gitignore
+++ b/examples/sync-server/.gitignore
@@ -1,1 +1,2 @@
 .amrg
+automerge-sync-server-data


### PR DESCRIPTION
If you run `yarn dev:demo` and add some todos, you'll end up with a bunch of files and folders in `sync-server\automerge-sync-server-data` that shouldn't make their way into source control. 