### PR TITLE
Reject with error

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
+++ b/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
@@ -28,7 +28,7 @@ describe("BroadcastChannel", () => {
     })
 
     const cShouldNotConnect = new Promise<void>((resolve, reject) => {
-      c.once("peer-candidate", () => reject("c should not connect"))
+      c.once("peer-candidate", () => reject(new Error("c should not connect")))
 
       setTimeout(() => {
         resolve()

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -765,7 +765,7 @@ describe("Repo", () => {
         }, 100)
 
         aliceHandle.on("ephemeral-message", () => {
-          reject("alice got the message")
+          reject(new Error("alice got the message"))
         })
       })
 


### PR DESCRIPTION
Really nitpicky: 

There are a couple of spots in tests where we were rejecting with a string, e.g. `reject("c should not connect")`. I happened to break something so that one of these rejections kicked in, and was scolded in the terminal for not passing an `Error` to `reject`. 