### PR TITLE
typedoc.json: extends property should be array

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/typedoc.json
+++ b/packages/automerge-repo-network-broadcastchannel/typedoc.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../typedoc.base.json",
-    "entryPoints": ["src/index.ts"],
-    "readme": "none"
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "readme": "none"
 }

--- a/packages/automerge-repo-network-messagechannel/typedoc.json
+++ b/packages/automerge-repo-network-messagechannel/typedoc.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../typedoc.base.json",
-    "entryPoints": ["src/index.ts"],
-    "readme": "none"
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "readme": "none"
 }

--- a/packages/automerge-repo-network-websocket/typedoc.json
+++ b/packages/automerge-repo-network-websocket/typedoc.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../typedoc.base.json",
-    "entryPoints": ["src/index.ts"],
-    "readme": "none"
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "readme": "none"
 }

--- a/packages/automerge-repo-react-hooks/typedoc.json
+++ b/packages/automerge-repo-react-hooks/typedoc.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../typedoc.base.json",
-    "entryPoints": ["src/index.ts"],
-    "readme": "none"
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "readme": "none"
 }

--- a/packages/automerge-repo-storage-indexeddb/typedoc.json
+++ b/packages/automerge-repo-storage-indexeddb/typedoc.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../typedoc.base.json",
-    "entryPoints": ["src/index.ts"],
-    "readme": "none"
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "readme": "none"
 }

--- a/packages/automerge-repo-storage-nodefs/typedoc.json
+++ b/packages/automerge-repo-storage-nodefs/typedoc.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../typedoc.base.json",
-    "entryPoints": ["src/index.ts"],
-    "readme": "none"
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "readme": "none"
 }

--- a/packages/automerge-repo-svelte-store/typedoc.json
+++ b/packages/automerge-repo-svelte-store/typedoc.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../typedoc.base.json",
-    "entryPoints": ["src/index.ts"],
-    "readme": "none"
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "readme": "none"
 }

--- a/packages/automerge-repo/typedoc.json
+++ b/packages/automerge-repo/typedoc.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../typedoc.base.json",
-    "entryPoints": ["src/index.ts"],
-    "readme": "none"
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "readme": "none"
 }


### PR DESCRIPTION
VS Code tells me that this

```
  "extends": "../../typedoc.base.json",
```

should be this

```
  "extends": ["../../typedoc.base.json"],
```