### PR TITLE
DocHandle.doc(): don't yield tick

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -290,7 +290,6 @@ export class DocHandle<T> //
   async doc(
     awaitStates: HandleState[] = [READY, UNAVAILABLE]
   ): Promise<A.Doc<T> | undefined> {
-    await pause() // yield one tick because reasons
     try {
       // wait for the document to enter one of the desired states
       await this.#statePromise(awaitStates)


### PR DESCRIPTION
I've never really been clear why we needed this `await pause()`, but at some point I removed it and broke blutack and so we put it back. 

It shouldn't ever really hurt anything to have an async function yield one tick, but you also shouldn't really need it. Currently tests pass with and without it. 

If this still breaks blutack, let's get to the bottom of why; and if we can't find a better solution, try to document it and get it under test. 


