### PR TITLE
Fix a handful of lint errors and remove some `any`s

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -431,7 +431,7 @@ export class DocHandle<T> //
    * a user could have multiple tabs open and would appear as multiple PeerIds.
    * every message source must have a unique PeerId.
    */
-  broadcast(message: any) {
+  broadcast(message: unknown) {
     this.emit("ephemeral-message-outbound", {
       handle: this,
       data: encode(message),
@@ -474,14 +474,14 @@ export interface DocHandleChangePayload<T> {
   patchInfo: A.PatchInfo<T>
 }
 
-export interface DocHandleEphemeralMessagePayload {
-  handle: DocHandle<any>
+export interface DocHandleEphemeralMessagePayload<T> {
+  handle: DocHandle<T>
   senderId: PeerId
   message: unknown
 }
 
-export interface DocHandleOutboundEphemeralMessagePayload {
-  handle: DocHandle<any>
+export interface DocHandleOutboundEphemeralMessagePayload<T> {
+  handle: DocHandle<T>
   data: Uint8Array
 }
 
@@ -490,9 +490,9 @@ export interface DocHandleEvents<T> {
   change: (payload: DocHandleChangePayload<T>) => void
   delete: (payload: DocHandleDeletePayload<T>) => void
   unavailable: (payload: DocHandleDeletePayload<T>) => void
-  "ephemeral-message": (payload: DocHandleEphemeralMessagePayload) => void
+  "ephemeral-message": (payload: DocHandleEphemeralMessagePayload<T>) => void
   "ephemeral-message-outbound": (
-    payload: DocHandleOutboundEphemeralMessagePayload
+    payload: DocHandleOutboundEphemeralMessagePayload<T>
   ) => void
 }
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -5,7 +5,7 @@ import { StorageAdapter } from "./storage/StorageAdapter.js"
 import { StorageSubsystem } from "./storage/StorageSubsystem.js"
 import { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js"
 import { type AutomergeUrl, DocumentId, PeerId } from "./types.js"
-import { v4 as uuid } from "uuid"
+
 import {
   parseAutomergeUrl,
   generateAutomergeUrl,
@@ -198,9 +198,9 @@ export class Repo extends EventEmitter<RepoEvents> {
    * @param clonedHandle - The handle to clone
    *
    * @remarks This is a wrapper around the `clone` function in the Automerge library.
-   * The new `DocHandle` will have a new URL but will share history with the original, 
-   * which means that changes made to the cloned handle can be sensibly merged back 
-   * into the original. 
+   * The new `DocHandle` will have a new URL but will share history with the original,
+   * which means that changes made to the cloned handle can be sensibly merged back
+   * into the original.
    *
    * Any peers this `Repo` is connected to for whom `sharePolicy` returns `true` will
    * be notified of the newly created DocHandle.
@@ -223,7 +223,7 @@ export class Repo extends EventEmitter<RepoEvents> {
 
     const handle = this.create<T>()
 
-    handle.update((doc: Automerge.Doc<T>) => {
+    handle.update(() => {
       // we replace the document with the new cloned one
       return Automerge.clone(sourceDoc)
     })
@@ -240,7 +240,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     automergeUrl: AutomergeUrl
   ): DocHandle<T> {
     if (!isValidAutomergeUrl(automergeUrl)) {
-      let maybeAutomergeUrl = parseLegacyUUID(automergeUrl)
+      const maybeAutomergeUrl = parseLegacyUUID(automergeUrl)
       if (maybeAutomergeUrl) {
         console.warn(
           "Legacy UUID document ID detected, converting to AutomergeUrl. This will be removed in a future version."

--- a/packages/automerge-repo/src/helpers/cbor.ts
+++ b/packages/automerge-repo/src/helpers/cbor.ts
@@ -1,10 +1,10 @@
-import { Encoder, decode as cborXdecode } from "cbor-x";
+import { Encoder, decode as cborXdecode } from "cbor-x"
 
-export function encode(obj: any): Buffer {
-  let encoder = new Encoder({tagUint8Array: false})
+export function encode(obj: unknown): Buffer {
+  const encoder = new Encoder({ tagUint8Array: false })
   return encoder.encode(obj)
 }
 
-export function decode(buf: Buffer | Uint8Array): any {
+export function decode<T = unknown>(buf: Buffer | Uint8Array): T {
   return cborXdecode(buf)
 }

--- a/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
@@ -1,7 +1,7 @@
-import { PeerId, Repo, type NetworkAdapter, DocumentId } from "../../index.js"
-import { eventPromise, eventPromises } from "../eventPromise.js"
 import assert from "assert"
 import { describe, it } from "vitest"
+import { PeerId, Repo, type NetworkAdapter } from "../../index.js"
+import { eventPromise, eventPromises } from "../eventPromise.js"
 import { pause } from "../pause.js"
 
 /**

--- a/packages/automerge-repo/src/helpers/withTimeout.ts
+++ b/packages/automerge-repo/src/helpers/withTimeout.ts
@@ -6,7 +6,7 @@ export const withTimeout = async <T>(
   promise: Promise<T>,
   t: number
 ): Promise<T> => {
-  let timeoutId: ReturnType<typeof setTimeout>
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(
       () => reject(new TimeoutError(`withTimeout: timed out after ${t}ms`)),
@@ -16,7 +16,7 @@ export const withTimeout = async <T>(
   try {
     return await Promise.race([promise, timeoutPromise])
   } finally {
-    clearTimeout(timeoutId!)
+    clearTimeout(timeoutId)
   }
 }
 

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -76,4 +76,4 @@ export type {
   WelcomeMessage,
 } from "./network/messages.js"
 export type { StorageKey } from "./storage/StorageAdapter.js"
-export type * from "./types.js"
+export * from "./types.js"

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -24,8 +24,8 @@ function keyHash(binary: Uint8Array) {
 }
 
 function headsHash(heads: A.Heads): string {
-  let encoder = new TextEncoder()
-  let headsbinary = mergeArrays(heads.map((h: string) => encoder.encode(h)))
+  const encoder = new TextEncoder()
+  const headsbinary = mergeArrays(heads.map((h: string) => encoder.encode(h)))
   return keyHash(headsbinary)
 }
 
@@ -53,7 +53,7 @@ export class StorageSubsystem {
       if (!this.#chunkInfos.has(documentId)) {
         this.#chunkInfos.set(documentId, [])
       }
-      this.#chunkInfos.get(documentId)!!.push({
+      this.#chunkInfos.get(documentId)!.push({
         key,
         type: "incremental",
         size: binary.length,
@@ -122,18 +122,18 @@ export class StorageSubsystem {
     if (!this.#shouldSave(documentId, doc)) {
       return
     }
-    let sourceChunks = this.#chunkInfos.get(documentId) ?? []
+    const sourceChunks = this.#chunkInfos.get(documentId) ?? []
     if (this.#shouldCompact(sourceChunks)) {
-      this.#saveTotal(documentId, doc, sourceChunks)
+      void this.#saveTotal(documentId, doc, sourceChunks)
     } else {
-      this.#saveIncremental(documentId, doc)
+      void this.#saveIncremental(documentId, doc)
     }
     this.#storedHeads.set(documentId, A.getHeads(doc))
   }
 
   async remove(documentId: DocumentId) {
-    this.#storageAdapter.removeRange([documentId, "snapshot"])
-    this.#storageAdapter.removeRange([documentId, "incremental"])
+    void this.#storageAdapter.removeRange([documentId, "snapshot"])
+    void this.#storageAdapter.removeRange([documentId, "incremental"])
   }
 
   #shouldSave(documentId: DocumentId, doc: A.Doc<unknown>): boolean {

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -112,7 +112,7 @@ export class CollectionSynchronizer extends Synchronizer {
     this.#peers.add(peerId)
     for (const docSynchronizer of Object.values(this.#docSynchronizers)) {
       const { documentId } = docSynchronizer
-      this.repo.sharePolicy(peerId, documentId).then(okToShare => {
+      void this.repo.sharePolicy(peerId, documentId).then(okToShare => {
         if (okToShare) docSynchronizer.beginSync([peerId])
       })
     }

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -43,7 +43,7 @@ export class DocSynchronizer extends Synchronizer {
 
   #syncStarted = false
 
-  constructor(private handle: DocHandle<any>) {
+  constructor(private handle: DocHandle<unknown>) {
     super()
     const docId = handle.documentId.slice(0, 5)
     this.#conciseLog = debug(`automerge-repo:concise:docsync:${docId}`) // Only logs one line per receive/send
@@ -80,7 +80,9 @@ export class DocSynchronizer extends Synchronizer {
     this.#peers.forEach(peerId => this.#sendSyncMessage(peerId, doc))
   }
 
-  async #broadcastToPeers({ data }: DocHandleOutboundEphemeralMessagePayload) {
+  async #broadcastToPeers({
+    data,
+  }: DocHandleOutboundEphemeralMessagePayload<unknown>) {
     this.#log(`broadcastToPeers`, this.#peers)
     this.#peers.forEach(peerId => this.#sendEphemeralMessage(peerId, data))
   }


### PR DESCRIPTION
This is mostly cosmetic, but means we should all have fewer errors cluttering our workspaces. No functional changes here.