### PR TITLE
remove the second join

### DIFF
--- a/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
@@ -68,8 +68,6 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
         this.emit("ready", { network: this })
       }
     }, 1000)
-
-    this.join()
   }
 
   join() {


### PR DESCRIPTION
As I'm tracking down an unrelated bug on the network side I noticed we were "join()"ing twice. I think we just need the top one. Alex, you're probably most up-to-speed on this but the tests pass and it seems to me like this should work?