### PR TITLE
Remove diff

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -61,7 +61,7 @@ export class Repo extends EventEmitter<RepoEvents> {
           // Try to load from disk
           const loaded = await storageSubsystem.loadDoc(handle.documentId)
           if (loaded) {
-            handle.update(() => loaded)
+            handle.updateWithPatches(() => loaded)
           }
         }
       }
@@ -223,7 +223,7 @@ export class Repo extends EventEmitter<RepoEvents> {
 
     const handle = this.create<T>()
 
-    handle.update(() => {
+    handle.updateWithPatches(() => {
       // we replace the document with the new cloned one
       return {
         doc: Automerge.clone(sourceDoc),

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -61,7 +61,13 @@ export class Repo extends EventEmitter<RepoEvents> {
           // Try to load from disk
           const loadedDoc = await storageSubsystem.loadDoc(handle.documentId)
           if (loadedDoc) {
-            handle.update(() => loadedDoc)
+            handle.update(() => ({
+              patches: [],
+              patchInfo: {
+                after: loadedDoc,
+                source: "load",
+              },
+            }))
           }
         }
       }
@@ -198,9 +204,9 @@ export class Repo extends EventEmitter<RepoEvents> {
    * @param clonedHandle - The handle to clone
    *
    * @remarks This is a wrapper around the `clone` function in the Automerge library.
-   * The new `DocHandle` will have a new URL but will share history with the original, 
-   * which means that changes made to the cloned handle can be sensibly merged back 
-   * into the original. 
+   * The new `DocHandle` will have a new URL but will share history with the original,
+   * which means that changes made to the cloned handle can be sensibly merged back
+   * into the original.
    *
    * Any peers this `Repo` is connected to for whom `sharePolicy` returns `true` will
    * be notified of the newly created DocHandle.
@@ -223,9 +229,12 @@ export class Repo extends EventEmitter<RepoEvents> {
 
     const handle = this.create<T>()
 
-    handle.update((doc: Automerge.Doc<T>) => {
+    handle.update(() => {
       // we replace the document with the new cloned one
-      return Automerge.clone(sourceDoc)
+      return {
+        patches: [],
+        patchInfo: { after: Automerge.clone(sourceDoc), source: "clone" },
+      }
     })
 
     return handle

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -59,15 +59,9 @@ export class Repo extends EventEmitter<RepoEvents> {
           await storageSubsystem.saveDoc(handle.documentId, handle.docSync()!)
         } else {
           // Try to load from disk
-          const loadedDoc = await storageSubsystem.loadDoc(handle.documentId)
-          if (loadedDoc) {
-            handle.update(() => ({
-              patches: [],
-              patchInfo: {
-                after: loadedDoc,
-                source: "load",
-              },
-            }))
+          const loaded = await storageSubsystem.loadDoc(handle.documentId)
+          if (loaded) {
+            handle.update(() => loaded)
           }
         }
       }
@@ -232,8 +226,8 @@ export class Repo extends EventEmitter<RepoEvents> {
     handle.update(() => {
       // we replace the document with the new cloned one
       return {
+        doc: Automerge.clone(sourceDoc),
         patches: [],
-        patchInfo: { after: Automerge.clone(sourceDoc), source: "clone" },
       }
     })
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -61,7 +61,7 @@ export class Repo extends EventEmitter<RepoEvents> {
           // Try to load from disk
           const loaded = await storageSubsystem.loadDoc(handle.documentId)
           if (loaded) {
-            handle.updateWithPatches(() => loaded)
+            handle.update(() => loaded)
           }
         }
       }
@@ -223,7 +223,7 @@ export class Repo extends EventEmitter<RepoEvents> {
 
     const handle = this.create<T>()
 
-    handle.updateWithPatches(() => {
+    handle.update(() => {
       // we replace the document with the new cloned one
       return {
         doc: Automerge.clone(sourceDoc),

--- a/packages/automerge-repo/src/helpers/patchesFromChange.ts
+++ b/packages/automerge-repo/src/helpers/patchesFromChange.ts
@@ -1,0 +1,34 @@
+import * as A from "@automerge/automerge/next"
+
+export const patchesFromChange = <T>(
+  doc: A.Doc<T>,
+  change: A.ChangeFn<T>,
+  options: A.ChangeOptions<T> = {}
+) => {
+  let patches: A.Patch[] | undefined
+  let patchInfo: A.PatchInfo<T> | undefined
+
+  const originalCallback = options.patchCallback
+  options = {
+    ...options,
+    patchCallback: (p, pInfo) => {
+      patches = p
+      patchInfo = pInfo
+
+      // if a patchCallback was provided in the original options, call it
+      if (originalCallback) {
+        originalCallback(p, pInfo)
+      }
+    },
+  }
+
+  const newDoc = A.change(doc, options, change)
+
+  return {
+    patches: patches ?? [],
+    patchInfo: patchInfo ?? {
+      after: newDoc,
+      source: "change",
+    },
+  }
+}

--- a/packages/automerge-repo/src/helpers/patchesFromChange.ts
+++ b/packages/automerge-repo/src/helpers/patchesFromChange.ts
@@ -25,8 +25,10 @@ export const patchesFromChange = <T>(
   const newDoc = A.change(doc, options, change)
 
   return {
+    doc: newDoc,
     patches: patches ?? [],
     patchInfo: patchInfo ?? {
+      before: doc,
       after: newDoc,
       source: "change",
     },

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -267,7 +267,7 @@ export class DocSynchronizer extends Synchronizer {
       this.#peerDocumentStatuses[message.senderId] = "has"
     }
 
-    this.handle.update(doc => {
+    this.handle.updateWithPatches(doc => {
       let patches: A.Patch[] | undefined
       let patchInfo: A.PatchInfo<unknown> | undefined
       const [newDoc, newSyncState] = A.receiveSyncMessage(
@@ -290,12 +290,14 @@ export class DocSynchronizer extends Synchronizer {
       return {
         doc: newDoc,
         patches: patches ?? [],
-        patchInfo: patchInfo ?? {
-          after: newDoc,
-          before: doc,
-          source: "receiveSyncMessage",
-        },
-        syncState: message.senderId,
+        patchInfo:
+          patchInfo ??
+          ({
+            after: newDoc,
+            before: doc,
+            source: "receiveSyncMessage",
+          } as const),
+        sourcePeerId: message.senderId,
       }
     })
 

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -267,7 +267,7 @@ export class DocSynchronizer extends Synchronizer {
       this.#peerDocumentStatuses[message.senderId] = "has"
     }
 
-    this.handle.updateWithPatches(doc => {
+    this.handle.update(doc => {
       let patches: A.Patch[] | undefined
       let patchInfo: A.PatchInfo<unknown> | undefined
       const [newDoc, newSyncState] = A.receiveSyncMessage(

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -266,17 +266,30 @@ export class DocSynchronizer extends Synchronizer {
     }
 
     this.handle.update(doc => {
-      const [newDoc, newSyncState] = A.receiveSyncMessage(
+      // console.log(doc)
+      let patches: A.Patch[]
+      let patchInfo: A.PatchInfo<unknown>
+      const [_, newSyncState] = A.receiveSyncMessage(
         doc,
         this.#getSyncState(message.senderId),
-        message.data
+        message.data,
+        {
+          patchCallback: (p, pInfo) => {
+            patches = p
+            patchInfo = pInfo
+          },
+        }
       )
 
       this.#setSyncState(message.senderId, newSyncState)
 
       // respond to just this peer (as required)
       this.#sendSyncMessage(message.senderId, doc)
-      return newDoc
+
+      return {
+        patches: patches!,
+        patchInfo: patchInfo!,
+      }
     })
 
     this.#checkDocUnavailable()

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -268,10 +268,9 @@ export class DocSynchronizer extends Synchronizer {
     }
 
     this.handle.update(doc => {
-      // console.log(doc)
-      let patches: A.Patch[]
-      let patchInfo: A.PatchInfo<unknown>
-      const [_, newSyncState] = A.receiveSyncMessage(
+      let patches: A.Patch[] | undefined
+      let patchInfo: A.PatchInfo<unknown> | undefined
+      const [newDoc, newSyncState] = A.receiveSyncMessage(
         doc,
         this.#getSyncState(message.senderId),
         message.data,
@@ -289,8 +288,11 @@ export class DocSynchronizer extends Synchronizer {
       this.#sendSyncMessage(message.senderId, doc)
 
       return {
-        patches: patches!,
-        patchInfo: patchInfo!,
+        patches: patches ?? [],
+        patchInfo: patchInfo ?? {
+          after: newDoc,
+          source: "receiveSyncMessage",
+        },
       }
     })
 

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -288,11 +288,14 @@ export class DocSynchronizer extends Synchronizer {
       this.#sendSyncMessage(message.senderId, doc)
 
       return {
+        doc: newDoc,
         patches: patches ?? [],
         patchInfo: patchInfo ?? {
           after: newDoc,
+          before: doc,
           source: "receiveSyncMessage",
         },
+        syncState: message.senderId,
       }
     })
 

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -26,7 +26,7 @@ describe("DocHandle", () => {
     assert.equal(handle.isReady(), false)
 
     // simulate loading from storage
-    handle.updateWithPatches(doc => updateFromMockStorage(doc))
+    handle.update(doc => updateFromMockStorage(doc))
 
     assert.equal(handle.isReady(), true)
     const doc = await handle.doc()
@@ -38,7 +38,7 @@ describe("DocHandle", () => {
     assert.equal(handle.isReady(), false)
 
     // simulate loading from storage
-    handle.updateWithPatches(doc => updateFromMockStorage(doc))
+    handle.update(doc => updateFromMockStorage(doc))
 
     assert.equal(handle.isReady(), true)
     const doc = await handle.doc()
@@ -56,7 +56,7 @@ describe("DocHandle", () => {
     assert.equal(handle.isReady(), false)
 
     // simulate loading from storage
-    handle.updateWithPatches(doc => updateFromMockStorage(doc))
+    handle.update(doc => updateFromMockStorage(doc))
 
     const doc = await handle.doc()
 
@@ -72,7 +72,7 @@ describe("DocHandle", () => {
     assert.throws(() => handle.change(d => (d.foo = "baz")))
 
     // simulate loading from storage
-    handle.updateWithPatches(doc => updateFromMockStorage(doc))
+    handle.update(doc => updateFromMockStorage(doc))
 
     // now we're in READY state so we can make changes
     assert.equal(handle.isReady(), true)
@@ -100,7 +100,7 @@ describe("DocHandle", () => {
     handle.request()
 
     // simulate updating from the network
-    handle.updateWithPatches(doc => {
+    handle.update(doc => {
       return patchesFromChange(doc, d => (d.foo = "bar"))
     })
 
@@ -192,7 +192,7 @@ describe("DocHandle", () => {
       handle.once("change", () => {
         reject(new Error("shouldn't have changed"))
       })
-      handle.updateWithPatches(d => {
+      handle.update(d => {
         setTimeout(done, 0)
         return {
           doc: d,
@@ -297,7 +297,7 @@ describe("DocHandle", () => {
     const handle = new DocHandle<TestDoc>(TEST_ID, { timeoutDelay: 5 })
 
     // simulate loading from storage before the timeout expires
-    handle.updateWithPatches(doc => updateFromMockStorage(doc))
+    handle.update(doc => updateFromMockStorage(doc))
 
     // now it should not time out
     const doc = await handle.doc()
@@ -326,7 +326,7 @@ describe("DocHandle", () => {
     handle.request()
 
     // simulate updating from the network before the timeout expires
-    handle.updateWithPatches(doc => {
+    handle.update(doc => {
       return patchesFromChange(doc, d => (d.foo = "bar"))
     })
 

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -90,7 +90,7 @@ describe("DocHandle", () => {
 
     assert.equal(handle.docSync(), undefined)
     assert.equal(handle.isReady(), false)
-    assert.throws(() => handle.change(_ => { }))
+    assert.throws(() => handle.change(_ => {}))
   })
 
   it("should become ready if the document is updated by the network", async () => {
@@ -137,9 +137,11 @@ describe("DocHandle", () => {
       handle.update(d => {
         setTimeout(done, 0)
         return {
+          doc: d,
           patches: [],
           patchInfo: {
             after: d,
+            before: d,
             source: "change",
           },
         }

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -2,15 +2,11 @@ import assert from "assert"
 import { describe, it } from "vitest"
 import { DocHandle } from "../src/DocHandle.js"
 import { generateAutomergeUrl, parseAutomergeUrl } from "../src/DocUrl.js"
-import { generateAutomergeUrl, parseAutomergeUrl } from "../src/DocUrl.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import {
   DocumentUnavailableMessage,
   MessageContents,
 } from "../src/network/messages.js"
-import { DocSynchronizer } from "../src/synchronizer/DocSynchronizer.js"
-import { PeerId } from "../src/types.js"
-import { TestDoc } from "./types.js"
 import { DocSynchronizer } from "../src/synchronizer/DocSynchronizer.js"
 import { PeerId } from "../src/types.js"
 import { TestDoc } from "./types.js"

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -708,9 +708,9 @@ describe("Repo", () => {
         const doc =
           Math.random() < 0.5
             ? // heads, create a new doc
-              repo.create<TestDoc>()
+            repo.create<TestDoc>()
             : // tails, pick a random doc
-              (getRandomItem(docs) as DocHandle<TestDoc>)
+            (getRandomItem(docs) as DocHandle<TestDoc>)
 
         // make sure the doc is ready
         if (!doc.isReady()) {
@@ -857,7 +857,7 @@ describe("Repo", () => {
 
 const disableConsoleWarn = () => {
   console["_warn"] = console.warn
-  console.warn = () => {}
+  console.warn = () => { }
 }
 
 const reenableConsoleWarn = () => {

--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -34,7 +34,7 @@ describe("StorageSubsystem", () => {
         const reloadedDoc = await storage.loadDoc(key)
 
         // check that it's the same doc
-        assert.deepStrictEqual(reloadedDoc, doc)
+        assert.deepStrictEqual(reloadedDoc.doc, doc)
       })
     })
   })
@@ -60,7 +60,7 @@ describe("StorageSubsystem", () => {
     assert(reloadedDoc, "doc should be loaded")
 
     // make a change
-    const changedDoc = A.change<any>(reloadedDoc, "test 2", d => {
+    const changedDoc = A.change<any>(reloadedDoc.doc, "test 2", d => {
       d.foo = "baz"
     })
 


### PR DESCRIPTION
This PR:

- Uses the already calculated Patches from the patch callback when including patches in the `change` event callback
- Adds the correct patch source
- Adds an additional `sourcePeerId` property when a change has originated from a sync message

#### TODO
- [x] Add tests for patch source

Closes #167