### PR TITLE
Some fixes

### DIFF
--- a/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
@@ -31,6 +31,7 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   connect(peerId: PeerId) {
+    this.socket?.removeAllListeners()
     if (!this.timerId) {
       this.timerId = setInterval(() => this.connect(peerId), 5000)
     }
@@ -43,7 +44,6 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
       log(`@ ${this.url}: open`)
       clearInterval(this.timerId)
       this.timerId = undefined
-      this.join()
     })
 
     // When a socket closes, or disconnects, remove it from the array.

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -129,11 +129,11 @@ export class DocSynchronizer extends Synchronizer {
     const [newSyncState, message] = A.generateSyncMessage(doc, syncState)
     this.#setSyncState(peerId, newSyncState)
     if (message) {
-      const decoded = A.decodeSyncMessage(message)
+      const isNew = A.getHeads(doc).length === 0
 
       if (
         !this.handle.isReady() &&
-        decoded.heads.length === 0 &&
+        isNew &&
         newSyncState.sharedHeads.length === 0 &&
         !Object.values(this.#peerDocumentStatuses).includes("has") &&
         this.#peerDocumentStatuses[peerId] === "unknown"
@@ -155,7 +155,7 @@ export class DocSynchronizer extends Synchronizer {
       }
 
       // if we have sent heads, then the peer now has or will have the document
-      if (decoded.heads.length > 0) {
+      if (!isNew) {
         this.#peerDocumentStatuses[peerId] = "has"
       }
     }


### PR DESCRIPTION
This PR fixes a number of issues which are leading to apparent sync failures when the sync server is running slowly:

* Most importantly, fix a bug where an unavailable document never transition to requesting if a peer is announced on the network adapter after the document has been marked as unavilable
* Clean up event handlers on the websocket client adapter. This was causing occasional exceptions when messages arrived on the old event handlers and attempted to send messages on a new (reconnected) socket which was not ready
* Avoid decoding sync messages before sending them - this can be quite expensive