### PR TITLE
housekeeping: clean up imports

### DIFF
--- a/packages/automerge-repo/fuzz/fuzz.ts
+++ b/packages/automerge-repo/fuzz/fuzz.ts
@@ -1,13 +1,15 @@
-import assert from "assert"
 import { MessageChannelNetworkAdapter } from "@automerge/automerge-repo-network-messagechannel"
 import * as Automerge from "@automerge/automerge/next"
-
-import { DocHandle, DocumentId, PeerId, SharePolicy } from "../src"
+import assert from "assert"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
-import { Repo } from "../src/Repo.js"
-import { DummyNetworkAdapter } from "../test/helpers/DummyNetworkAdapter.js"
-import { DummyStorageAdapter } from "../test/helpers/DummyStorageAdapter.js"
+import {
+  DocHandle,
+  DocumentId,
+  PeerId,
+  Repo,
+  SharePolicy,
+} from "../src/index.js"
 import { getRandomItem } from "../test/helpers/getRandomItem.js"
 
 interface TestDoc {

--- a/packages/automerge-repo/fuzz/tsconfig.json
+++ b/packages/automerge-repo/fuzz/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "Node16",
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -14,12 +14,11 @@ import {
   TypegenDisabled,
 } from "xstate"
 import { waitFor } from "xstate/lib/waitFor.js"
-import { headsAreSame } from "./helpers/headsAreSame.js"
-import { pause } from "./helpers/pause.js"
-import { TimeoutError, withTimeout } from "./helpers/withTimeout.js"
-import type { DocumentId, PeerId, AutomergeUrl } from "./types.js"
 import { stringifyAutomergeUrl } from "./DocUrl.js"
 import { encode } from "./helpers/cbor.js"
+import { headsAreSame } from "./helpers/headsAreSame.js"
+import { withTimeout } from "./helpers/withTimeout.js"
+import type { AutomergeUrl, DocumentId, PeerId } from "./types.js"
 
 /** DocHandle is a wrapper around a single Automerge document that lets us
  * listen for changes and notify the network and storage of new changes.

--- a/packages/automerge-repo/src/DocUrl.ts
+++ b/packages/automerge-repo/src/DocUrl.ts
@@ -29,7 +29,9 @@ export const parseAutomergeUrl = (url: AutomergeUrl) => {
  */
 export const stringifyAutomergeUrl = ({
   documentId,
-}: {documentId: DocumentId | BinaryDocumentId}): AutomergeUrl => {
+}: {
+  documentId: DocumentId | BinaryDocumentId
+}): AutomergeUrl => {
   if (documentId instanceof Uint8Array)
     return (urlPrefix +
       binaryToDocumentId(documentId as BinaryDocumentId)) as AutomergeUrl

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -1,21 +1,19 @@
+import { next as Automerge } from "@automerge/automerge"
 import debug from "debug"
+import { EventEmitter } from "eventemitter3"
+import { DocHandle } from "./DocHandle.js"
+import {
+  generateAutomergeUrl,
+  isValidAutomergeUrl,
+  parseAutomergeUrl,
+  parseLegacyUUID,
+} from "./DocUrl.js"
 import { NetworkAdapter } from "./network/NetworkAdapter.js"
 import { NetworkSubsystem } from "./network/NetworkSubsystem.js"
 import { StorageAdapter } from "./storage/StorageAdapter.js"
 import { StorageSubsystem } from "./storage/StorageSubsystem.js"
 import { CollectionSynchronizer } from "./synchronizer/CollectionSynchronizer.js"
-import { type AutomergeUrl, DocumentId, PeerId } from "./types.js"
-
-import {
-  parseAutomergeUrl,
-  generateAutomergeUrl,
-  isValidAutomergeUrl,
-  parseLegacyUUID,
-} from "./DocUrl.js"
-
-import { DocHandle } from "./DocHandle.js"
-import { EventEmitter } from "eventemitter3"
-import { next as Automerge } from "@automerge/automerge"
+import { DocumentId, PeerId, type AutomergeUrl } from "./types.js"
 
 /** A Repo is a collection of documents with networking, syncing, and storage capabilities. */
 /** The `Repo` is the main entry point of this library

--- a/packages/automerge-repo/src/helpers/headsAreSame.ts
+++ b/packages/automerge-repo/src/helpers/headsAreSame.ts
@@ -1,4 +1,4 @@
-import {Heads} from "@automerge/automerge/next"
+import { Heads } from "@automerge/automerge/next"
 import { arraysAreEqual } from "./arraysAreEqual.js"
 
 export const headsAreSame = (a: Heads, b: Heads) => {

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -26,16 +26,16 @@
  * ```
  */
 
-export { Repo } from "./Repo.js"
 export { DocHandle } from "./DocHandle.js"
-export { NetworkAdapter } from "./network/NetworkAdapter.js"
-export { StorageAdapter } from "./storage/StorageAdapter.js"
 export {
   isValidAutomergeUrl,
   parseAutomergeUrl,
   stringifyAutomergeUrl,
 } from "./DocUrl.js"
+export { Repo } from "./Repo.js"
+export { NetworkAdapter } from "./network/NetworkAdapter.js"
 export { isValidRepoMessage } from "./network/messages.js"
+export { StorageAdapter } from "./storage/StorageAdapter.js"
 
 /** @hidden **/
 export * as cbor from "./helpers/cbor.js"

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -4,8 +4,8 @@ import { PeerId, SessionId } from "../types.js"
 import { NetworkAdapter, PeerDisconnectedPayload } from "./NetworkAdapter.js"
 import {
   EphemeralMessage,
-  RepoMessage,
   MessageContents,
+  RepoMessage,
   isEphemeralMessage,
   isValidRepoMessage,
 } from "./messages.js"

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -1,10 +1,10 @@
 import * as A from "@automerge/automerge/next"
-import { StorageAdapter, StorageKey } from "./StorageAdapter.js"
-import * as sha256 from "fast-sha256"
-import { type DocumentId } from "../types.js"
-import { mergeArrays } from "../helpers/mergeArrays.js"
 import debug from "debug"
+import * as sha256 from "fast-sha256"
 import { headsAreSame } from "../helpers/headsAreSame.js"
+import { mergeArrays } from "../helpers/mergeArrays.js"
+import { type DocumentId } from "../types.js"
+import { StorageAdapter, StorageKey } from "./StorageAdapter.js"
 
 // Metadata about a chunk of data loaded from storage. This is stored on the
 // StorageSubsystem so when we are compacting we know what chunks we can safely delete

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -1,12 +1,12 @@
+import debug from "debug"
 import { DocHandle } from "../DocHandle.js"
 import { stringifyAutomergeUrl } from "../DocUrl.js"
 import { Repo } from "../Repo.js"
+import { RepoMessage } from "../network/messages.js"
 import { DocumentId, PeerId } from "../types.js"
 import { DocSynchronizer } from "./DocSynchronizer.js"
 import { Synchronizer } from "./Synchronizer.js"
 
-import debug from "debug"
-import { RepoMessage } from "../network/messages.js"
 const log = debug("automerge-repo:collectionsync")
 
 /** A CollectionSynchronizer is responsible for synchronizing a DocCollection with peers. */

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -11,8 +11,8 @@ import {
 import {
   DocumentUnavailableMessage,
   EphemeralMessage,
-  RepoMessage,
   MessageContents,
+  RepoMessage,
   RequestMessage,
   SyncMessage,
   isRequestMessage,
@@ -28,8 +28,6 @@ type PeerDocumentStatus = "unknown" | "has" | "unavailable" | "wants"
  */
 export class DocSynchronizer extends Synchronizer {
   #log: debug.Debugger
-  #conciseLog: debug.Debugger
-  #opsLog: debug.Debugger
 
   /** Active peers */
   #peers: PeerId[] = []
@@ -46,9 +44,7 @@ export class DocSynchronizer extends Synchronizer {
   constructor(private handle: DocHandle<unknown>) {
     super()
     const docId = handle.documentId.slice(0, 5)
-    this.#conciseLog = debug(`automerge-repo:concise:docsync:${docId}`) // Only logs one line per receive/send
     this.#log = debug(`automerge-repo:docsync:${docId}`)
-    this.#opsLog = debug(`automerge-repo:ops:docsync:${docId}`) // Log list of ops of each message
 
     handle.on("change", () => this.#syncWithPeers())
 

--- a/packages/automerge-repo/src/synchronizer/Synchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/Synchronizer.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "eventemitter3"
-import { RepoMessage, MessageContents } from "../network/messages.js"
+import { MessageContents, RepoMessage } from "../network/messages.js"
 
 export abstract class Synchronizer extends EventEmitter<SynchronizerEvents> {
   abstract receiveMessage(message: RepoMessage): void

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert"
-import { describe, it, beforeEach } from "vitest"
+import { beforeEach, describe, it } from "vitest"
 import { PeerId, Repo } from "../src/index.js"
 import { CollectionSynchronizer } from "../src/synchronizer/CollectionSynchronizer.js"
 

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -1,6 +1,6 @@
 import * as A from "@automerge/automerge/next"
-import { decode } from "cbor-x"
 import assert from "assert"
+import { decode } from "cbor-x"
 import { describe, it } from "vitest"
 import { generateAutomergeUrl, parseAutomergeUrl } from "../src/DocUrl.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -2,15 +2,11 @@ import assert from "assert"
 import { describe, it } from "vitest"
 import { DocHandle } from "../src/DocHandle.js"
 import { generateAutomergeUrl, parseAutomergeUrl } from "../src/DocUrl.js"
-import { generateAutomergeUrl, parseAutomergeUrl } from "../src/DocUrl.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import {
   DocumentUnavailableMessage,
   MessageContents,
 } from "../src/network/messages.js"
-import { DocSynchronizer } from "../src/synchronizer/DocSynchronizer.js"
-import { PeerId } from "../src/types.js"
-import { TestDoc } from "./types.js"
 import { DocSynchronizer } from "../src/synchronizer/DocSynchronizer.js"
 import { PeerId } from "../src/types.js"
 import { TestDoc } from "./types.js"

--- a/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
@@ -11,10 +11,12 @@ export class DummyStorageAdapter implements StorageAdapter {
     return key.split(".")
   }
 
-  async loadRange(keyPrefix: StorageKey): Promise<{data: Uint8Array, key: StorageKey}[]> {
+  async loadRange(
+    keyPrefix: StorageKey
+  ): Promise<{ data: Uint8Array; key: StorageKey }[]> {
     const range = Object.entries(this.#data)
       .filter(([key, _]) => key.startsWith(this.#keyToString(keyPrefix)))
-      .map(([key, data]) => ({key: this.#stringToKey(key), data}))
+      .map(([key, data]) => ({ key: this.#stringToKey(key), data }))
     return Promise.resolve(range)
   }
 


### PR DESCRIPTION
I've just used VS Code's "organize imports" to remove unused imports and organize imports throughout. Also includes prettier auto-formatting in a couple of spots. 