### PR TITLE
Set moduleResolution to Bundler in examples

### DIFF
--- a/examples/react-counter/tsconfig.json
+++ b/examples/react-counter/tsconfig.json
@@ -8,7 +8,7 @@
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,

--- a/examples/react-todo/tsconfig.json
+++ b/examples/react-todo/tsconfig.json
@@ -8,7 +8,7 @@
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,

--- a/examples/svelte-counter/tsconfig.json
+++ b/examples/svelte-counter/tsconfig.json
@@ -8,7 +8,7 @@
     "isolatedModules": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,


### PR DESCRIPTION
I meant to include this commit in #193. This resolves the issue with types for `useDocument` etc. 