### PR TITLE
Remove build command from examples/react-use-awareness

### DIFF
--- a/examples/react-use-awareness/package.json
+++ b/examples/react-use-awareness/package.json
@@ -2,17 +2,16 @@
   "name": "automerge-use-awareness-example-project",
   "repository": "https://github.com/automerge/automerge-repo/tree/master/examples/react-use-awareness",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@automerge/automerge-repo": "^1.0.7",
-    "@automerge/automerge-repo-network-broadcastchannel": "^1.0.7",
-    "@automerge/automerge-repo-react-hooks": "^1.0.7",
+    "@automerge/automerge-repo": "^1.0.6",
+    "@automerge/automerge-repo-network-broadcastchannel": "^1.0.6",
+    "@automerge/automerge-repo-react-hooks": "^1.0.6",
     "eventemitter3": "^5.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Running `build` from the monorepo root builds all packages that have a build command. There's never any reason to build the examples, and it slows things down. 