### PR TITLE
Refactor repo tests

### DIFF
--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -25,7 +25,7 @@ import { getRandomItem } from "./helpers/getRandomItem.js"
 import { TestDoc } from "./types.js"
 
 describe("Repo", () => {
-  describe("single repo", () => {
+  describe("local only", () => {
     const setup = ({ startReady = true } = {}) => {
       const storageAdapter = new DummyStorageAdapter()
       const networkAdapter = new DummyNetworkAdapter({ startReady })
@@ -377,7 +377,7 @@ describe("Repo", () => {
     })
   })
 
-  describe("sync", async () => {
+  describe("with peers", async () => {
     const charlieExcludedDocuments: DocumentId[] = []
     const bobExcludedDocuments: DocumentId[] = []
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -182,7 +182,7 @@ describe("Repo", () => {
     })
 
     it("doesn't mark a document as unavailable until network adapters are ready", async () => {
-      const { repo, networkAdapter } = setup(false)
+      const { repo, networkAdapter } = setup({ startReady: false })
       const url = generateAutomergeUrl()
       const handle = repo.find<TestDoc>(url)
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -26,9 +26,9 @@ import { TestDoc } from "./types.js"
 
 describe("Repo", () => {
   describe("single repo", () => {
-    const setup = (networkReady = true) => {
+    const setup = ({ startReady = true } = {}) => {
       const storageAdapter = new DummyStorageAdapter()
-      const networkAdapter = new DummyNetworkAdapter(networkReady)
+      const networkAdapter = new DummyNetworkAdapter({ startReady })
 
       const repo = new Repo({
         storage: storageAdapter,

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -632,7 +632,7 @@ describe("Repo", () => {
       const a = new Repo({
         network: [new MessageChannelNetworkAdapter(ab)],
         peerId: "a" as PeerId,
-        sharePolicy: async () => true
+        sharePolicy: async () => true,
       })
 
       const handle = a.find(url)
@@ -652,7 +652,6 @@ describe("Repo", () => {
       // The empty repo should be notified of the new peer, send it a request
       // and eventually resolve the handle to "READY"
       await handle.whenReady()
-
     })
 
     it("a deleted document from charlieRepo can be refetched", async () => {
@@ -895,11 +894,13 @@ describe("Repo", () => {
   })
 })
 
+const warn = console.warn
+const NO_OP = () => {}
+
 const disableConsoleWarn = () => {
-  console["_warn"] = console.warn
-  console.warn = () => {}
+  console.warn = NO_OP
 }
 
 const reenableConsoleWarn = () => {
-  console.warn = console["_warn"]
+  console.warn = warn
 }

--- a/packages/automerge-repo/test/helpers/DummyNetworkAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyNetworkAdapter.ts
@@ -1,16 +1,21 @@
 import { NetworkAdapter } from "../../src/index.js"
 
 export class DummyNetworkAdapter extends NetworkAdapter {
-  #startReady = true
-  constructor(startReady: boolean) {
+  #startReady: boolean
+
+  constructor({ startReady = true }: Options = {}) {
     super()
     this.#startReady = startReady
   }
-  send() { }
+  send() {}
   connect(_: string) {
     if (this.#startReady) {
       this.emit("ready", { network: this })
     }
   }
-  disconnect() { }
+  disconnect() {}
+}
+
+type Options = {
+  startReady?: boolean
 }


### PR DESCRIPTION
Uses named parameters for clarity, e.g. `setup({startReady: false})` instead of `setup(false)`

Separates tests into three describe blocks, each with its own setup: 
- local only
- with peers (linear network) 
- with peers (mesh network)

Keeps everything contained within either the test closure or the setup closure, to prevent tests from stepping on each other. 