### PR TITLE
Remove adapter-specific message types from automerge-repo

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -14,12 +14,7 @@
  *
  */
 
-import {
-  Message,
-  NetworkAdapter,
-  PeerId,
-  RepoMessage,
-} from "@automerge/automerge-repo"
+import { Message, NetworkAdapter, PeerId } from "@automerge/automerge-repo"
 
 export type BroadcastChannelNetworkAdapterOptions = {
   channelName: string

--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -41,7 +41,7 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
 
     this.#broadcastChannel.addEventListener(
       "message",
-      (e: { data: Message }) => {
+      (e: { data: BroadcastChannelMessage }) => {
         const message = e.data
         if ("targetId" in message && message.targetId !== this.peerId) {
           return
@@ -87,7 +87,7 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
     this.emit("peer-candidate", { peerId })
   }
 
-  send(message: RepoMessage) {
+  send(message: Message) {
     if ("data" in message) {
       this.#broadcastChannel.postMessage({
         ...message,
@@ -106,3 +106,27 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
     throw new Error("Unimplemented: leave on BroadcastChannelNetworkAdapter")
   }
 }
+
+/** Notify the network that we have arrived so everyone knows our peer ID */
+type ArriveMessage = {
+  type: "arrive"
+
+  /** The peer ID of the sender of this message */
+  senderId: PeerId
+
+  /** Arrive messages don't have a targetId */
+  targetId: never
+}
+
+/** Respond to an arriving peer with our peer ID */
+type WelcomeMessage = {
+  type: "welcome"
+
+  /** The peer ID of the recipient sender this message */
+  senderId: PeerId
+
+  /** The peer ID of the recipient of this message */
+  targetId: PeerId
+}
+
+type BroadcastChannelMessage = ArriveMessage | WelcomeMessage | Message

--- a/packages/automerge-repo-network-websocket/src/messages.ts
+++ b/packages/automerge-repo-network-websocket/src/messages.ts
@@ -1,4 +1,4 @@
-import { type RepoMessage, type PeerId } from "@automerge/automerge-repo"
+import { Message, type PeerId } from "@automerge/automerge-repo"
 import { ProtocolVersion } from "./protocolVersion.js"
 
 /** The sender is disconnecting */
@@ -42,7 +42,7 @@ export type ErrorMessage = {
 // join/leave
 
 /** A message from the client to the server */
-export type FromClientMessage = JoinMessage | LeaveMessage | RepoMessage
+export type FromClientMessage = JoinMessage | LeaveMessage | Message
 
 /** A message from the server to the client */
-export type FromServerMessage = PeerMessage | ErrorMessage | RepoMessage
+export type FromServerMessage = PeerMessage | ErrorMessage | Message

--- a/packages/automerge-repo-network-websocket/src/messages.ts
+++ b/packages/automerge-repo-network-websocket/src/messages.ts
@@ -1,5 +1,5 @@
-import { Message, type PeerId } from "@automerge/automerge-repo"
-import { ProtocolVersion } from "./protocolVersion.js"
+import type { Message, PeerId } from "@automerge/automerge-repo"
+import type { ProtocolVersion } from "./protocolVersion.js"
 
 /** The sender is disconnecting */
 export type LeaveMessage = {

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -66,14 +66,12 @@ export type {
   PeerDisconnectedPayload,
 } from "./network/NetworkAdapter.js"
 export type {
-  ArriveMessage,
   DocumentUnavailableMessage,
   EphemeralMessage,
   Message,
   RepoMessage,
   RequestMessage,
   SyncMessage,
-  WelcomeMessage,
 } from "./network/messages.js"
 export type { StorageKey } from "./storage/StorageAdapter.js"
 export * from "./types.js"

--- a/packages/automerge-repo/src/network/NetworkAdapter.ts
+++ b/packages/automerge-repo/src/network/NetworkAdapter.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "eventemitter3"
 import { PeerId } from "../types.js"
-import { RepoMessage } from "./messages.js"
+import { Message } from "./messages.js"
 
 /** An interface representing some way to connect to other peers
  *
@@ -22,7 +22,7 @@ export abstract class NetworkAdapter extends EventEmitter<NetworkAdapterEvents> 
    *
    * @argument message - the message to send
    */
-  abstract send(message: RepoMessage): void
+  abstract send(message: Message): void
 
   /** Called by the {@link Repo} to disconnect from the network */
   abstract disconnect(): void
@@ -44,7 +44,7 @@ export interface NetworkAdapterEvents {
   "peer-disconnected": (payload: PeerDisconnectedPayload) => void
 
   /** Emitted when the network adapter receives a message from a peer */
-  message: (payload: RepoMessage) => void
+  message: (payload: Message) => void
 }
 
 export interface OpenPayload {

--- a/packages/automerge-repo/src/network/messages.ts
+++ b/packages/automerge-repo/src/network/messages.ts
@@ -87,26 +87,18 @@ export type RequestMessage = {
   documentId: DocumentId
 }
 
-/** Notify the network that we have arrived so everyone knows our peer ID */
-export type ArriveMessage = {
-  type: "arrive"
+/** (anticipating work in progress) */
+export type AuthMessage<TPayload = any> = {
+  type: "auth"
 
   /** The peer ID of the sender of this message */
   senderId: PeerId
 
-  /** Arrive messages don't have a targetId */
-  targetId: never
-}
-
-/** Respond to an arriving peer with our peer ID */
-export type WelcomeMessage = {
-  type: "welcome"
-
-  /** The peer ID of the recipient sender this message */
-  senderId: PeerId
-
   /** The peer ID of the recipient of this message */
   targetId: PeerId
+
+  /** The payload of the auth message (up to the specific auth provider) */
+  payload: TPayload
 }
 
 /** These are message types that a {@link NetworkAdapter} surfaces to a {@link Repo}. */

--- a/packages/automerge-repo/src/network/messages.ts
+++ b/packages/automerge-repo/src/network/messages.ts
@@ -108,13 +108,8 @@ export type RepoMessage =
   | RequestMessage
   | DocumentUnavailableMessage
 
-/** These are all the message types that a {@link NetworkAdapter} might see.
- *
- * @remarks
- * It is not _required_ that a {@link NetworkAdapter} use these types: They are free to use
- * whatever message type makes sense for their transport. However, this type is a useful default.
- * */
-export type Message = RepoMessage | ArriveMessage | WelcomeMessage
+/** These are all the message types that a {@link NetworkAdapter} might see. */
+export type Message = RepoMessage | AuthMessage
 
 /**
  * The contents of a message, without the sender ID or other properties added by the {@link NetworkSubsystem})


### PR DESCRIPTION
`automerge-repo` currently exposes two union types for messages:
- `RepoMessage` includes all message types that a network adapter emits to the `Repo`. 
- `Message` includes all of these plus `ArriveMessage` and `WelcomeMessage`, which are message types used by some network adapters but not others. 

In anticipation of the AuthProvider work, I'm introducing an `AuthMessage` type, which doesn't fit into either of these categories: It's not `Message`, because _all_ network adapters need to be able to handle it, not just the ones that have `arrive` and `welcome`; and it's not a `RepoMessage` because it's not surfaced to the `Repo`. 

The abstract `NetworkAdapter` needs a message type that `automerge-repo` expects _every_ adapter implementation to accept, and that should be `Message`. 

This PR removes `arrive` and `welcome` messages from `automerge-repo`, leaving it entirely up to each network adapter what kind of internal messages to use. That means that we have some duplicate type definitions between `MessageChannelNetworkAdapter` and `BroadcastChannelNetworkAdapter` but that's OK. 

`Message` is redefined as `RepoMessage | AuthMessage`, and each adapter extends that type with its own internal message types. 



