### PR TITLE
Add arbitrary key-value storage

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -106,7 +106,7 @@ export class Repo extends EventEmitter<RepoEvents> {
       // synchronizer.removeDocument(documentId)
 
       if (storageSubsystem) {
-        storageSubsystem.remove(documentId).catch(err => {
+        storageSubsystem.removeDoc(documentId).catch(err => {
           this.#log("error deleting document", { documentId, err })
         })
       }

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -52,6 +52,7 @@ export type {
   DocHandleOutboundEphemeralMessagePayload,
   HandleState,
 } from "./DocHandle.js"
+
 export type {
   DeleteDocumentPayload,
   DocumentPayload,
@@ -59,12 +60,14 @@ export type {
   RepoEvents,
   SharePolicy,
 } from "./Repo.js"
+
 export type {
   NetworkAdapterEvents,
   OpenPayload,
   PeerCandidatePayload,
   PeerDisconnectedPayload,
 } from "./network/NetworkAdapter.js"
+
 export type {
   DocumentUnavailableMessage,
   EphemeralMessage,
@@ -73,5 +76,12 @@ export type {
   RequestMessage,
   SyncMessage,
 } from "./network/messages.js"
-export type { StorageKey } from "./storage/StorageAdapter.js"
+
+export type {
+  Chunk,
+  ChunkInfo,
+  ChunkType,
+  StorageKey,
+} from "./storage/types.js"
+
 export * from "./types.js"

--- a/packages/automerge-repo/src/storage/StorageAdapter.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapter.ts
@@ -1,41 +1,34 @@
+import { StorageKey, Chunk } from "./types.js"
+
 /** A storage adapter represents some way of storing binary data for a {@link Repo}
  *
  * @remarks
- * `StorageAdapter`s are a little like a key/value store. The keys are arrays
- * of strings ({@link StorageKey}) and the values are binary blobs.
+ * `StorageAdapter`s provide a key/value storage interface. The keys are arrays of strings
+ * ({@link StorageKey}) and the values are binary blobs.
  */
 export abstract class StorageAdapter {
-  // load, store, or remove a single binary blob based on an array key
-  // automerge-repo mostly uses keys in the following form:
-  // [documentId, "snapshot"] or [documentId, "incremental", "0"]
-  // but the storage adapter is agnostic to the meaning of the key
-  // and we expect to store other data in the future such as syncstates
-  /** Load the single blob correspongind to `key` */
+  /** Load the single value corresponding to `key` */
   abstract load(key: StorageKey): Promise<Uint8Array | undefined>
-  /** save the blod `data` to the key `key` */
+
+  /** Save the value `data` to the key `key` */
   abstract save(key: StorageKey, data: Uint8Array): Promise<void>
-  /** remove the blob corresponding to `key` */
+
+  /** Remove the value corresponding to `key` */
   abstract remove(key: StorageKey): Promise<void>
 
-  // the keyprefix will match any key that starts with the given array
-  // for example, [documentId, "incremental"] will match all incremental saves
-  // or [documentId] will match all data for a given document
-  // be careful! this will also match [documentId, "syncState"]!
-  // (we aren't using this yet but keep it in mind.)
-  /** Load all blobs with keys that start with `keyPrefix` */
-  abstract loadRange(keyPrefix: StorageKey): Promise<{key: StorageKey, data: Uint8Array}[]>
-  /** Remove all blobs with keys that start with `keyPrefix` */
+  /**
+   * Load all values with keys that start with `keyPrefix`.
+   *
+   * @remarks
+   * The `keyprefix` will match any key that starts with the given array. For example:
+   * - `[documentId, "incremental"]` will match all incremental saves
+   * - `[documentId]` will match all data for a given document.
+   *
+   * Be careful! `[documentId]` would also match something like `[documentId, "syncState"]`! We
+   * aren't using this yet but keep it in mind.)
+   */
+  abstract loadRange(keyPrefix: StorageKey): Promise<Chunk[]>
+
+  /** Remove all values with keys that start with `keyPrefix` */
   abstract removeRange(keyPrefix: StorageKey): Promise<void>
 }
-
-/** The type of keys for a {@link StorageAdapter}
- *
- * @remarks
- * Storage keys are arrays because they are hierarchical and the storage 
- * subsystem will need to be able to do range queries for all keys that
- * have a particular prefix. For example, incremental changes for a given
- * document might be stored under `[<documentId>, "incremental", <SHA256>]`.
- * `StorageAdapter` implementations should not assume any particular structure
- * though.
- **/
-export type  StorageKey = string[]

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -26,6 +26,57 @@ export class StorageSubsystem {
 
   constructor(private storageAdapter: StorageAdapter) {}
 
+  // ARBITRARY KEY/VALUE STORAGE
+
+  // The `load`, `save`, and `remove` methods are for generic key/value storage, as opposed to
+  // Automerge documents. For example, they're used by the LocalFirstAuthProvider to persist the
+  // encrypted team graph that encodes group membership and permissions.
+  //
+  // The namespace parameter is to prevent collisions with other users of the storage subsystem.
+  // Typically this will be the name of the plug-in, adapter, or other system that is using it. For
+  // example, the LocalFirstAuthProvider uses the namespace `LocalFirstAuthProvider`.
+
+  /** Loads a value from storage. */
+  async load(
+    /** Namespace to prevent collisions with other users of the storage subsystem. */
+    namespace: string,
+
+    /** Key to load. Typically a UUID or other unique identifier, but could be any string. */
+    key: string
+  ): Promise<Uint8Array | undefined> {
+    const storageKey = [namespace, key] as StorageKey
+    return await this.storageAdapter.load(storageKey)
+  }
+
+  /** Saves a value in storage. */
+  async save(
+    /** Namespace to prevent collisions with other users of the storage subsystem. */
+    namespace: string,
+
+    /** Key to load. Typically a UUID or other unique identifier, but could be any string. */
+    key: string,
+
+    /** Data to save, as a binary blob. */
+    data: Uint8Array
+  ): Promise<void> {
+    const storageKey = [namespace, key] as StorageKey
+    await this.storageAdapter.save(storageKey, data)
+  }
+
+  /** Removes a value from storage. */
+  async remove(
+    /** Namespace to prevent collisions with other users of the storage subsystem. */
+    namespace: string,
+
+    /** Key to remove. Typically a UUID or other unique identifier, but could be any string. */
+    key: string
+  ): Promise<void> {
+    const storageKey = [namespace, key] as StorageKey
+    await this.storageAdapter.remove(storageKey)
+  }
+
+  // AUTOMERGE DOCUMENT STORAGE
+
   /**
    * Loads the Automerge document with the given ID from storage.
    */

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -83,7 +83,7 @@ export class StorageSubsystem {
   /**
    * Removes the Automerge document with the given ID from storage
    */
-  async remove(documentId: DocumentId) {
+  async removeDoc(documentId: DocumentId) {
     void this.storageAdapter.removeRange([documentId, "snapshot"])
     void this.storageAdapter.removeRange([documentId, "incremental"])
   }

--- a/packages/automerge-repo/src/storage/chunkTypeFromKey.ts
+++ b/packages/automerge-repo/src/storage/chunkTypeFromKey.ts
@@ -1,0 +1,22 @@
+import { StorageKey } from "./types.js"
+import { ChunkType } from "./types.js"
+
+/**
+ * Keys for storing Automerge documents are of the form:
+ * ```ts
+ * [documentId, "snapshot", hash]  // OR
+ * [documentId, "incremental", hash]
+ * ```
+ * This function returns the chunk type ("snapshot" or "incremental") if the key is in one of these
+ * forms.
+ */
+export function chunkTypeFromKey(key: StorageKey): ChunkType | null {
+  if (key.length < 2) return null
+
+  const chunkTypeStr = key[key.length - 2] // next-to-last element in key
+  if (chunkTypeStr === "snapshot" || chunkTypeStr === "incremental") {
+    return chunkTypeStr as ChunkType
+  }
+
+  return null
+}

--- a/packages/automerge-repo/src/storage/keyHash.ts
+++ b/packages/automerge-repo/src/storage/keyHash.ts
@@ -1,0 +1,17 @@
+import * as A from "@automerge/automerge/next"
+import * as sha256 from "fast-sha256"
+import { mergeArrays } from "../helpers/mergeArrays.js"
+
+export function keyHash(binary: Uint8Array) {
+  // calculate hash
+  const hash = sha256.hash(binary)
+  return bufferToHexString(hash)
+}
+export function headsHash(heads: A.Heads): string {
+  const encoder = new TextEncoder()
+  const headsbinary = mergeArrays(heads.map((h: string) => encoder.encode(h)))
+  return keyHash(headsbinary)
+}
+function bufferToHexString(data: Uint8Array) {
+  return Array.from(data, byte => byte.toString(16).padStart(2, "0")).join("")
+}

--- a/packages/automerge-repo/src/storage/types.ts
+++ b/packages/automerge-repo/src/storage/types.ts
@@ -1,0 +1,39 @@
+/**
+ * A chunk is a snapshot or incremental change that is stored in a {@link StorageAdapter}.
+ */
+export type Chunk = {
+  key: StorageKey
+  data: Uint8Array
+}
+
+/**
+ * Metadata about a chunk of data loaded from storage. This is stored on the StorageSubsystem so
+ * when we are compacting we know what chunks we can safely delete.
+ */
+export type ChunkInfo = {
+  key: StorageKey
+  type: ChunkType
+  size: number
+}
+
+export type ChunkType = "snapshot" | "incremental"
+
+/**
+ * A storage key is an array of strings that represents a path to a value in a
+ * {@link StorageAdapter}.
+ *
+ * @remarks
+ * Storage keys are arrays because they are hierarchical and they allow the storage subsystem to do
+ * range queries for all keys that have a particular prefix. For example, incremental changes for a
+ * given document might be stored under `[<documentId>, "incremental", <SHA256>]`.
+ *
+ * automerge-repo mostly uses keys in the following form:
+ * ```ts
+ * [documentId, "snapshot", hash]  // OR
+ * [documentId, "incremental", hash]
+ * ```
+ *
+ * However, the storage adapter implementation should be agnostic to the meaning of the key and
+ * should not assume any particular structure.
+ **/
+export type StorageKey = string[]

--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -8,6 +8,8 @@ import { describe, it } from "vitest"
 import { generateAutomergeUrl, parseAutomergeUrl } from "../src/AutomergeUrl.js"
 import { StorageSubsystem } from "../src/storage/StorageSubsystem.js"
 import { DummyStorageAdapter } from "./helpers/DummyStorageAdapter.js"
+import { cbor } from "../src/index.js"
+import { pause } from "../src/helpers/pause.js"
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "automerge-repo-tests"))
 
@@ -19,7 +21,8 @@ describe("StorageSubsystem", () => {
 
   Object.entries(adaptersToTest).forEach(([adapterName, adapter]) => {
     describe(adapterName, () => {
-      it("can store and retrieve an Automerge document", async () => {
+      describe("Automerge document storage", () => {
+        it("stores and retrieves an Automerge document", async () => {
         const storage = new StorageSubsystem(adapter)
 
         const doc = A.change(A.init<any>(), "test", d => {
@@ -63,6 +66,91 @@ describe("StorageSubsystem", () => {
 
         // save it to storage
         storage2.saveDoc(key, changedDoc)
+        })
+
+        it("removes an Automerge document", async () => {
+          const storage = new StorageSubsystem(adapter)
+
+          const doc = A.change(A.init<any>(), "test", d => {
+            d.foo = "bar"
+          })
+
+          // save it to storage
+          const key = parseAutomergeUrl(generateAutomergeUrl()).documentId
+          await storage.saveDoc(key, doc)
+
+          // reload it from storage
+          const reloadedDoc = await storage.loadDoc(key)
+
+          // check that it's the same doc
+          assert.deepStrictEqual(reloadedDoc, doc)
+
+          // remove it
+          await storage.removeDoc(key)
+
+          // reload it from storage
+          const reloadedDoc2 = await storage.loadDoc(key)
+
+          // check that it's undefined
+          assert.equal(reloadedDoc2, undefined)
+        })
+      })
+
+      describe("Arbitrary key/value storage", () => {
+        it("stores and retrieves a blob", async () => {
+          const storage = new StorageSubsystem(adapter)
+
+          const value = cbor.encode({ foo: "bar" })
+
+          const namespace = "MyCoolAdapter"
+          const key = "ABC123"
+          await storage.save(namespace, key, value)
+
+          const reloadedValue = await storage.load(namespace, key)
+          assert.notEqual(reloadedValue, undefined)
+          assert.deepEqual(cbor.decode(reloadedValue)["foo"], "bar")
+        })
+
+        it("keeps namespaces separate", async () => {
+          const storage = new StorageSubsystem(adapter)
+
+          const key = "ABC123"
+
+          const namespace1 = "MyCoolAdapter"
+          const value1 = cbor.encode({ foo: "bar" })
+          await storage.save(namespace1, key, value1)
+
+          const namespace2 = "SomeDumbAdapter"
+          const value2 = cbor.encode({ baz: "pizza" })
+          await storage.save(namespace2, key, value2)
+
+          const reloadedValue1 = await storage.load(namespace1, key)
+          assert.notEqual(reloadedValue1, undefined)
+          assert.deepEqual(cbor.decode(reloadedValue1)["foo"], "bar")
+
+          const reloadedValue2 = await storage.load(namespace2, key)
+          assert.notEqual(reloadedValue2, undefined)
+          assert.deepEqual(cbor.decode(reloadedValue2)["baz"], "pizza")
+        })
+
+        it("removes a blob", async () => {
+          const storage = new StorageSubsystem(adapter)
+
+          const value = cbor.encode({ foo: "bar" })
+
+          const namespace = "MyCoolAdapter"
+          const key = "ABC123"
+          await storage.save(namespace, key, value)
+
+          const reloadedValue = await storage.load(namespace, key)
+          assert.notEqual(reloadedValue, undefined)
+          assert.deepEqual(cbor.decode(reloadedValue)["foo"], "bar")
+
+          await storage.remove(namespace, key)
+
+          const reloadedValue2 = await storage.load(namespace, key)
+          assert.equal(reloadedValue2, undefined)
+        })
       })
     })
   })


### PR DESCRIPTION
This PR adds support for arbitrary key-value storage to StorageSubsystem. The `load`, `save`, and `remove` methods are for generic key/value storage, and the `loadDoc`, `saveDoc`, and `removeDoc`  methods are for Automerge documents. 

For example, these will be used by the `LocalFirstAuthProvider` to persist the encrypted team graph that encodes group membership and permissions.

```ts
 const namespace = "MyCoolAdapter" 
 const key = "ABC123" 

 await storage.save(namespace, key, value) 
  
 const reloadedValue = await storage.load(namespace, key) 
  
 await storage.remove(namespace, key) 
```

The namespace parameter is to prevent collisions with other users of the storage subsystem.  Typically this will be the name of the plug-in, adapter, or other system that is using it. For example, the LocalFirstAuthProvider uses the namespace `LocalFirstAuthProvider`.
