### PR TITLE
StorageSubsystem: Fix bug with rapid-fire saves & concurrent reads

### DIFF
--- a/packages/automerge-repo-storage-indexeddb/src/index.ts
+++ b/packages/automerge-repo-storage-indexeddb/src/index.ts
@@ -4,7 +4,11 @@
  * @packageDocumentation
  */
 
-import {StorageAdapter, type StorageKey} from "@automerge/automerge-repo"
+import {
+  Chunk,
+  StorageAdapter,
+  type StorageKey,
+} from "@automerge/automerge-repo"
 
 export class IndexedDBStorageAdapter extends StorageAdapter {
   private dbPromise: Promise<IDBDatabase>
@@ -56,7 +60,7 @@ export class IndexedDBStorageAdapter extends StorageAdapter {
       request.onsuccess = event => {
         const result = (event.target as IDBRequest).result
         if (result && typeof result === "object" && "binary" in result) {
-          resolve((result as {binary: Uint8Array}).binary)
+          resolve((result as { binary: Uint8Array }).binary)
         } else {
           resolve(undefined)
         }
@@ -69,7 +73,7 @@ export class IndexedDBStorageAdapter extends StorageAdapter {
 
     const transaction = db.transaction(this.store, "readwrite")
     const objectStore = transaction.objectStore(this.store)
-    objectStore.put({key: keyArray, binary: binary}, keyArray)
+    objectStore.put({ key: keyArray, binary: binary }, keyArray)
 
     return new Promise((resolve, reject) => {
       transaction.onerror = () => {
@@ -98,7 +102,7 @@ export class IndexedDBStorageAdapter extends StorageAdapter {
     })
   }
 
-  async loadRange(keyPrefix: string[]): Promise<{data: Uint8Array, key: StorageKey}[]> {
+  async loadRange(keyPrefix: string[]): Promise<Chunk[]> {
     const db = await this.dbPromise
     const lowerBound = keyPrefix
     const upperBound = [...keyPrefix, "\uffff"]
@@ -107,7 +111,7 @@ export class IndexedDBStorageAdapter extends StorageAdapter {
     const transaction = db.transaction(this.store)
     const objectStore = transaction.objectStore(this.store)
     const request = objectStore.openCursor(range)
-    const result: {data: Uint8Array, key: StorageKey}[] = []
+    const result: { data: Uint8Array; key: StorageKey }[] = []
 
     return new Promise((resolve, reject) => {
       transaction.onerror = () => {
@@ -117,7 +121,10 @@ export class IndexedDBStorageAdapter extends StorageAdapter {
       request.onsuccess = event => {
         const cursor = (event.target as IDBRequest).result as IDBCursorWithValue
         if (cursor) {
-          result.push({data: (cursor.value as {binary: Uint8Array}).binary, key: cursor.key as StorageKey})
+          result.push({
+            data: (cursor.value as { binary: Uint8Array }).binary,
+            key: cursor.key as StorageKey,
+          })
           cursor.continue()
         } else {
           resolve(result)

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -3,7 +3,11 @@
  * A `StorageAdapter` which stores data in the local filesystem
  */
 
-import { StorageAdapter, type StorageKey } from "@automerge/automerge-repo"
+import {
+  Chunk,
+  StorageAdapter,
+  type StorageKey,
+} from "@automerge/automerge-repo"
 import fs from "fs"
 import path from "path"
 import { rimraf } from "rimraf"
@@ -59,9 +63,7 @@ export class NodeFSStorageAdapter extends StorageAdapter {
     }
   }
 
-  async loadRange(
-    keyPrefix: StorageKey
-  ): Promise<{ data: Uint8Array; key: StorageKey }[]> {
+  async loadRange(keyPrefix: StorageKey): Promise<Chunk[]> {
     /* This whole function does a bunch of gratuitious string manipulation
        and could probably be simplified. */
 
@@ -83,7 +85,7 @@ export class NodeFSStorageAdapter extends StorageAdapter {
     const allKeys = [...new Set([...cachedKeys, ...diskKeys])]
 
     // Load all files
-    const result = await Promise.all(
+    const chunks = await Promise.all(
       allKeys.map(async keyString => {
         const key: StorageKey = keyString.split(path.sep)
         const data = await this.load(key)
@@ -91,7 +93,7 @@ export class NodeFSStorageAdapter extends StorageAdapter {
       })
     )
 
-    return result
+    return chunks
   }
 
   async removeRange(keyPrefix: string[]): Promise<void> {

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -92,8 +92,12 @@ export class StorageSubsystem {
     const chunkInfos: ChunkInfo[] = []
 
     for (const chunk of chunks) {
+      // chunks might have been deleted in the interim
+      if (chunk.data === undefined) continue
+
       const chunkType = chunkTypeFromKey(chunk.key)
       if (chunkType == null) continue
+
       chunkInfos.push({
         key: chunk.key,
         type: chunkType,

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -129,9 +129,9 @@ export class StorageSubsystem {
 
     const sourceChunks = this.#chunkInfos.get(documentId) ?? []
     if (this.#shouldCompact(sourceChunks)) {
-      void this.#saveTotal(documentId, doc, sourceChunks)
+      await this.#saveTotal(documentId, doc, sourceChunks)
     } else {
-      void this.#saveIncremental(documentId, doc)
+      await this.#saveIncremental(documentId, doc)
     }
     this.#storedHeads.set(documentId, A.getHeads(doc))
   }
@@ -140,8 +140,8 @@ export class StorageSubsystem {
    * Removes the Automerge document with the given ID from storage
    */
   async removeDoc(documentId: DocumentId) {
-    void this.#storageAdapter.removeRange([documentId, "snapshot"])
-    void this.#storageAdapter.removeRange([documentId, "incremental"])
+    await this.#storageAdapter.removeRange([documentId, "snapshot"])
+    await this.#storageAdapter.removeRange([documentId, "incremental"])
   }
 
   /**

--- a/packages/automerge-repo/src/storage/types.ts
+++ b/packages/automerge-repo/src/storage/types.ts
@@ -3,7 +3,7 @@
  */
 export type Chunk = {
   key: StorageKey
-  data: Uint8Array
+  data: Uint8Array | undefined
 }
 
 /**

--- a/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
@@ -1,4 +1,4 @@
-import { StorageAdapter, type StorageKey } from "../../src/index.js"
+import { Chunk, StorageAdapter, type StorageKey } from "../../src/index.js"
 
 export class DummyStorageAdapter implements StorageAdapter {
   #data: Record<string, Uint8Array> = {}
@@ -11,9 +11,7 @@ export class DummyStorageAdapter implements StorageAdapter {
     return key.split(".")
   }
 
-  async loadRange(
-    keyPrefix: StorageKey
-  ): Promise<{ data: Uint8Array; key: StorageKey }[]> {
+  async loadRange(keyPrefix: StorageKey): Promise<Chunk[]> {
     const range = Object.entries(this.#data)
       .filter(([key, _]) => key.startsWith(this.#keyToString(keyPrefix)))
       .map(([key, data]) => ({ key: this.#stringToKey(key), data }))


### PR DESCRIPTION
In the process of adding a bit more test coverage to the storage system, I stumbled across a slippery little intermittent bug. This test was failing: 

https://github.com/automerge/automerge-repo/blob/f9f596a9e3589d34e7b61290697d3463152e6587/packages/automerge-repo/test/StorageSubsystem.test.ts#L43-L67

It creates 100 changes to a document in quick succession, and then immediately attempts to read the document. While that read is happening, some of those changes are still in flight, and we try to read incremental changes that have already been garbage-collected as part of the compaction process. 

There are two separate issues, and addressing either of them gets the test to pass. This PR fixes both. 

#### Problem 1: Fire-and-forget `void` async calls 

https://github.com/automerge/automerge-repo/blob/0153a67b1739412b1b26edc8a65f076adc749f07/packages/automerge-repo/src/storage/StorageSubsystem.ts#L122-L141

Both `saveDoc` and `removeDoc` have async signatures, but internally they fire off asynchronous processes and then return without for them to complete. That's just asking for trouble. The decision to await completion or not should be pushed as far up the call stack as possible. These functions are called by `Repo`, and the repo should be able to decide whether to await results or not. Likewise, in the test I should be able wait for changes to take effect before reading (or not, if this kind of concurrency is actually what I want to test).

#### Problem 2: Unspecified behavior when network adapter can't find a blob

The storage adapters all return `undefined` if a blob doesn't exist, but then `StorageSubsystem.loadDoc` assumes that `NetworkAdapter.loadRange` contains only chunks with valid data. TypeScript didn't catch this because the `Chunk` type mistakenly asserted that `data` would contain a binary blob. This PR fixes the type, and has `loadDoc` just ignore chunks with undefined `data`:

https://github.com/automerge/automerge-repo/blob/27f14eb3c6352560e956d6f84a5b4c178f006111/packages/automerge-repo/src/storage/StorageSubsystem.ts#L90-L92

That's the simplest solution, and it fixes the problem in this particular context. But it makes me a little nervous to just proceed blithely on the assumption that if a file is gone we didn't need it anyway. I think it's worth thinking about what situations might cause a blob not to be found. 

In this case, compaction has taken place between (a) the time we collected a set of keys to load and (b) the time we try to load those keys. So maybe the right call would be for the adapter to be responsible for ensuring that all the chunks it returns from `loadRange` have data, something like: 

```ts
export type Chunk = {
  key: StorageKey
  data: Uint8Array // not | undefined
}

async loadRange(keyPrefix: StorageKey): Promise<Chunk[]> {
  // ...

  if (chunks.some(chunk => chunk.data === undefined)) {
    await pause(10)
    return this.loadRange(keyPrefix)
  }
  return chunks
}
```

Or better yet, rather than retrying an infinite number of times, have it throw an error after a set number of retries. 