### PR TITLE
Proposed AuthProvider API

### DIFF
--- a/examples/sync-server/index.js
+++ b/examples/sync-server/index.js
@@ -39,7 +39,7 @@ export class Server {
       storage: new NodeFSStorageAdapter(dir),
       /** @ts-ignore @type {(import("@automerge/automerge-repo").PeerId)}  */
       peerId: `storage-server-${hostname}`,
-      // Since this is a server, we don't share generously — meaning we only sync documents they already
+      // Since this is a server, we don't advertise documents -- we only sync documents peers already
       // know about and can ask for by ID.
       sharePolicy: async () => false,
     }

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -87,6 +87,11 @@ export class Repo extends EventEmitter<RepoEvents> {
     this.networkSubsystem.on("message", msg => {
       this.#synchronizer.receiveMessage(msg)
     })
+
+    // Handle errors
+    networkSubsystem.on("error", err => {
+      this.#log("network error", { err })
+    })
   }
 
   /** Returns an existing handle if we have it; creates one otherwise. */

--- a/packages/automerge-repo/src/auth/AuthChannel.ts
+++ b/packages/automerge-repo/src/auth/AuthChannel.ts
@@ -1,0 +1,55 @@
+import { EventEmitter } from "eventemitter3"
+import { NetworkAdapter } from "../network/NetworkAdapter.js"
+import type { PeerId } from "../types.js"
+import debug from "debug"
+import { AuthMessage, Message, isAuthMessage } from "../network/messages.js"
+
+/**
+ * An AuthChannel is a channel that is used to exchange authentication messages over a network
+ * adapter. It is created by the AuthProvider.
+ */
+export class AuthChannel<TPayload = any> //
+  extends EventEmitter<AuthChannelEvents<TPayload>>
+{
+  log: debug.Debugger
+  closed = false
+
+  networkAdapter: NetworkAdapter
+  senderId: PeerId
+  targetId: PeerId
+
+  constructor(networkAdapter: NetworkAdapter, peerId: PeerId) {
+    super()
+    this.log = debug(`automerge-repo:authchannel:${peerId}`)
+    this.networkAdapter = networkAdapter
+    this.senderId = networkAdapter.peerId!
+    this.targetId = peerId
+    this.networkAdapter.on("message", this.onMessage)
+  }
+
+  send(payload: TPayload) {
+    if (this.closed) throw new Error("AuthChannel is closed")
+    this.networkAdapter.send({
+      type: "auth",
+      senderId: this.senderId,
+      targetId: this.targetId,
+      payload,
+    })
+  }
+
+  close() {
+    this.removeAllListeners()
+    this.networkAdapter.off("message", this.onMessage)
+    this.closed = true
+  }
+
+  onMessage = (message: Message) => {
+    if (isAuthMessage(message)) {
+      this.emit("message", (message as AuthMessage<TPayload>).payload)
+    }
+  }
+}
+
+export interface AuthChannelEvents<TPayload> {
+  message: (payload: TPayload) => void
+}

--- a/packages/automerge-repo/src/auth/AuthProvider.ts
+++ b/packages/automerge-repo/src/auth/AuthProvider.ts
@@ -1,0 +1,92 @@
+import { EventEmitter } from "eventemitter3"
+import { forwardEvents } from "../helpers/forwardEvents.js"
+import { SharePolicy } from "../index.js"
+import { NetworkAdapter } from "../network/NetworkAdapter.js"
+import { AuthChannel } from "./AuthChannel.js"
+import { AuthenticatedNetworkAdapter } from "./AuthenticatedNetworkAdapter.js"
+import { ALWAYS_OK, AUTHENTICATION_VALID } from "./constants.js"
+import {
+  AuthProviderConfig,
+  AuthenticateFn,
+  MessageTransformer,
+  Transform,
+} from "./types.js"
+
+/**
+ * An AuthProvider is responsible for authentication (proving that a peer is who they say they are)
+ * and authorization (deciding whether a peer is allowed to access a document).
+ *
+ * By default, an AuthProvider is maximally permissive: it allows any peer to access any document.
+ *
+ * An AuthProvider can be configured by passing a config object to the constructor, or by extending
+ * the class and overriding methods.
+ */
+export class AuthProvider<
+  TEvents extends EventEmitter.ValidEventTypes = any
+> extends EventEmitter<TEvents> {
+  constructor(config: AuthProviderConfig = {}) {
+    super()
+    return Object.assign(this, config)
+  }
+
+  /** Is this peer who they say they are? */
+  authenticate: AuthenticateFn = async () => AUTHENTICATION_VALID
+
+  /** Should we tell this peer about the existence of this document? */
+  okToAdvertise: SharePolicy = ALWAYS_OK
+
+  /** Should we provide this document & changes to it if requested? */
+  okToSync: SharePolicy = ALWAYS_OK
+
+  /**
+   * An AuthProvider can optionally transform incoming and outgoing messages. For example,
+   * authentication might involve encrypting and decrypting messages using a shared secret.
+   * By default, messages are not transformed.
+   */
+  transform: Transform = { inbound: NO_TRANSFORM, outbound: NO_TRANSFORM }
+
+  /**
+   * The repo uses the AuthProvider to wrap each network adapter in order to authenticate new peers
+   * and transform inbound and outbound messages.
+   * @param baseAdapter
+   * @returns
+   */
+  wrapNetworkAdapter = (baseAdapter: NetworkAdapter) => {
+    const authenticate = this.authenticate
+    const transform = this.transform
+    const wrappedAdapter = new AuthenticatedNetworkAdapter(
+      baseAdapter,
+      transform
+    )
+
+    // try to authenticate new peers; if we succeed, we forward the peer-candidate event
+    baseAdapter.on("peer-candidate", async ({ peerId }) => {
+      const channel = new AuthChannel(baseAdapter, peerId)
+      const authResult = await authenticate(peerId, channel)
+
+      if (authResult.isValid) {
+        wrappedAdapter.emit("peer-candidate", { peerId })
+      } else {
+        const { error } = authResult
+        wrappedAdapter.emit("error", { peerId, error })
+      }
+    })
+
+    // forward all other events
+    forwardEvents(baseAdapter, wrappedAdapter, [
+      "ready",
+      "close",
+      "peer-disconnected",
+      "error",
+    ])
+
+    return wrappedAdapter
+  }
+}
+
+export const authenticationError = (msg: string) => ({
+  isValid: false,
+  error: new Error(msg),
+})
+
+const NO_TRANSFORM: MessageTransformer = p => p

--- a/packages/automerge-repo/src/auth/AuthenticatedNetworkAdapter.ts
+++ b/packages/automerge-repo/src/auth/AuthenticatedNetworkAdapter.ts
@@ -1,0 +1,45 @@
+import { RepoMessage, isValidRepoMessage } from "../index.js"
+import { NetworkAdapter } from "../network/NetworkAdapter.js"
+import { Transform } from "./types.js"
+
+/**
+ * An AuthenticatedNetworkAdapter is a NetworkAdapter that wraps another NetworkAdapter and
+ * transforms outbound messages.
+ */
+export class AuthenticatedNetworkAdapter<T extends NetworkAdapter> //
+  extends NetworkAdapter
+{
+  baseAdapter: T
+  transform: Transform
+
+  connect: typeof NetworkAdapter.prototype.connect
+  disconnect: typeof NetworkAdapter.prototype.disconnect
+
+  constructor(baseAdapter: T, transform: Transform) {
+    super()
+    this.baseAdapter = baseAdapter
+    this.transform = transform
+
+    // pass through the base adapter's connect & disconnect methods
+    this.connect = this.baseAdapter.connect.bind(this.baseAdapter)
+    this.disconnect = this.baseAdapter.disconnect.bind(this.baseAdapter)
+
+    // transform incoming messages
+    baseAdapter.on("message", payload => {
+      try {
+        const transformedPayload = transform.inbound(payload)
+        this.emit("message", transformedPayload)
+      } catch (e) {
+        this.emit("error", {
+          peerId: payload.senderId,
+          error: e as Error,
+        })
+      }
+    })
+  }
+
+  // transform outgoing messages
+  send = (message: RepoMessage) => {
+    this.baseAdapter.send(this.transform.outbound(message))
+  }
+}

--- a/packages/automerge-repo/src/auth/SyncServerAuthProvider.ts
+++ b/packages/automerge-repo/src/auth/SyncServerAuthProvider.ts
@@ -1,0 +1,7 @@
+import { AuthProvider } from "./AuthProvider.js"
+import { NEVER_OK } from "./constants.js"
+
+/** Just like the base AuthProvider, but doesn't advertise anything */
+export class SyncServerAuthProvider extends AuthProvider {
+  okToAdvertise = NEVER_OK
+}

--- a/packages/automerge-repo/src/auth/constants.ts
+++ b/packages/automerge-repo/src/auth/constants.ts
@@ -1,0 +1,8 @@
+import { SharePolicy, ValidAuthenticationResult } from "./types.js"
+
+// CONSTANTS
+
+export const AUTHENTICATION_VALID: ValidAuthenticationResult = { isValid: true }
+
+export const ALWAYS_OK: SharePolicy = async () => true
+export const NEVER_OK: SharePolicy = async () => false

--- a/packages/automerge-repo/src/auth/types.ts
+++ b/packages/automerge-repo/src/auth/types.ts
@@ -1,0 +1,60 @@
+import { DocumentId, PeerId } from "../types.js"
+import { AuthChannel } from "./AuthChannel.js"
+
+// PROVIDER
+
+export interface AuthProviderConfig {
+  authenticate?: AuthenticateFn
+  transform?: Transform
+  okToAdvertise?: SharePolicy
+  okToSync?: SharePolicy
+}
+
+// AUTHENTICATION
+
+/**
+ * An authentication function takes a peer ID and a channel with which to communicate with that peer.
+ * @returns a promise of an `AuthenticationResult` object indicating whether authentication
+ * succeeded, and, if not, why.
+ */
+export type AuthenticateFn = (
+  /** ID of the remote peer. */
+  peerId: PeerId,
+
+  /** The provider implementation might use the provided channel to communicate with the peer. */
+  channel: AuthChannel
+) => Promise<AuthenticationResult>
+
+export type ValidAuthenticationResult = {
+  isValid: true
+}
+
+export type InvalidAuthenticationResult = {
+  isValid: false
+  error: Error
+}
+
+export type AuthenticationResult =
+  | ValidAuthenticationResult
+  | InvalidAuthenticationResult
+
+// TRANSFORMATION
+
+/** A Transform consists of two functions, for transforming inbound and outbound messages, respectively. */
+export type Transform = {
+  inbound: MessageTransformer
+  outbound: MessageTransformer
+}
+
+export type MessageTransformer = (msg: any) => any
+
+// AUTHORIZATION
+
+/**
+ * A SharePolicy takes a peer ID and optionally a document ID and returns true if the peer is
+ * authorized to access the document.
+ */
+export type SharePolicy = (
+  peerId: PeerId,
+  documentId?: DocumentId
+) => Promise<boolean>

--- a/packages/automerge-repo/src/helpers/forwardEvents.ts
+++ b/packages/automerge-repo/src/helpers/forwardEvents.ts
@@ -1,0 +1,21 @@
+import { EventEmitter } from "eventemitter3"
+
+/** Forwards the given list of events from one EventEmitter to another of the same type */
+export const forwardEvents = <
+  T extends EventEmitter.ValidEventTypes,
+  K extends EventEmitter.EventNames<T>[]
+>(
+  source: EventEmitter<T>,
+  target: EventEmitter<T>,
+  events: K
+) => {
+  type Listener = EventEmitter.EventListener<T, EventEmitter.EventNames<T>>
+  type Args = Parameters<Listener>
+
+  events.forEach(e => {
+    const listener = ((...args: Args) => {
+      target.emit(e, ...args)
+    }) as Listener
+    source.on(e, listener)
+  })
+}

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -34,8 +34,10 @@ export {
 } from "./AutomergeUrl.js"
 export { Repo } from "./Repo.js"
 export { NetworkAdapter } from "./network/NetworkAdapter.js"
-export { isValidRepoMessage } from "./network/messages.js"
+export { isValidRepoMessage, isAuthMessage } from "./network/messages.js"
 export { StorageAdapter } from "./storage/StorageAdapter.js"
+export { AuthProvider } from "./auth/AuthProvider.js"
+export { AuthenticatedNetworkAdapter } from "./auth/AuthenticatedNetworkAdapter.js"
 
 /** @hidden **/
 export * as cbor from "./helpers/cbor.js"
@@ -60,6 +62,7 @@ export type {
 } from "./network/NetworkAdapter.js"
 
 export type {
+  AuthMessage,
   DocumentUnavailableMessage,
   EphemeralMessage,
   Message,

--- a/packages/automerge-repo/src/network/NetworkAdapter.ts
+++ b/packages/automerge-repo/src/network/NetworkAdapter.ts
@@ -45,6 +45,9 @@ export interface NetworkAdapterEvents {
 
   /** Emitted when the network adapter receives a message from a peer */
   message: (payload: Message) => void
+
+  /** Emitted when a network adapter encounters a non-fatal error (e.g. fails to authenticate with a peer) */
+  error: (payload: ErrorPayload) => void
 }
 
 export interface OpenPayload {
@@ -57,4 +60,9 @@ export interface PeerCandidatePayload {
 
 export interface PeerDisconnectedPayload {
   peerId: PeerId
+}
+
+export interface ErrorPayload {
+  peerId: PeerId
+  error: Error
 }

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -1,7 +1,11 @@
 import debug from "debug"
 import { EventEmitter } from "eventemitter3"
 import { PeerId, SessionId } from "../types.js"
-import { NetworkAdapter, PeerDisconnectedPayload } from "./NetworkAdapter.js"
+import {
+  ErrorPayload,
+  NetworkAdapter,
+  PeerDisconnectedPayload,
+} from "./NetworkAdapter.js"
 import {
   EphemeralMessage,
   MessageContents,
@@ -90,6 +94,12 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
       this.emit("message", msg)
     })
 
+    networkAdapter.on("error", payload => {
+      const { peerId, error } = payload
+      this.#log(`adapter error %o`, { peerId, error: error.message })
+      this.emit("error", payload)
+    })
+
     networkAdapter.on("close", () => {
       this.#log("adapter closed")
       Object.entries(this.#adaptersByPeer).forEach(([peerId, other]) => {
@@ -161,6 +171,7 @@ export interface NetworkSubsystemEvents {
   "peer-disconnected": (payload: PeerDisconnectedPayload) => void
   message: (payload: RepoMessage) => void
   ready: () => void
+  error: (payload: ErrorPayload) => void
 }
 
 export interface PeerPayload {

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -54,8 +54,6 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
     networkAdapter.on("peer-candidate", ({ peerId }) => {
       this.#log(`peer candidate: ${peerId} `)
 
-      // TODO: This is where authentication would happen
-
       if (!this.#adaptersByPeer[peerId]) {
         // TODO: handle losing a server here
         this.#adaptersByPeer[peerId] = networkAdapter

--- a/packages/automerge-repo/src/network/messages.ts
+++ b/packages/automerge-repo/src/network/messages.ts
@@ -87,7 +87,7 @@ export type RequestMessage = {
   documentId: DocumentId
 }
 
-/** (anticipating work in progress) */
+/** Sent by an {@link AuthProvider} to authenticate a peer */
 export type AuthMessage<TPayload = any> = {
   type: "auth"
 
@@ -142,3 +142,6 @@ export const isSyncMessage = (msg: Message): msg is SyncMessage =>
 
 export const isEphemeralMessage = (msg: Message): msg is EphemeralMessage =>
   msg.type === "ephemeral"
+
+export const isAuthMessage = (msg: Message): msg is AuthMessage =>
+  msg.type === "auth"

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -115,9 +115,11 @@ export class CollectionSynchronizer extends Synchronizer {
     this.#peers.add(peerId)
     for (const docSynchronizer of Object.values(this.#docSynchronizers)) {
       const { documentId } = docSynchronizer
-      void this.repo.sharePolicy(peerId, documentId).then(okToShare => {
-        if (okToShare) docSynchronizer.beginSync([peerId])
-      })
+      void this.repo.authProvider
+        .okToSync(peerId, documentId)
+        .then(okToShare => {
+          if (okToShare) docSynchronizer.beginSync([peerId])
+        })
     }
   }
 

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -40,15 +40,18 @@ export class CollectionSynchronizer extends Synchronizer {
     return docSynchronizer
   }
 
-  /** returns an array of peerIds that we share this document generously with */
-  async #documentGenerousPeers(documentId: DocumentId): Promise<PeerId[]> {
+  /** returns an array of peerIds that we should advertise this document to */
+  async #peersOkToAdvertise(documentId: DocumentId): Promise<PeerId[]> {
     const peers = Array.from(this.#peers)
-    const generousPeers: PeerId[] = []
+    const peersToAdvertise: PeerId[] = []
     for (const peerId of peers) {
-      const okToShare = await this.repo.sharePolicy(peerId, documentId)
-      if (okToShare) generousPeers.push(peerId)
+      const okToAdvertise = await this.repo.authProvider.okToAdvertise(
+        peerId,
+        documentId
+      )
+      if (okToAdvertise) peersToAdvertise.push(peerId)
     }
-    return generousPeers
+    return peersToAdvertise
   }
 
   // PUBLIC
@@ -76,14 +79,14 @@ export class CollectionSynchronizer extends Synchronizer {
     docSynchronizer.receiveMessage(message)
 
     // Initiate sync with any new peers
-    const peers = await this.#documentGenerousPeers(documentId)
+    const peers = await this.#peersOkToAdvertise(documentId)
     docSynchronizer.beginSync(
       peers.filter(peerId => !docSynchronizer.hasPeer(peerId))
     )
   }
 
   /**
-   * Starts synchronizing the given document with all peers that we share it generously with.
+   * Starts synchronizing the given document with all peers that we advertise it to
    */
   addDocument(documentId: DocumentId) {
     // HACK: this is a hack to prevent us from adding the same document twice
@@ -91,7 +94,7 @@ export class CollectionSynchronizer extends Synchronizer {
       return
     }
     const docSynchronizer = this.#fetchDocSynchronizer(documentId)
-    void this.#documentGenerousPeers(documentId).then(peers => {
+    void this.#peersOkToAdvertise(documentId).then(peers => {
       docSynchronizer.beginSync(peers)
     })
   }

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -228,7 +228,7 @@ export class DocSynchronizer extends Synchronizer {
 
   receiveEphemeralMessage(message: EphemeralMessage) {
     if (message.documentId !== this.handle.documentId)
-      throw new Error(`channelId doesn't match documentId`)
+      throw new Error(`not my documentId`)
 
     const { senderId, data } = message
 
@@ -250,7 +250,7 @@ export class DocSynchronizer extends Synchronizer {
 
   receiveSyncMessage(message: SyncMessage | RequestMessage) {
     if (message.documentId !== this.handle.documentId)
-      throw new Error(`channelId doesn't match documentId`)
+      throw new Error(`not my documentId`)
 
     // We need to block receiving the syncMessages until we've checked local storage
     if (!this.handle.inState([READY, REQUESTING, UNAVAILABLE])) {

--- a/packages/automerge-repo/test/AuthProvider.test.ts
+++ b/packages/automerge-repo/test/AuthProvider.test.ts
@@ -133,7 +133,7 @@ describe("AuthProvider", () => {
 
   describe("authentication", () => {
     const setup = async (
-      authProvider: AuthProvider | Record<string, AuthProvider>
+      authProvider?: AuthProvider | Record<string, AuthProvider>
     ) => {
       if (authProvider instanceof AuthProvider)
         authProvider = {
@@ -147,13 +147,13 @@ describe("AuthProvider", () => {
       const aliceRepo = new Repo({
         network: [new MessageChannelNetworkAdapter(aliceToBob)],
         peerId: "alice" as PeerId,
-        authProvider: authProvider.alice,
+        ...(authProvider ? { authProvider: authProvider.alice } : {}),
       })
 
       const bobRepo = new Repo({
         network: [new MessageChannelNetworkAdapter(bobToAlice)],
         peerId: "bob" as PeerId,
-        authProvider: authProvider.bob,
+        ...(authProvider ? { authProvider: authProvider.bob } : {}),
       })
 
       const aliceHandle = aliceRepo.create<TestDoc>()
@@ -198,16 +198,22 @@ describe("AuthProvider", () => {
       it("a maximally permissive auth provider authenticates everyone", async () => {
         const permissive = new AuthProvider() // AuthProvider is maximally permissive by default
         const { bobRepo, aliceHandle, teardown } = await setup(permissive)
-
         await pause(50)
+
         // bob has alice's document
         assert.notEqual(bobRepo.handles[aliceHandle.documentId], undefined)
 
         teardown()
       })
 
-      it("a custom auth provider might just authenticate based on peerId", async () => {
-        // TODO
+      it("the maximally permissive auth provider is the same as no auth provider", async () => {
+        const { bobRepo, aliceHandle, teardown } = await setup() // no auth provider
+        await pause(50)
+
+        // bob has alice's document
+        assert.notEqual(bobRepo.handles[aliceHandle.documentId], undefined)
+
+        teardown()
       })
     })
 

--- a/packages/automerge-repo/test/AuthProvider.test.ts
+++ b/packages/automerge-repo/test/AuthProvider.test.ts
@@ -1,0 +1,366 @@
+import assert from "assert"
+import { MessageChannelNetworkAdapter } from "@automerge/automerge-repo-network-messagechannel"
+import { describe, it } from "vitest"
+import { authenticationError, AuthProvider } from "../src/auth/AuthProvider.js"
+import { eventPromise } from "../src/helpers/eventPromise.js"
+import { pause } from "../src/helpers/pause.js"
+import { withTimeout } from "../src/helpers/withTimeout.js"
+import {
+  DocumentId,
+  PeerId,
+  Repo,
+  RepoMessage,
+  SharePolicy,
+} from "../src/index.js"
+import { decrypt, encrypt } from "./helpers/encrypt.js"
+import { expectPromises } from "./helpers/expectPromises.js"
+import type { TestDoc } from "./types.js"
+import { AuthenticateFn, AuthenticationResult } from "../src/auth/types.js"
+import { AUTHENTICATION_VALID } from "../src/auth/constants.js"
+
+describe("AuthProvider", () => {
+  describe("authorization", async () => {
+    const setup = async () => {
+      // Set up three repos; connect Alice to Bob, and Bob to Charlie
+
+      const aliceBobChannel = new MessageChannel()
+      const bobCharlieChannel = new MessageChannel()
+
+      const { port1: aliceToBob, port2: bobToAlice } = aliceBobChannel
+      const { port1: bobToCharlie, port2: charlieToBob } = bobCharlieChannel
+
+      class NotForCharlieAuthProvider extends AuthProvider {
+        excludedDocs: DocumentId[] = []
+
+        // make sure that charlie never learns about excluded documents
+        notForCharlie: SharePolicy = async (peerId, documentId) => {
+          if (this.excludedDocs.includes(documentId!) && peerId === "charlie")
+            return false
+          return true
+        }
+
+        okToAdvertise = this.notForCharlie
+        okToSync = this.notForCharlie
+      }
+
+      const authProvider = new NotForCharlieAuthProvider()
+
+      const aliceRepo = new Repo({
+        network: [new MessageChannelNetworkAdapter(aliceToBob)],
+        peerId: "alice" as PeerId,
+        authProvider,
+      })
+
+      const bobRepo = new Repo({
+        network: [
+          new MessageChannelNetworkAdapter(bobToAlice),
+          new MessageChannelNetworkAdapter(bobToCharlie),
+        ],
+        peerId: "bob" as PeerId,
+        authProvider,
+      })
+
+      const charlieRepo = new Repo({
+        network: [new MessageChannelNetworkAdapter(charlieToBob)],
+        peerId: "charlie" as PeerId,
+      })
+
+      const aliceHandle = aliceRepo.create<TestDoc>()
+      aliceHandle.change(d => {
+        d.foo = "bar"
+      })
+
+      const notForCharlieHandle = aliceRepo.create<TestDoc>()
+      const notForCharlie = notForCharlieHandle.documentId
+      authProvider.excludedDocs.push(notForCharlie)
+
+      notForCharlieHandle.change(d => {
+        d.foo = "baz"
+      })
+
+      await Promise.all([
+        eventPromise(aliceRepo.networkSubsystem, "peer"),
+        eventPromise(bobRepo.networkSubsystem, "peer"),
+        eventPromise(charlieRepo.networkSubsystem, "peer"),
+      ])
+
+      const teardown = () => {
+        aliceBobChannel.port1.close()
+        bobCharlieChannel.port1.close()
+      }
+
+      return {
+        aliceRepo,
+        bobRepo,
+        charlieRepo,
+        aliceHandle,
+        notForCharlie,
+        teardown,
+      }
+    }
+
+    it("charlie doesn't learn about a document he's not supposed to have", async () => {
+      const { aliceRepo, bobRepo, charlieRepo, notForCharlie, teardown } =
+        await setup()
+
+      // HACK: we don't know how long to wait before confirming the handle would have been advertised but wasn't
+      await pause(50)
+
+      assert.notEqual(aliceRepo.handles[notForCharlie], undefined, "alice yes")
+      assert.notEqual(bobRepo.handles[notForCharlie], undefined, "bob yes")
+      assert.equal(charlieRepo.handles[notForCharlie], undefined, "charlie no")
+
+      teardown()
+    })
+
+    it("charlie doesn't get a document he's not supposed to have even if he learns its id", async () => {
+      const { aliceRepo, bobRepo, charlieRepo, notForCharlie, teardown } =
+        await setup()
+
+      const aliceHandle = aliceRepo.find(notForCharlie)
+      const bobHandle = bobRepo.find(notForCharlie)
+      const charlieHandle = charlieRepo.find(notForCharlie)
+
+      await pause(50)
+
+      assert.equal(aliceHandle.isReady(), true, "alice yes")
+      assert.equal(bobHandle.isReady(), true, "bob yes")
+      assert.equal(charlieHandle.isReady(), false, "charlie no")
+
+      teardown()
+    })
+  })
+
+  describe("authentication", () => {
+    const setup = async (
+      authProvider: AuthProvider | Record<string, AuthProvider>
+    ) => {
+      if (authProvider instanceof AuthProvider)
+        authProvider = {
+          alice: authProvider,
+          bob: authProvider,
+        }
+
+      const aliceBobChannel = new MessageChannel()
+      const { port1: aliceToBob, port2: bobToAlice } = aliceBobChannel
+
+      const aliceRepo = new Repo({
+        network: [new MessageChannelNetworkAdapter(aliceToBob)],
+        peerId: "alice" as PeerId,
+        authProvider: authProvider.alice,
+      })
+
+      const bobRepo = new Repo({
+        network: [new MessageChannelNetworkAdapter(bobToAlice)],
+        peerId: "bob" as PeerId,
+        authProvider: authProvider.bob,
+      })
+
+      const aliceHandle = aliceRepo.create<TestDoc>()
+      aliceHandle.change(d => {
+        d.foo = "bar"
+      })
+
+      const teardown = () => {
+        aliceToBob.close()
+        bobToAlice.close()
+      }
+
+      return {
+        aliceRepo,
+        bobRepo,
+        aliceHandle,
+        teardown,
+      }
+    }
+
+    describe("without network communication", () => {
+      it("a maximally restrictive auth provider won't authenticate anyone", async () => {
+        const restrictive = new AuthProvider({
+          authenticate: async () => {
+            return {
+              isValid: false,
+              error: new Error("nope"),
+            }
+          },
+          okToAdvertise: async () => false,
+          okToSync: async () => false,
+        })
+        const { bobRepo, aliceHandle, teardown } = await setup(restrictive)
+
+        await pause(50)
+        // bob doesn't have alice's document
+        assert.equal(bobRepo.handles[aliceHandle.documentId], undefined)
+
+        teardown()
+      })
+
+      it("a maximally permissive auth provider authenticates everyone", async () => {
+        const permissive = new AuthProvider() // AuthProvider is maximally permissive by default
+        const { bobRepo, aliceHandle, teardown } = await setup(permissive)
+
+        await pause(50)
+        // bob has alice's document
+        assert.notEqual(bobRepo.handles[aliceHandle.documentId], undefined)
+
+        teardown()
+      })
+
+      it("a custom auth provider might just authenticate based on peerId", async () => {
+        // TODO
+      })
+    })
+
+    describe("with network communication", () => {
+      // We'll make a (very insecure) password auth provider that sends a password challenge, and
+      // compares the password returned to a hard-coded password list.
+      class PasswordAuthProvider extends AuthProvider {
+        // The auth provider is initialized with a password response, which it will provide when
+        // challenged.
+        constructor(private passwordResponse: string) {
+          super()
+        }
+
+        #challenge = "what is the password?"
+
+        #passwords: Record<string, string> = {
+          alice: "abracadabra",
+          bob: "bucaramanga",
+        }
+
+        authenticate: AuthenticateFn = async (peerId, channel) => {
+          return new Promise<AuthenticationResult>((resolve, reject) => {
+            // send challenge
+            channel.send(new TextEncoder().encode(this.#challenge))
+
+            channel.on("message", msg => {
+              const msgText = new TextDecoder().decode(msg)
+              switch (msgText) {
+                case this.#challenge:
+                  // received challenge, send password
+                  channel.send(new TextEncoder().encode(this.passwordResponse))
+                  break
+
+                case this.#passwords[peerId]:
+                  // received correct password
+                  resolve(AUTHENTICATION_VALID)
+                  break
+
+                default:
+                  // received incorrect password
+                  resolve(authenticationError("that is not the password"))
+                  break
+              }
+            })
+          })
+        }
+      }
+
+      it("should sync with bob if he provides the right password", async () => {
+        const { aliceRepo, bobRepo, aliceHandle, teardown } = await setup({
+          alice: new PasswordAuthProvider("abracadabra"), // ✅ alice gives the correct password
+          bob: new PasswordAuthProvider("bucaramanga"), // ✅ bob gives the correct password
+        })
+
+        // if these resolve, we've been authenticated
+        await expectPromises(
+          eventPromise(aliceRepo.networkSubsystem, "peer"), // ✅
+          eventPromise(bobRepo.networkSubsystem, "peer") // ✅
+        )
+
+        // bob should now receive alice's document
+        const bobHandle = bobRepo.find<TestDoc>(aliceHandle.documentId)
+        await eventPromise(bobHandle, "change")
+        const doc = await bobHandle.doc()
+        assert.equal(doc.foo, "bar")
+
+        teardown()
+      })
+
+      it("shouldn't sync with bob if he provides the wrong password", async () => {
+        const { aliceRepo, bobRepo, aliceHandle, teardown } = await setup({
+          alice: new PasswordAuthProvider("abracadabra"), // ✅ alice gives the correct password
+          bob: new PasswordAuthProvider("asdfasdfasdf"), // ❌ bob gives the wrong password
+        })
+
+        await expectPromises(
+          eventPromise(aliceRepo.networkSubsystem, "error"), // ❌ alice doesn't authenticate bob, because his password was wrong
+          eventPromise(bobRepo.networkSubsystem, "peer") // ✅ bob authenticates alice
+        )
+
+        // bob doesn't have alice's document
+        const alicesDocumentForBob = bobRepo.handles[aliceHandle.documentId]
+        assert.equal(alicesDocumentForBob, undefined)
+
+        teardown()
+      })
+    })
+
+    describe("adding encryption to the network adapter", () => {
+      // The idea here is that rather than authenticate peers, the auth provider
+      // encrypts and decrypts messages using a secret key that each peer knows.
+      // No keys are revealed, but the peers can only communicate if they know the
+      // secret key.
+
+      function encryptingAuthProvider(secretKey: string) {
+        return new AuthProvider({
+          transform: {
+            inbound: (message: RepoMessage) => {
+              if ("data" in message) {
+                const decrypted = decrypt(message.data, secretKey)
+                return { ...message, data: decrypted }
+              }
+            },
+            outbound: (message: RepoMessage) => {
+              if ("data" in message) {
+                const encrypted = encrypt(message.data, secretKey)
+                return { ...message, data: encrypted }
+              }
+            },
+          },
+        })
+      }
+
+      it("encrypts outgoing messages and decrypts incoming messages", async () => {
+        const { aliceRepo, bobRepo, aliceHandle, teardown } = await setup({
+          alice: encryptingAuthProvider("BatteryHorseCorrectStaple"),
+          bob: encryptingAuthProvider("BatteryHorseCorrectStaple"),
+        })
+
+        await expectPromises(
+          eventPromise(aliceRepo.networkSubsystem, "peer"), // ✅
+          eventPromise(bobRepo.networkSubsystem, "peer") // ✅
+        )
+
+        // bob has alice's document
+        const bobHandle = bobRepo.find<TestDoc>(aliceHandle.documentId)
+        await eventPromise(bobHandle, "change")
+        const doc = await bobHandle.doc()
+        assert.equal(doc.foo, "bar")
+
+        teardown()
+      })
+
+      it("doesn't sync if both peers don't use the same secret key", async () => {
+        const { aliceRepo, bobRepo, aliceHandle, teardown } = await setup({
+          alice: encryptingAuthProvider("BatteryHorseCorrectStaple"),
+          bob: encryptingAuthProvider("asdfasdfasdfasdfadsf"),
+        })
+
+        // one of these will throw an error, the other will hang
+        await withTimeout(
+          Promise.race([
+            eventPromise(aliceRepo.networkSubsystem, "error"),
+            eventPromise(bobRepo.networkSubsystem, "error"),
+          ]),
+          50
+        )
+
+        // bob doesn't have alice's document
+        assert.equal(bobRepo.handles[aliceHandle.documentId], undefined)
+
+        teardown()
+      })
+    })
+  })
+})

--- a/packages/automerge-repo/test/helpers/encrypt.ts
+++ b/packages/automerge-repo/test/helpers/encrypt.ts
@@ -1,0 +1,52 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  createHash,
+} from "crypto"
+
+const ALGORITHM = "aes-256-gcm"
+
+export function encrypt(payload: Uint8Array, pw: string): Uint8Array {
+  const salt = randomBytes(16)
+  const iv = randomBytes(12)
+  const key = getKeyFromPassword(pw, salt)
+  const cipher = createCipheriv(ALGORITHM, key, iv)
+
+  const encrypted = Buffer.concat([
+    cipher.update(Buffer.from(payload)),
+    cipher.final(),
+  ])
+  const tag = cipher.getAuthTag()
+
+  return Buffer.concat([salt, iv, tag, encrypted])
+}
+
+export function decrypt(encrypted: Uint8Array, pw: string): Uint8Array {
+  const salt = encrypted.slice(0, 16)
+  const iv = encrypted.slice(16, 28)
+  const tag = encrypted.slice(28, 44)
+  const data = encrypted.slice(44)
+
+  const key = getKeyFromPassword(pw, salt)
+  const decipher = createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(tag)
+
+  // this will throw if the password is wrong
+  return Buffer.concat([decipher.update(data), decipher.final()])
+}
+
+function getKeyFromPassword(pw: string, salt: Uint8Array): Uint8Array {
+  const pwBytes = new TextEncoder().encode(pw)
+
+  // note: for this to actually be secure, you would want to use a deliberately
+  // slow key derivation function like scrypt - for example:
+
+  // return scryptSync(pwBytes, salt, 32)
+
+  // As this is just used for testing, we'll use a hash function instead to keep things fast.
+
+  const hash = createHash("sha256")
+  hash.update(Buffer.concat([pwBytes, salt]))
+  return hash.digest()
+}

--- a/packages/automerge-repo/test/helpers/expectPromises.ts
+++ b/packages/automerge-repo/test/helpers/expectPromises.ts
@@ -1,0 +1,6 @@
+import { withTimeout } from "../../src/helpers/withTimeout.js"
+
+export async function expectPromises(...promises: Promise<any>[]) {
+  const timeout = 50
+  return withTimeout(Promise.all(promises), timeout)
+}


### PR DESCRIPTION
> 🚧 Opening this as a draft for discussion purposes -- some details of the proposed API are still in flux. 

This is a proposal for an AuthProvider API. This fixes #25 but has evolved a bit from that initial proposal.

### Why

Automerge Repo currently offers no way to authenticate a peer, and very little in the way of access control.

Our current security model is the "Rumplestiltskin rule": If you know a document's ID, you can read that document, and everyone else who knows that ID will accept your changes.

That model is good enough for a surprising number of situations — the ID serves as an unguessable secret "password" for the document — but it has limitations. Without a way to establish a peer's identity, we can't revoke access for an individual peer — say if someone leaves a team, or if a device is lost. And we can't distinguish between read and write permissions, or limit access to specific documents.

An application might implement authentication and authorization in any number of ways, so this needs to be pluggable — like the existing network and storage adapters.

Initializing a repo with a specific auth provider might look something like this:

```ts
import { SuperCoolAuthProvider } from 'supercool-auth-library'

const authOptions = {
  // ...options specific to this type of authentication
}
const auth = new SuperCoolAuthProvider(options)

const repo = new Repo({ network, storage, auth })
```

### Using the base `AuthProvider` directly

Most of these examples are from the [tests](https://github.com/automerge/automerge-repo/blob/3cbc4d18aaa0bacf8d734079eb7af64eefb1f89b/packages/automerge-repo/test/AuthProvider.test.ts). 

#### Adding an `AuthProvider` to a repo

```ts
const permissive = new AuthProvider() // AuthProvider is maximally permissive by default

const aliceRepo = new Repo({
  network: [new MessageChannelNetworkAdapter(aliceToBob)],
  peerId: "alice" as PeerId,
  authProvider: permissive
})
```

Using the base (maximally permissive) AuthProvider without any overrides is the same as instantiating a repo with no AuthProvider.  

#### Overriding the base adapter's methods

You can instantiate an `AuthProvider` with a config object containing any of the following: 

```ts
export interface AuthProviderConfig {
  authenticate?: AuthenticateFn
  transform?: Transform
  okToAdvertise?: SharePolicy
  okToSync?: SharePolicy
}
```
##### `okToAdvertise` and `okToSync` 

These are both `SharePolicy` functions. They have the same signature as the existing `sharePolicy` config option -- they take a peer ID and optionally a document ID, and return true or false; but they explicitly separate out two questions that the current `sharePolicy` muddles:

- `okToAdvertise`  Should we tell this peer about the existence of this document? 
- `okToSync` Should we provide this document & changes to it if requested? 
 
##### `authenticate` 

This is a function that takes a `PeerId` and a channel with which to (optionally) communicate with that peer. It returns a promise of an `AuthenticationResult` object indicating whether authentication succeeded, and, if not, why. 

#####  `transform` 

A `Transform` consists of two functions, for transforming inbound and outbound messages, respectively. This might be use, for example, to encrypt messages using a shared secret. 


#### Example: Maximally restrictive provider

```ts
const restrictive = new AuthProvider({
  authenticate: async () => {
    return {
      isValid: false,
      error: new Error("nope"),
    }
  },
  okToAdvertise: async () => false,
  okToSync: async () => false,
})
```


#### Example: Restricting access by peer

```ts
// only advertise new docs to the sync server
const authProvider = new AuthProvider({
  okToAdvertise: async (peerId, _documentId) => peerId === "syncserver.foo.com",
})
``` 

#### Example: Restricting access by document

```ts
const handle = collection.create()
const authProvider = new AuthProvider({
  okToAdvertise: async (_peerId, documentId) => documentId !== handle.documentId,
})
```

#### Example: Restricting access by peer and document

```ts
class NotForCharlieAuthProvider extends AuthProvider {
  excludedDocs: DocumentId[] = []

  // make sure that charlie never learns about excluded documents
  notForCharlie: SharePolicy = async (peerId, documentId) => {
    if (this.excludedDocs.includes(documentId!) && peerId === "charlie")
      return false
    return true
  }

  okToAdvertise = this.notForCharlie
  okToSync = this.notForCharlie
}

const authProvider = new NotForCharlieAuthProvider()

const notForCharlieHandle = aliceRepo.create<TestDoc>()
const notForCharlie = notForCharlieHandle.documentId
authProvider.excludedDocs.push(notForCharlie)
```

### Extending `AuthProvider` 

In the above examples, the provider is customized by passing  a config object to the base class's constructor. Alternatively, a custom provider might extend the base class. Here's the maximally restrictive provider we saw earlier:

```ts
class RestrictiveAuthProvider extends AuthProvider {
  authenticate = async () => {
    return {
      isValid: false,
      error: new Error("nope"),
    }
  }
  okToAdvertise = async () => false
  okToSync = async () => false
}
const restrictive = new RestrictiveAuthProvider()
``` 

#### Example: Using network communication

We'll make a (very insecure) password auth provider that sends a password challenge, and compares the password returned to a hard-coded password list.

```ts
class PasswordAuthProvider extends AuthProvider {
  // The auth provider is initialized with a password response, which it will provide when
  // challenged.
  constructor(private passwordResponse: string) {
    super()
  }

  #challenge = "what is the password?"

  #passwords: Record<string, string> = {
    alice: "abracadabra",
    bob: "bucaramanga",
  }

  authenticate: AuthenticateFn = async (peerId, channel) => {
    return new Promise<AuthenticationResult>(resolve => {
      // send challenge
      channel.send(new TextEncoder().encode(this.#challenge))

      channel.on("message", msg => {
        const msgText = new TextDecoder().decode(msg)
        switch (msgText) {
          case this.#challenge:
            // received challenge, send password
            channel.send(new TextEncoder().encode(this.passwordResponse))
            break

          case this.#passwords[peerId]:
            // received correct password
            resolve(AUTHENTICATION_VALID)
            break

          default:
            // received incorrect password
            resolve(authenticationError("that is not the password"))
            break
        }
      })
    })
  }
}
``` 

#### Example: Transforming network traffic

The idea here is that rather than authenticate peers, the auth provider encrypts and decrypts messages using a secret key that each peer knows. No keys are revealed, but the peers can only communicate if they know the secret key.

```ts
function encryptingAuthProvider(secretKey: string) {
  return new AuthProvider({
    transform: {
      inbound: payload => {
        const decrypted = decrypt(payload.message, secretKey)
        return { ...payload, message: decrypted }
      },
      outbound: payload => {
        const encrypted = encrypt(payload.message, secretKey)
        return { ...payload, message: encrypted }
      },
    },
  })
}
``` 


[^1]: `okToReceive` would have misled developers to think that you could enforce write permissions that way; but the peer who shares document changes with you isn't necessarily the peer who made the changes. Write permissions would need to be implemented some other way — for example, the way [crdx](https://github.com/HerbCaudill/crdx) does, with cryptographic proof of authorship embedded into the CRDT. 