### PR TITLE
Add a create helper for node apps

### DIFF
--- a/packages/create-repo-node-app/.eslintrc
+++ b/packages/create-repo-node-app/.eslintrc
@@ -1,0 +1,28 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "ignorePatterns": ["dist/**", "test/**", "node_modules/**"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "semi": ["error", "never"],
+    "import/extensions": 0,
+    "lines-between-class-members": 0,
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-empty-function": ["warn", { "allow": ["methods"] }],
+    "no-param-reassign": 0,
+    "no-use-before-define": 0
+  }
+}

--- a/packages/create-repo-node-app/README.md
+++ b/packages/create-repo-node-app/README.md
@@ -1,0 +1,21 @@
+# Scaffolding for a node `automerge-repo` app
+
+This generates a simple javascript project with the necessary dependencies for a repo which synchronises over websockets and stores data in the filesystem.
+
+## How to use
+
+### NPM
+
+```
+npm create @automerge/repo-node-app <your project name>
+```
+
+### Yarn
+
+```
+yarn create @automerge/repo-node-app <your project name>
+```
+
+Now change into the directory and start editing `index.js`
+
+

--- a/packages/create-repo-node-app/package.json
+++ b/packages/create-repo-node-app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@automerge/create-repo-node-app",
+  "version": "1.0.0",
+  "description": "Create an automerge-repo app for node",
+  "repository": "https://github.com/automerge/automerge-repo/tree/master/packages/create-repo-node-app",
+  "author": "Alex Good <alex@memoryandthought.me>",
+  "license": "MIT",
+  "type": "module",
+  "bin": "dist/index.js",
+  "scripts": {
+    "build": "tsc && chmod a+x dist/index.js",
+    "watch": "npm-watch build"
+  }
+}

--- a/packages/create-repo-node-app/src/index.ts
+++ b/packages/create-repo-node-app/src/index.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// This is needed to tell your system that this file is a Node script.
+
+import fs from 'fs'
+import path from 'path'
+import child_process from 'child_process'
+
+const execSync = child_process.execSync
+
+function createPackageJson(projectName: string) {
+  const packageJson = {
+    name: projectName,
+    version: '1.0.0',
+    description: '',
+    main: 'index.js',
+    type: 'module',
+    scripts: {
+      start: 'node index.js',
+    },
+    dependencies: {
+      '@automerge/automerge-repo': '^0.1',
+      '@automerge/automerge-repo-network-websocket': '^0.1',
+      '@automerge/automerge-repo-storage-nodefs': '^0.1',
+    },
+  }
+  fs.writeFileSync(
+    path.join(projectName, 'package.json'),
+    JSON.stringify(packageJson, null, 2) + '\n'
+  )
+}
+
+function createIndexJs(projectName: string) {
+  const indexJsContent = `import { Repo } from "@automerge/automerge-repo"
+import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket"
+import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs"
+import { next as Automerge } from "@automerge/automerge"
+
+const repo = new Repo({
+  storage: [new NodeFSStorageAdapter("./db")],
+  network: [new BrowserWebSocketClientAdapter("wss://sync.automerge.org")]
+})
+`
+  fs.writeFileSync(path.join(projectName, 'index.js'), indexJsContent)
+}
+
+function main() {
+  const projectName = process.argv[2]
+  if (!projectName) {
+    console.error('Please provide a project name')
+    process.exit(1)
+  }
+
+  fs.mkdirSync(projectName)
+  createPackageJson(projectName)
+  createIndexJs(projectName)
+  execSync(`cd ${projectName} && npm install`, { stdio: 'inherit' })
+}
+
+main()
+

--- a/packages/create-repo-node-app/tsconfig.json
+++ b/packages/create-repo-node-app/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "jsx": "react",
+    "module": "NodeNext",
+    "moduleResolution": "Node16",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
It's frequently useful to be able to quickly jump into a new project with the websocket network adapter and filesystem storage set up so that you can start experimenting with repo. This commit adds an NPM "initializer" which can be used as follows:

   npm create @automerge/node-repo-app

This quickly creates an NPM package with the necessary dependencies and a simple `index.js`.