### PR TITLE
BrowserWebSocketClientAdapter: Don't throw on unknown message type

### DIFF
--- a/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
@@ -9,7 +9,6 @@ import {
   JoinMessage,
 } from "./messages.js"
 import { ProtocolV1 } from "./protocolVersion.js"
-import { isValidRepoMessage } from "@automerge/automerge-repo"
 
 const log = debug("WebsocketClient")
 
@@ -170,9 +169,6 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
         log(`error: ${decoded.message}`)
         break
       default:
-        if (!isValidRepoMessage(decoded)) {
-          throw new Error("Invalid message received")
-        }
         this.emit("message", decoded)
     }
   }


### PR DESCRIPTION
This prevents an auth provider from sending auth messages. 

It's not the network adapter's place to have opinions about messages that it doesn't handle internally -- it should just emit them and let listeners decide what to do with them. 

It is the NetworkSubsystem's job to do this check, and it already does:

https://github.com/automerge/automerge-repo/blob/703bfa2b83fb3e04e43d856ae5f83c32670d92da/packages/automerge-repo/src/network/NetworkSubsystem.ts#L68-L72