### PR TITLE
Make create-repo-node-app build script work cross-platform

### DIFF
--- a/packages/create-repo-node-app/package.json
+++ b/packages/create-repo-node-app/package.json
@@ -8,7 +8,8 @@
   "type": "module",
   "bin": "dist/index.js",
   "scripts": {
-    "build": "tsc && chmod a+x dist/index.js",
+    "build": "tsc",
+    "postbuild": "node postbuild.js",
     "watch": "npm-watch build"
   },
   "publishConfig": {

--- a/packages/create-repo-node-app/postbuild.js
+++ b/packages/create-repo-node-app/postbuild.js
@@ -1,0 +1,3 @@
+import fs from "fs"
+
+fs.chmodSync("dist/index.js", "755")


### PR DESCRIPTION
`chmod` isn't a thing on Windows so this build script fails (and consequently the monorepo-wide build script fails). 

https://github.com/automerge/automerge-repo/blob/e6131e08a899336085ad377036f047020dbec591/packages/create-repo-node-app/package.json#L11 

This is Copilot's suggestion for a cross-platform equivalent -- I can't confirm that it works, so someone should!