### PR TITLE
WIP: Stable peer ids

### DIFF
--- a/packages/automerge-repo-network-websocket/src/messages.ts
+++ b/packages/automerge-repo-network-websocket/src/messages.ts
@@ -1,4 +1,4 @@
-import type { Message, PeerId } from "@automerge/automerge-repo"
+import type { Message, PeerId, StorageId } from "@automerge/automerge-repo"
 import type { ProtocolVersion } from "./protocolVersion.js"
 
 /** The sender is disconnecting */
@@ -12,6 +12,14 @@ export type JoinMessage = {
   type: "join"
   /** The PeerID of the client */
   senderId: PeerId
+
+  /** Unique ID of the storage that the sender peer is using, is persistent across sessions */
+  storageId?: StorageId
+
+  /** Indicates whether other peers should persist the sync state of the sender peer.
+   * Sync state is only persisted for non-ephemeral peers */
+  isEphemeral: boolean
+
   /** The protocol version the client supports */
   supportedProtocolVersions: ProtocolVersion[]
 }
@@ -21,6 +29,14 @@ export type PeerMessage = {
   type: "peer"
   /** The PeerID of the server */
   senderId: PeerId
+
+  /** Unique ID of the storage that the sender peer is using, is persistent across sessions */
+  storageId?: StorageId
+
+  /** Indicates whether other peers should persist the sync state of the sender peer.
+   * Sync state is only persisted for non-ephemeral peers */
+  isEphemeral: boolean
+
   /** The protocol version the server selected for this connection */
   selectedProtocolVersion: ProtocolVersion
   /** The PeerID of the client */

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -83,6 +83,7 @@ export type {
   ChunkInfo,
   ChunkType,
   StorageKey,
+  StorageId,
 } from "./storage/types.js"
 
 export * from "./types.js"

--- a/packages/automerge-repo/src/network/NetworkAdapter.ts
+++ b/packages/automerge-repo/src/network/NetworkAdapter.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "eventemitter3"
 import { PeerId } from "../types.js"
 import { Message } from "./messages.js"
+import { StorageId } from "../storage/types.js"
 
 /** An interface representing some way to connect to other peers
  *
@@ -11,12 +12,20 @@ import { Message } from "./messages.js"
  */
 export abstract class NetworkAdapter extends EventEmitter<NetworkAdapterEvents> {
   peerId?: PeerId // hmmm, maybe not
+  storageId?: StorageId
+  isEphemeral: boolean = true
 
   /** Called by the {@link Repo} to start the connection process
    *
    * @argument peerId - the peerId of this repo
+   * @argument storageId - the storage id of the peer
+   * @argument isEphemeral - weather or not the other end should persist our sync state
    */
-  abstract connect(peerId: PeerId): void
+  abstract connect(
+    peerId: PeerId,
+    storageId: StorageId | undefined,
+    isEphemeral: boolean
+  ): void
 
   /** Called by the {@link Repo} to send a message to a peer
    *
@@ -53,6 +62,8 @@ export interface OpenPayload {
 
 export interface PeerCandidatePayload {
   peerId: PeerId
+  storageId?: StorageId
+  isEphemeral: boolean
 }
 
 export interface PeerDisconnectedPayload {

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -32,14 +32,14 @@ export class StorageSubsystem {
     this.#storageAdapter = storageAdapter
   }
 
-  async id(): Promise<string> {
+  async id(): Promise<StorageId> {
     let storedId = await this.#storageAdapter.load(["storage-adapter-id"])
 
-    let id
+    let id: StorageId
     if (storedId) {
-      id = new TextDecoder().decode(storedId)
+      id = new TextDecoder().decode(storedId) as StorageId
     } else {
-      id = Uuid.v4()
+      id = Uuid.v4() as StorageId
       await this.#storageAdapter.save(
         ["storage-adapter-id"],
         new TextEncoder().encode(id)
@@ -282,3 +282,6 @@ export class StorageSubsystem {
     return incrementalSize >= snapshotSize
   }
 }
+
+/** A branded type for storage IDs */
+export type StorageId = string & { __storageId: true }

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -2,9 +2,9 @@ import * as A from "@automerge/automerge/next"
 import debug from "debug"
 import { headsAreSame } from "../helpers/headsAreSame.js"
 import { mergeArrays } from "../helpers/mergeArrays.js"
-import { PeerId, type DocumentId } from "../types.js"
+import { type DocumentId } from "../types.js"
 import { StorageAdapter } from "./StorageAdapter.js"
-import { ChunkInfo, StorageKey } from "./types.js"
+import { ChunkInfo, StorageKey, StorageId } from "./types.js"
 import { keyHash, headsHash } from "./keyHash.js"
 import { chunkTypeFromKey } from "./chunkTypeFromKey.js"
 import * as Uuid from "uuid"
@@ -229,19 +229,19 @@ export class StorageSubsystem {
 
   async loadSyncState(
     documentId: DocumentId,
-    peerId: PeerId
+    storageId: StorageId
   ): Promise<A.SyncState | undefined> {
-    const key = [documentId, "sync-state", peerId]
+    const key = [documentId, "sync-state", storageId]
     const loaded = await this.#storageAdapter.load(key)
     return loaded ? A.decodeSyncState(loaded) : undefined
   }
 
   async saveSyncState(
     documentId: DocumentId,
-    peerId: PeerId,
+    storageId: StorageId,
     syncState: A.SyncState
   ): Promise<void> {
-    const key = [documentId, "sync-state", peerId]
+    const key = [documentId, "sync-state", storageId]
     await this.#storageAdapter.save(key, A.encodeSyncState(syncState))
   }
 
@@ -282,6 +282,3 @@ export class StorageSubsystem {
     return incrementalSize >= snapshotSize
   }
 }
-
-/** A branded type for storage IDs */
-export type StorageId = string & { __storageId: true }

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -7,6 +7,7 @@ import { StorageAdapter } from "./StorageAdapter.js"
 import { ChunkInfo, StorageKey } from "./types.js"
 import { keyHash, headsHash } from "./keyHash.js"
 import { chunkTypeFromKey } from "./chunkTypeFromKey.js"
+import * as Uuid from "uuid"
 
 /**
  * The storage subsystem is responsible for saving and loading Automerge documents to and from
@@ -29,6 +30,23 @@ export class StorageSubsystem {
 
   constructor(storageAdapter: StorageAdapter) {
     this.#storageAdapter = storageAdapter
+  }
+
+  async id(): Promise<string> {
+    let storedId = await this.#storageAdapter.load(["storage-adapter-id"])
+
+    let id
+    if (storedId) {
+      id = new TextDecoder().decode(storedId)
+    } else {
+      id = Uuid.v4()
+      await this.#storageAdapter.save(
+        ["storage-adapter-id"],
+        new TextEncoder().encode(id)
+      )
+    }
+
+    return id
   }
 
   // ARBITRARY KEY/VALUE STORAGE

--- a/packages/automerge-repo/src/storage/types.ts
+++ b/packages/automerge-repo/src/storage/types.ts
@@ -37,3 +37,6 @@ export type ChunkType = "snapshot" | "incremental"
  * should not assume any particular structure.
  **/
 export type StorageKey = string[]
+
+/** A branded type for storage IDs */
+export type StorageId = string & { __storageId: true }

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -37,14 +37,19 @@ export class CollectionSynchronizer extends Synchronizer {
   #initDocSynchronizer(handle: DocHandle<unknown>): DocSynchronizer {
     const docSynchronizer = new DocSynchronizer({
       handle,
-      onLoadSyncState: peerId => {
+      onLoadSyncState: async peerId => {
         if (!this.repo.storageSubsystem) {
-          return Promise.resolve(undefined)
+          return
+        }
+
+        const persistanceInfo = this.repo.persistanceInfoByPeerId[peerId]
+        if (!persistanceInfo || persistanceInfo.isEphemeral) {
+          return
         }
 
         return this.repo.storageSubsystem.loadSyncState(
           handle.documentId,
-          peerId
+          persistanceInfo.storageId
         )
       },
     })

--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -8,6 +8,7 @@ import { describe, it } from "vitest"
 import { generateAutomergeUrl, parseAutomergeUrl } from "../src/AutomergeUrl.js"
 import { PeerId, cbor } from "../src/index.js"
 import { StorageSubsystem } from "../src/storage/StorageSubsystem.js"
+import { StorageId } from "../src/storage/types.js"
 import { DummyStorageAdapter } from "./helpers/DummyStorageAdapter.js"
 import * as Uuid from "uuid"
 
@@ -183,12 +184,15 @@ describe("StorageSubsystem", () => {
 
           const { documentId } = parseAutomergeUrl(generateAutomergeUrl())
           const syncState = A.initSyncState()
-          const bob = "bob" as PeerId
+          const bobStorageId = Uuid.v4() as StorageId
 
           const rawSyncState = A.decodeSyncState(A.encodeSyncState(syncState))
 
-          await storage.saveSyncState(documentId, bob, syncState)
-          const loadedSyncState = await storage.loadSyncState(documentId, bob)
+          await storage.saveSyncState(documentId, bobStorageId, syncState)
+          const loadedSyncState = await storage.loadSyncState(
+            documentId,
+            bobStorageId
+          )
           assert.deepStrictEqual(loadedSyncState, rawSyncState)
         })
 
@@ -197,16 +201,19 @@ describe("StorageSubsystem", () => {
 
           const { documentId } = parseAutomergeUrl(generateAutomergeUrl())
           const syncState = A.initSyncState()
-          const bob = "bob" as PeerId
+          const bobStorageId = Uuid.v4() as StorageId
 
-          await storage.saveSyncState(documentId, bob, syncState)
+          await storage.saveSyncState(documentId, bobStorageId, syncState)
           await storage.removeDoc(documentId)
-          const loadedSyncState = await storage.loadSyncState(documentId, bob)
+          const loadedSyncState = await storage.loadSyncState(
+            documentId,
+            bobStorageId
+          )
           assert.strictEqual(loadedSyncState, undefined)
         })
       })
 
-      describe("storage adapter id", () => {
+      describe("storage id", () => {
         it("generates a unique id", async () => {
           const storage = new StorageSubsystem(adapter)
 

--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -9,6 +9,7 @@ import { generateAutomergeUrl, parseAutomergeUrl } from "../src/AutomergeUrl.js"
 import { PeerId, cbor } from "../src/index.js"
 import { StorageSubsystem } from "../src/storage/StorageSubsystem.js"
 import { DummyStorageAdapter } from "./helpers/DummyStorageAdapter.js"
+import * as Uuid from "uuid"
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "automerge-repo-tests"))
 
@@ -202,6 +203,20 @@ describe("StorageSubsystem", () => {
           await storage.removeDoc(documentId)
           const loadedSyncState = await storage.loadSyncState(documentId, bob)
           assert.strictEqual(loadedSyncState, undefined)
+        })
+      })
+
+      describe("storage adapter id", () => {
+        it("generates a unique id", async () => {
+          const storage = new StorageSubsystem(adapter)
+
+          // generate unique id and return same id on subsequence calls
+          const id1 = await storage.id()
+          const id2 = await storage.id()
+
+          assert.strictEqual(Uuid.validate(id1), true)
+          assert.strictEqual(Uuid.validate(id2), true)
+          assert.strictEqual(id1, id2)
         })
       })
     })


### PR DESCRIPTION
- Create a stable storage ID that's generated once for each storage adapter. The sync state is persisted per storage ID. This makes the persisted sync state more useful because the same sync state can be reused even when the peer ID changes. Later this will make it also easier to assign sync state to logical entities like people and devices.

- On connect, each peer transmits:
  - their peerId
  - their storageId (if they have a storage adapter)
  - an isEphemeral flag (sync state of ephemeral peers will not be persisted)