### PR TITLE
Allow a broadcastChannel name to be properly set in the adapter

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -27,7 +27,7 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
 
   constructor(options?: BroadcastChannelNetworkAdapterOptions) {
     super()
-    this.#options = { ...(options ?? {}), channelName: "broadcast" }
+    this.#options = { channelName: "broadcast", ...(options ?? {}) }
   }
 
   connect(peerId: PeerId) {

--- a/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
+++ b/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
@@ -18,11 +18,11 @@ describe("BroadcastChannel", () => {
   runAdapterTests(setup)
 
   it("allows a channel name to be specified in the options and limits messages to that channel", async () => {
-    const a = new BroadcastChannelNetworkAdapter({ channelName: "test" })
-    const b = new BroadcastChannelNetworkAdapter({ channelName: "test" })
+    const a = new BroadcastChannelNetworkAdapter()
+    const b = new BroadcastChannelNetworkAdapter()
 
     // this adapter should never connect
-    const c = new BroadcastChannelNetworkAdapter()
+    const c = new BroadcastChannelNetworkAdapter({ channelName: "other" })
 
     const aConnect = new Promise<void>(resolve => {
       a.once("peer-candidate", () => resolve())
@@ -38,6 +38,7 @@ describe("BroadcastChannel", () => {
 
     a.connect("a" as PeerId)
     b.connect("b" as PeerId)
+    c.connect("c" as PeerId)
 
     return Promise.all([aConnect, cShouldNotConnect])
   })


### PR DESCRIPTION
When I implemented this originally, I somehow managed to write a test which didn't test anything I was trying to achieve. No surprise that the feature didn't actually work.

This should remedy the issue.