### PR TITLE
Make `isEphemeral` optional in network adapter's `peer-candidate` event. 

### DIFF
--- a/packages/automerge-repo/src/network/NetworkAdapter.ts
+++ b/packages/automerge-repo/src/network/NetworkAdapter.ts
@@ -63,7 +63,7 @@ export interface OpenPayload {
 export interface PeerCandidatePayload {
   peerId: PeerId
   storageId?: StorageId
-  isEphemeral: boolean
+  isEphemeral?: boolean
 }
 
 export interface PeerDisconnectedPayload {

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -54,7 +54,7 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
 
     networkAdapter.on(
       "peer-candidate",
-      ({ peerId, storageId, isEphemeral }) => {
+      ({ peerId, storageId, isEphemeral = false }) => {
         this.#log(`peer candidate: ${peerId} `)
 
         // TODO: This is where authentication would happen


### PR DESCRIPTION
Otherwise this is a breaking change.

In the listener in `NetworkSubsystem`, defaults to false; I assume this is what we'd want. 