### PR TITLE
console log when we exceed 1000ms for a load

### DIFF
--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -130,7 +130,15 @@ export class StorageSubsystem {
     if (binary.length === 0) return null
 
     // Load into an Automerge document
+    const start = performance.now()
     const newDoc = A.loadIncremental(A.init(), binary) as A.Doc<T>
+    const mark = performance.measure(`loadIncremental:${documentId}`, {
+      start,
+      end: performance.now(),
+    })
+    if (mark.duration > 1000) {
+      console.warn("long document load:", mark)
+    }
 
     // Record the latest heads for the document
     this.#storedHeads.set(documentId, A.getHeads(newDoc))


### PR DESCRIPTION
Any objection? I usually avoid checking in `console.warns()` but at least at the moment I want to emphasize finding and fixing these slow documents.