### PR TITLE
useRepo tests

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useRepo.test.tsx
+++ b/packages/automerge-repo-react-hooks/src/useRepo.test.tsx
@@ -1,31 +1,23 @@
 import { renderHook } from "@testing-library/react"
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from "vitest"
 import { RepoContext, useRepo } from "./useRepo.js"
 import { Repo } from "@automerge/automerge-repo"
 import React from "react"
 
 describe("useRepo", () => {
-  const repo = new Repo({
-    network: [],
-  })
-
-  expect(repo).toBeInstanceOf(Repo)
-  // TODO: @pvh: Move this test to automerge-repo
-  test.skip("should `new Repo({ network: [] })` work")
-
   test("should error when context unavailable", () => {
+    const repo = new Repo({ network: [] })
     // Prevent console spam by swallowing console.error "uncaught error" message
     const spy = vi.spyOn(console, "error")
     spy.mockImplementation(() => {})
-
     expect(() => renderHook(() => useRepo())).toThrow(
       /Repo was not found on RepoContext/
     )
-
     spy.mockRestore()
   })
 
   test("should return repo from context", () => {
+    const repo = new Repo({ network: [] })
     const wrapper = ({ children }) => (
       <RepoContext.Provider value={repo} children={children} />
     )

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -2,7 +2,7 @@ import { next as A } from "@automerge/automerge"
 import { MessageChannelNetworkAdapter } from "@automerge/automerge-repo-network-messagechannel"
 import assert from "assert"
 import * as Uuid from "uuid"
-import { describe, it } from "vitest"
+import { describe, expect, it } from "vitest"
 import { READY } from "../src/DocHandle.js"
 import { parseAutomergeUrl } from "../src/AutomergeUrl.js"
 import {
@@ -31,6 +31,15 @@ import { TestDoc } from "./types.js"
 import { StorageId } from "../src/storage/types.js"
 
 describe("Repo", () => {
+  describe("constructor", () => {
+    it("can be instantiated without network adapters", () => {
+      const repo = new Repo({
+        network: [],
+      })
+      expect(repo).toBeInstanceOf(Repo)
+    })
+  })
+
   describe("local only", () => {
     const setup = ({ startReady = true } = {}) => {
       const storageAdapter = new DummyStorageAdapter()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config"
 
 export default defineConfig({
   test: {
+    globals: true,
     environment: "jsdom",
     coverage: {
       provider: "v8",


### PR DESCRIPTION
In `useRepo.test.tsx`, there's a floating assertion that confirms that a repo can be instantiated with no network:

https://github.com/automerge/automerge-repo/blob/d73e71588c3835a172fdf4d19e56a1f946c041ed/packages/automerge-repo-react-hooks/src/useRepo.test.tsx#L8-L14

This PR moves that into a proper test in `Repo.test.ts`:

https://github.com/automerge/automerge-repo/blob/4e426f7b564cbca4e8fbb43b36910edad0f73f65/packages/automerge-repo/test/Repo.test.ts#L34-L41


 