### PR TITLE
move test:log to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start:syncserver": "cross-env DEBUG='WebsocketServer' yarn workspace @automerge/example-sync-server start",
     "repocheck": "manypkg check",
     "test": "vitest",
+    "test:log": "cross-env DEBUG='automerge-repo:*' vitest",
     "test:coverage": "vitest --coverage",
     "test:ui": "vitest --coverage --ui",
     "watch": "lerna run watch --parallel --stream"

--- a/packages/automerge-repo/package.json
+++ b/packages/automerge-repo/package.json
@@ -13,7 +13,6 @@
     "test:coverage": "c8 --reporter=lcov --reporter=html --reporter=text yarn test",
     "test": "vitest",
     "test:watch": "npm-watch test",
-    "test:log": "cross-env DEBUG='automerge-repo:*' yarn test",
     "fuzz": "ts-node --esm --experimentalSpecifierResolution=node fuzz/fuzz.ts"
   },
   "browser": {


### PR DESCRIPTION
Moves the `test:log` script from the automerge-repo package to the monorepo root. 