### PR TITLE
Refactor websocket adapters

### DIFF
--- a/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
@@ -23,9 +23,7 @@ abstract class WebSocketNetworkAdapter extends NetworkAdapter {
 }
 
 export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
-  // Type trickery required for platform independence,
-  // see https://stackoverflow.com/questions/45802988/typescript-use-correct-version-of-settimeout-node-vs-window
-  timerId?: ReturnType<typeof setTimeout>
+  timerId?: TimeoutId
   remotePeerId?: PeerId // this adapter only connects to one remote client at a time
   #startupComplete: boolean = false
 
@@ -194,3 +192,5 @@ function joinMessage(
     supportedProtocolVersions: [ProtocolV1],
   }
 }
+
+type TimeoutId = ReturnType<typeof setTimeout> //  https://stackoverflow.com/questions/45802988

--- a/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
@@ -52,6 +52,7 @@ export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
       this.socket.removeEventListener("open", this.onOpen)
       this.socket.removeEventListener("close", this.onClose)
       this.socket.removeEventListener("message", this.onMessage)
+      this.socket.removeEventListener("error", this.onError)
     }
     // Wire up retries
     if (!this.#retryIntervalId)

--- a/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
@@ -15,10 +15,6 @@ import { ProtocolV1, ProtocolVersion } from "./protocolVersion.js"
 
 const { encode, decode } = cborHelpers
 
-interface WebSocketWithIsAlive extends WebSocket {
-  isAlive: boolean
-}
-
 export class NodeWSServerAdapter extends NetworkAdapter {
   server: WebSocketServer
   sockets: { [peerId: PeerId]: WebSocket } = {}
@@ -190,4 +186,8 @@ function selectProtocol(versions?: ProtocolVersion[]): ProtocolVersion | null {
     return ProtocolV1
   }
   return null
+}
+
+interface WebSocketWithIsAlive extends WebSocket {
+  isAlive: boolean
 }

--- a/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
@@ -113,6 +113,11 @@ export class NodeWSServerAdapter extends NetworkAdapter {
 
     const myPeerId = this.peerId
     if (!myPeerId) throw new Error("Missing my peer ID.")
+
+    const documentId = "documentId" in message ? "@" + message.documentId : ""
+    const { byteLength } = messageBytes
+    log(`[${senderId}->${myPeerId}${documentId}] ${type} | ${byteLength} bytes`)
+
     switch (type) {
       case "join":
         {

--- a/packages/automerge-repo-network-websocket/src/assert.ts
+++ b/packages/automerge-repo-network-websocket/src/assert.ts
@@ -1,0 +1,28 @@
+/* c8 ignore start */
+
+export function assert(value: boolean, message?: string): asserts value
+export function assert<T>(
+  value: T | undefined,
+  message?: string
+): asserts value is T
+export function assert(value: any, message = "Assertion failed") {
+  if (value === false || value === null || value === undefined) {
+    const error = new Error(trimLines(message))
+    error.stack = removeLine(error.stack, "assert.ts")
+    throw error
+  }
+}
+
+const trimLines = (s: string) =>
+  s
+    .split("\n")
+    .map(s => s.trim())
+    .join("\n")
+
+const removeLine = (s = "", targetText: string) =>
+  s
+    .split("\n")
+    .filter(line => !line.includes(targetText))
+    .join("\n")
+
+/* c8 ignore end */

--- a/packages/automerge-repo-network-websocket/src/messages.ts
+++ b/packages/automerge-repo-network-websocket/src/messages.ts
@@ -46,11 +46,26 @@ export type ErrorMessage = {
   targetId: PeerId
 }
 
-// This adapter doesn't use the network adapter Message types, it has its own idea of how to handle
-// join/leave
-
 /** A message from the client to the server */
 export type FromClientMessage = JoinMessage | LeaveMessage | Message
 
 /** A message from the server to the client */
 export type FromServerMessage = PeerMessage | ErrorMessage | Message
+
+// TYPE GUARDS
+
+export const isJoinMessage = (
+  message: FromClientMessage
+): message is JoinMessage => message.type === "join"
+
+export const isLeaveMessage = (
+  message: FromClientMessage
+): message is LeaveMessage => message.type === "leave"
+
+export const isPeerMessage = (
+  message: FromServerMessage
+): message is PeerMessage => message.type === "peer"
+
+export const isErrorMessage = (
+  message: FromServerMessage
+): message is ErrorMessage => message.type === "error"

--- a/packages/automerge-repo-network-websocket/src/toArrayBuffer.ts
+++ b/packages/automerge-repo-network-websocket/src/toArrayBuffer.ts
@@ -1,0 +1,8 @@
+/**
+ * This incantation deals with websocket sending the whole underlying buffer even if we just have a
+ * uint8array view on it
+ */
+export const toArrayBuffer = (bytes: Uint8Array) => {
+  const { buffer, byteOffset, byteLength } = bytes
+  return buffer.slice(byteOffset, byteOffset + byteLength)
+}

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -19,10 +19,9 @@ import http from "http"
 import { getPortPromise as getAvailablePort } from "portfinder"
 import { describe, it } from "vitest"
 import WebSocket from "ws"
-import { BrowserWebSocketClientAdapter } from "../src/BrowserWebSocketClientAdapter.js"
 import { NodeWSServerAdapter } from "../src/NodeWSServerAdapter.js"
 
-describe.only("Websocket adapters", () => {
+describe("Websocket adapters", () => {
   const browserPeerId = "browser" as PeerId
   const serverPeerId = "server" as PeerId
   const documentId = parseAutomergeUrl(generateAutomergeUrl()).documentId

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -19,6 +19,7 @@ import http from "http"
 import { getPortPromise as getAvailablePort } from "portfinder"
 import { describe, it } from "vitest"
 import WebSocket from "ws"
+import { BrowserWebSocketClientAdapter } from "../src/BrowserWebSocketClientAdapter.js"
 import { NodeWSServerAdapter } from "../src/NodeWSServerAdapter.js"
 
 describe("Websocket adapters", () => {


### PR DESCRIPTION
- Refactors `BrowserWebSocketClientAdapter` and `NodeWSServerAdapter` for readability and maintainability - see comments below. 
- Makes the retry and keepAlive intervals configurable, so we can speed them up in testing and get those processes covered by tests.
- Handles the `leave` message on the server - see comments. 
- Implements the `disconnect` method on the server - see comments.
- Refactors the package's test suites to simplify setup.
- Adds tests to bring this package to 100% coverage. 