### PR TITLE
feat(automerge-repo): add export method

### DIFF
--- a/packages/automerge-repo/README.md
+++ b/packages/automerge-repo/README.md
@@ -45,6 +45,8 @@ A `Repo` exposes these methods:
   networks.
 - `delete(docId: DocumentId)`  
   Deletes the local copy of a document from the local cache and local storage. _This does not currently delete the document from any other peers_.
+- `export(docId: DocumentId)`  
+  Exports the document. Returns a Promise containing either the Uint8Array of the document or undefined if the document is currently unavailable. See the [Automerge binary format spec](https://automerge.org/automerge-binary-format-spec/) for more details on the shape of the Uint8Array.
 - `.on("document", ({handle: DocHandle}) => void)`  
   Registers a callback to be fired each time a new document is loaded or created.
 - `.on("delete-document", ({handle: DocHandle}) => void)`  

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -450,6 +450,24 @@ export class Repo extends EventEmitter<RepoEvents> {
     this.emit("delete-document", { documentId })
   }
 
+  /**
+   * Exports a document to a binary format.
+   * @param id - The url or documentId of the handle to export
+   *
+   * @returns Promise<Uint8Array | undefined> - A Promise containing the binary document,
+   * or undefined if the document is unavailable.
+   */
+  async export(
+    id: AnyDocumentId
+  ): Promise<Uint8Array | undefined> {
+    const documentId = interpretAsDocumentId(id)
+
+    const handle = this.#getHandle(documentId, false)
+    const doc = await handle.doc()
+    if (!doc) return undefined
+    return Automerge.save(doc)
+  }
+
   subscribeToRemotes = (remotes: StorageId[]) => {
     this.#log("subscribeToRemotes", { remotes })
     this.#remoteHeadsSubscriptions.subscribeToRemotes(remotes)

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -13,6 +13,7 @@ import { Repo } from "../src/Repo.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
 import {
+  AnyDocumentId,
   AutomergeUrl,
   DocHandle,
   DocumentId,
@@ -320,6 +321,27 @@ describe("Repo", () => {
 
         repo.delete(handle.documentId)
       }))
+
+    it("exports a document", async () => {
+      const { repo } = setup()
+      const handle = repo.create<TestDoc>()
+      handle.change(d => {
+        d.foo = "bar"
+      })
+      assert.equal(handle.isReady(), true)
+
+      const exported = await repo.export(handle.documentId)
+      const loaded = A.load(exported)
+      const doc = await handle.doc()
+      assert.deepEqual(doc, loaded)
+    })
+
+    it("rejects when exporting a document that does not exist", async () => {
+      const { repo } = setup()
+      assert.rejects(async () => {
+        await repo.export("foo" as AnyDocumentId)
+      })
+    })
 
     it("storage state doesn't change across reloads when the document hasn't changed", async () => {
       const storage = new DummyStorageAdapter()


### PR DESCRIPTION
Following up from https://github.com/automerge/automerge-repo/pull/251, this adds an export convenience method that will export a document without having to dip into automerge's `A.save()`

