### PR TITLE
improve handling of changing URLs in useDocument and useHandle

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -1,6 +1,6 @@
 import { ChangeFn, ChangeOptions, Doc } from "@automerge/automerge/next"
 import { AutomergeUrl, DocHandleChangePayload } from "@automerge/automerge-repo"
-import { useLayoutEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useRepo } from "./useRepo.js"
 
 /** A hook which returns a document identified by a URL and a function to change the document.
@@ -18,13 +18,9 @@ export function useDocument<T>(
   const repo = useRepo()
 
   const handle = documentUrl ? repo.find<T>(documentUrl) : null
-
   const handleRef = useRef(null)
 
-  // Doing this in a useLayoutEffect seems to help make sure that
-  // a loading state gets rendered before we block the UI thread
-  // with a slow load.
-  useLayoutEffect(() => {
+  useEffect(() => {
     // When the handle has changed, reset the doc to an empty state.
     // This ensures that if loading the doc takes a long time, the UI
     // shows a loading state during that time rather than a stale doc.

--- a/packages/automerge-repo-react-hooks/src/useHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useHandle.ts
@@ -1,5 +1,5 @@
 import { AutomergeUrl, DocHandle } from "@automerge/automerge-repo"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useRepo } from "./useRepo.js"
 
 /** A hook which returns a {@link DocHandle} identified by a URL.
@@ -7,8 +7,15 @@ import { useRepo } from "./useRepo.js"
  * @remarks
  * This requires a {@link RepoContext} to be provided by a parent component.
  */
-export function useHandle<T>(automergeUrl: AutomergeUrl): DocHandle<T> {
+export function useHandle<T>(docUrl?: AutomergeUrl): DocHandle<T> | undefined {
   const repo = useRepo()
-  const [handle] = useState<DocHandle<T>>(repo.find(automergeUrl))
+  const [handle, setHandle] = useState<DocHandle<T>>(
+    docUrl ? repo.find(docUrl) : undefined
+  )
+
+  useEffect(() => {
+    setHandle(docUrl ? repo.find(docUrl) : undefined)
+  }, [docUrl])
+
   return handle
 }

--- a/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
@@ -17,6 +17,8 @@ function getRepoWrapper(repo: Repo) {
   )
 }
 
+const SLOW_DOC_LOAD_TIME_MS = 10
+
 describe("useDocument", () => {
   const repo = new Repo({
     peerId: "bob" as PeerId,
@@ -31,10 +33,24 @@ describe("useDocument", () => {
     const handleB = repo.create<ExampleDoc>()
     handleB.change(doc => (doc.foo = "B"))
 
+    // A doc that takes 10ms to load, to simulate a slow load.
+    // The time value isn't totally arbitrary; 1ms can cause flaky tests
+    // presumably because of interations with React's scheduler / batched
+    // renders, but 10ms seems safe empirically.
+    const handleSlow = repo.create<ExampleDoc>()
+    handleSlow.change(doc => (doc.foo = "slow"))
+    const oldDoc = handleSlow.doc.bind(handleSlow)
+    handleSlow.doc = async () => {
+      await new Promise(resolve => setTimeout(resolve, SLOW_DOC_LOAD_TIME_MS))
+      const result = await oldDoc()
+      return result
+    }
+
     return {
       repo,
       handleA,
       handleB,
+      handleSlow,
       wrapper: getRepoWrapper(repo),
     }
   }
@@ -87,5 +103,72 @@ describe("useDocument", () => {
     result.current.setUrl(undefined)
     await waitForNextUpdate()
     assert.deepStrictEqual(result.current.doc, undefined)
+  })
+
+  it("sets the doc to undefined while the initial load is happening", async () => {
+    const { wrapper, handleA, handleSlow } = setup()
+
+    const { result, waitForNextUpdate, waitFor } = renderHook(
+      () => {
+        const [url, setUrl] = useState<AutomergeUrl>()
+        const [doc] = useDocument(url)
+
+        return {
+          setUrl,
+          doc,
+        }
+      },
+      { wrapper }
+    )
+
+    // initially doc is undefined
+    assert.deepStrictEqual(result.current.doc, undefined)
+
+    // start by setting url to doc A
+    result.current.setUrl(handleA.url)
+    await waitForNextUpdate()
+    assert.deepStrictEqual(result.current.doc, { foo: "A" })
+
+    // Now we set the URL to a handle that's slow to load.
+    // The doc should be undefined while the load is happening.
+    result.current.setUrl(handleSlow.url)
+    await waitForNextUpdate()
+    assert.deepStrictEqual(result.current.doc, undefined)
+    await waitForNextUpdate()
+    assert.deepStrictEqual(result.current.doc, { foo: "slow" })
+  })
+
+  it("avoids showing stale data", async () => {
+    const { wrapper, handleA, handleSlow } = setup()
+
+    const { result, waitForNextUpdate, waitFor } = renderHook(
+      () => {
+        const [url, setUrl] = useState<AutomergeUrl>()
+        const [doc] = useDocument(url)
+
+        return {
+          setUrl,
+          doc,
+        }
+      },
+      { wrapper }
+    )
+
+    // initially doc is undefined
+    assert.deepStrictEqual(result.current.doc, undefined)
+
+    // Set the URL to a slow doc and then a fast doc.
+    // We should see the fast doc forever, even after
+    // the slow doc has had time to finish loading.
+    result.current.setUrl(handleSlow.url)
+    result.current.setUrl(handleA.url)
+    await waitForNextUpdate()
+    assert.deepStrictEqual(result.current.doc, { foo: "A" })
+
+    // wait for the slow doc to finish loading...
+    await new Promise(resolve => setTimeout(resolve, SLOW_DOC_LOAD_TIME_MS * 2))
+
+    // we didn't update the doc to the slow doc, so it should still be A
+    assert.deepStrictEqual(result.current.doc, { foo: "A" })
   })
 })

--- a/packages/automerge-repo-react-hooks/test/useHandle.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useHandle.test.tsx
@@ -1,0 +1,110 @@
+import { PeerId, Repo, AutomergeUrl } from "@automerge/automerge-repo"
+import { DummyStorageAdapter } from "@automerge/automerge-repo/test/helpers/DummyStorageAdapter"
+import { describe, it } from "vitest"
+import { RepoContext } from "../src/useRepo"
+import { useHandle } from "../src/useHandle"
+import { renderHook } from "@testing-library/react-hooks"
+import React, { useState } from "react"
+import assert from "assert"
+
+interface ExampleDoc {
+  foo: string
+}
+
+function getRepoWrapper(repo: Repo) {
+  return ({ children }) => (
+    <RepoContext.Provider value={repo}>{children}</RepoContext.Provider>
+  )
+}
+
+describe("useHandle", () => {
+  const repo = new Repo({
+    peerId: "bob" as PeerId,
+    network: [],
+    storage: new DummyStorageAdapter(),
+  })
+
+  function setup() {
+    const handleA = repo.create<ExampleDoc>()
+    handleA.change(doc => (doc.foo = "A"))
+
+    const handleB = repo.create<ExampleDoc>()
+    handleB.change(doc => (doc.foo = "B"))
+
+    return {
+      repo,
+      handleA,
+      handleB,
+      wrapper: getRepoWrapper(repo),
+    }
+  }
+
+  it("loads a handle", async () => {
+    const { handleA, wrapper } = setup()
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => {
+        const handle = useHandle(handleA.url)
+
+        return {
+          handle,
+        }
+      },
+      { wrapper }
+    )
+
+    assert.deepStrictEqual(result.current.handle, handleA)
+  })
+
+  it("returns undefined when no url given", async () => {
+    const { handleA, wrapper } = setup()
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => {
+        const handle = useHandle()
+
+        return {
+          handle,
+        }
+      },
+      { wrapper }
+    )
+
+    assert.deepStrictEqual(result.current.handle, undefined)
+  })
+
+  it("updates the handle when the url changes", async () => {
+    const { wrapper, handleA, handleB } = setup()
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => {
+        const [url, setUrl] = useState<AutomergeUrl>()
+        const handle = useHandle(url)
+
+        return {
+          setUrl,
+          handle,
+        }
+      },
+      { wrapper }
+    )
+
+    // initially doc is undefined
+    assert.deepStrictEqual(result.current.handle, undefined)
+
+    // set url to doc A
+    result.current.setUrl(handleA.url)
+    await waitForNextUpdate()
+    assert.deepStrictEqual(result.current.handle, handleA)
+
+    // set url to doc B
+    result.current.setUrl(handleB.url)
+    await waitForNextUpdate()
+    assert.deepStrictEqual(result.current.handle, handleB)
+
+    // set url to undefined
+    result.current.setUrl(undefined)
+    await waitForNextUpdate()
+    assert.deepStrictEqual(result.current.handle, undefined)
+  })
+})


### PR DESCRIPTION
Previously, useDocument did not behave well for documents that took a long time to load:

1) while a load was blocking the UI, an old stale doc would be shown (potentially for multiple seconds for large docs).
2) loads that finished out of order could result in an inconsistent final state.

We have seen this cause problems in the "DocConnector" sidebar in trail-runner.

Below are demos of the two issues with a [demo app](https://github.com/inkandswitch/tiny-essay-editor/tree/knapsack/src/knapsack/components) based on the trail-runner sidebar. When you click an entry on the left, it loads a new doc URL and shows it in the main pane. The main pane shows the doc URL as well as the doc contents. (I've assigned each url a color to make visual inspection easier.)

1) stale docs during loads: while the Embark essay loads, we see the old doc still:

https://github.com/automerge/automerge-repo/assets/934016/2c2d6e65-8c00-4792-b85f-b47ada9da0e9

2) when I click on the slow-loading Embark essay and then another already-loaded doc, we end up with the Embark essay doc contents, which don't match the doc url that's supposed to be shown in the main pane:

https://github.com/automerge/automerge-repo/assets/934016/b1f9e2cf-83ad-4f85-a456-b58df3a1df1f

## solution

- Upon a handle changing, the old doc contents are cleared out to avoid staleness inconsistencies.
- Out-of-order loads are accounted for; when a load finishes it's ignored if the handle has since changed.

Here are demos of the fixed behavior in the same two cases shown above:

1) Now while the Embark essay loads we see a loading state in the main pane because the doc url is set to undefined:

https://github.com/automerge/automerge-repo/assets/934016/f76d3c6c-59ca-4834-8dd2-085c430f4897

2) When we click the same out of order as before, we end up in the correct consistent state. (When the Embark essay finishes loading, that's ignored because the handle has moved on. You can't fully see this visually but I've confirmed it with console logs)

https://github.com/automerge/automerge-repo/assets/934016/f9b416c3-ff9a-42d9-a71f-fe470c0d9b73

## todos

- need to figure out how to do automated tests for this. 
- I saw this broke one existing test, need to see if that's a real issue or not.