### PR TITLE
Only forward sync state messages with a more recent timestamp

### DIFF
--- a/packages/automerge-repo/src/RemoteHeadsSubscriptions.ts
+++ b/packages/automerge-repo/src/RemoteHeadsSubscriptions.ts
@@ -348,12 +348,12 @@ export class RemoteHeadsSubscriptions extends EventEmitter<RemoteHeadsSubscripti
       }
       let remote = this.#knownHeads.get(documentId)
       if (!remote) {
-        remote = new Map([[storageId as StorageId, { heads, timestamp }]])
+        remote = new Map()
         this.#knownHeads.set(documentId, remote)
       }
 
       const docRemote = remote.get(storageId as StorageId)
-      if (docRemote && docRemote.timestamp > timestamp) {
+      if (docRemote && docRemote.timestamp >= timestamp) {
         continue
       } else {
         remote.set(storageId as StorageId, { timestamp, heads })

--- a/packages/automerge-repo/test/RemoteHeadsSubscriptions.test.ts
+++ b/packages/automerge-repo/test/RemoteHeadsSubscriptions.test.ts
@@ -287,7 +287,7 @@ describe("RepoHeadsSubscriptions", () => {
     assert.strictEqual(messages.length, 0)
   })
 
-  it("should ignore sync states with an older timestamp", async () => {
+  it("should only notify of sync states with a more recent timestamp", async () => {
     const remoteHeadsSubscription = new RemoteHeadsSubscriptions()
 
     const messagesPromise = waitForMessages(
@@ -296,6 +296,9 @@ describe("RepoHeadsSubscriptions", () => {
     )
 
     remoteHeadsSubscription.subscribeToRemotes([storageB])
+    remoteHeadsSubscription.handleRemoteHeads(docBHeadsChangedForStorageB2)
+
+    // send same message
     remoteHeadsSubscription.handleRemoteHeads(docBHeadsChangedForStorageB2)
 
     // send message with old heads


### PR DESCRIPTION
When the RemoteHeadsSubscription object receives a remote head event, it checks if the timestamp is older than the remote heads to avoid forwarding old remote heads. The problem is that if the timestamp is equal, it would also forward the remote heads. In standalone TEE, this would lead to an infinite loop of remote heads being forwarded if one document was open in the same browser on multiple tabs. This pull request fixes this so peers only forward the sync state if it's more recent.