### PR TITLE
fix: worker.plugins is now a function warning

### DIFF
--- a/examples/react-counter/vite.config.ts
+++ b/examples/react-counter/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   worker: {
     format: "es",
-    plugins: [wasm()],
+    plugins: () => [wasm()],
   },
 
   optimizeDeps: {

--- a/examples/react-todo/vite.config.ts
+++ b/examples/react-todo/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 
   worker: {
     format: "es",
-    plugins: [wasm(), topLevelAwait()],
+    plugins: () => [wasm(), topLevelAwait()],
   },
 
   optimizeDeps: {

--- a/examples/react-use-awareness/vite.config.js
+++ b/examples/react-use-awareness/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
     topLevelAwait()
   ],
   worker: {
-    plugins: [
+    plugins: () => [
       wasm(),
       topLevelAwait()
     ]

--- a/examples/svelte-counter/vite.config.ts
+++ b/examples/svelte-counter/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 
   worker: {
     format: "es",
-    plugins: [wasm(), topLevelAwait()],
+    plugins: () => [wasm(), topLevelAwait()],
   },
 
   optimizeDeps: {


### PR DESCRIPTION
When starting one of the examples vite throws the following warning:

> worker.plugins is now a function that returns an array of plugins. Please update your Vite config accordingly.

This PR updates the Vite config accordingly.