### PR TITLE
Fix types on react hooks

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useBootstrap.ts
+++ b/packages/automerge-repo-react-hooks/src/useBootstrap.ts
@@ -28,10 +28,14 @@ export const useHash = () => {
 
 // Get a key from a query-param-style URL hash
 const getQueryParamValue = (key: string, hash: string) =>
-  new URLSearchParams(hash.substr(1)).get(key)
+  new URLSearchParams(hash.slice(1)).get(key)
 
-const setQueryParamValue = (key: string, value, hash): string => {
-  const u = new URLSearchParams(hash.substr(1))
+const setQueryParamValue = (
+  key: string,
+  value: string,
+  hash: string
+): string => {
+  const u = new URLSearchParams(hash.slice(1))
   u.set(key, value)
   return u.toString()
 }
@@ -90,7 +94,7 @@ export const useBootstrap = <T>({
     } catch (error) {
       // Presumably the URL was invalid
       if (url && onInvalidAutomergeUrl)
-        return onInvalidAutomergeUrl(repo, error)
+        return onInvalidAutomergeUrl(repo, error as Error)
       // Forward other errors
       throw error
     }

--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -1,5 +1,8 @@
+import {
+  AnyDocumentId,
+  DocHandleChangePayload,
+} from "@automerge/automerge-repo"
 import { ChangeFn, ChangeOptions, Doc } from "@automerge/automerge/next"
-import { AutomergeUrl, DocHandleChangePayload } from "@automerge/automerge-repo"
 import { useEffect, useRef, useState } from "react"
 import { useRepo } from "./useRepo.js"
 
@@ -12,12 +15,12 @@ import { useRepo } from "./useRepo.js"
  * This requires a {@link RepoContext} to be provided by a parent component.
  * */
 export function useDocument<T>(
-  documentUrl?: AutomergeUrl
+  id?: AnyDocumentId
 ): [Doc<T> | undefined, (changeFn: ChangeFn<T>) => void] {
   const [doc, setDoc] = useState<Doc<T>>()
   const repo = useRepo()
 
-  const handle = documentUrl ? repo.find<T>(documentUrl) : null
+  const handle = id ? repo.find<T>(id) : null
   const handleRef = useRef(null)
 
   useEffect(() => {

--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -1,5 +1,6 @@
 import {
   AnyDocumentId,
+  DocHandle,
   DocHandleChangePayload,
 } from "@automerge/automerge-repo"
 import { ChangeFn, ChangeOptions, Doc } from "@automerge/automerge/next"
@@ -19,7 +20,7 @@ export function useDocument<T>(id?: AnyDocumentId) {
   const repo = useRepo()
 
   const handle = id ? repo.find<T>(id) : null
-  const handleRef = useRef(null)
+  const handleRef = useRef<DocHandle<T> | null>(null)
 
   useEffect(() => {
     // When the handle has changed, reset the doc to an empty state.

--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -14,9 +14,7 @@ import { useRepo } from "./useRepo.js"
  * @remarks
  * This requires a {@link RepoContext} to be provided by a parent component.
  * */
-export function useDocument<T>(
-  id?: AnyDocumentId
-): [Doc<T> | undefined, (changeFn: ChangeFn<T>) => void] {
+export function useDocument<T>(id?: AnyDocumentId) {
   const [doc, setDoc] = useState<Doc<T>>()
   const repo = useRepo()
 
@@ -61,5 +59,5 @@ export function useDocument<T>(
     handle.change(changeFn, options)
   }
 
-  return [doc, changeDoc]
+  return [doc, changeDoc] as const
 }

--- a/packages/automerge-repo-react-hooks/src/useHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useHandle.ts
@@ -9,7 +9,7 @@ import { useRepo } from "./useRepo.js"
  */
 export function useHandle<T>(id?: AnyDocumentId): DocHandle<T> | undefined {
   const repo = useRepo()
-  const [handle, setHandle] = useState<DocHandle<T>>(
+  const [handle, setHandle] = useState<DocHandle<T> | undefined>(
     id ? repo.find(id) : undefined
   )
 

--- a/packages/automerge-repo-react-hooks/src/useHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useHandle.ts
@@ -7,7 +7,7 @@ import { useRepo } from "./useRepo.js"
  * @remarks
  * This requires a {@link RepoContext} to be provided by a parent component.
  */
-export function useHandle<T>(id?: AnyDocumentId): DocHandle<T> | undefined {
+export function useHandle<T>(id?: AnyDocumentId) {
   const repo = useRepo()
   const [handle, setHandle] = useState<DocHandle<T> | undefined>(
     id ? repo.find(id) : undefined

--- a/packages/automerge-repo-react-hooks/src/useHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useHandle.ts
@@ -1,4 +1,4 @@
-import { AutomergeUrl, DocHandle } from "@automerge/automerge-repo"
+import { AnyDocumentId, DocHandle } from "@automerge/automerge-repo"
 import { useEffect, useState } from "react"
 import { useRepo } from "./useRepo.js"
 
@@ -7,15 +7,15 @@ import { useRepo } from "./useRepo.js"
  * @remarks
  * This requires a {@link RepoContext} to be provided by a parent component.
  */
-export function useHandle<T>(docUrl?: AutomergeUrl): DocHandle<T> | undefined {
+export function useHandle<T>(id?: AnyDocumentId): DocHandle<T> | undefined {
   const repo = useRepo()
   const [handle, setHandle] = useState<DocHandle<T>>(
-    docUrl ? repo.find(docUrl) : undefined
+    id ? repo.find(id) : undefined
   )
 
   useEffect(() => {
-    setHandle(docUrl ? repo.find(docUrl) : undefined)
-  }, [docUrl])
+    setHandle(id ? repo.find(id) : undefined)
+  }, [id])
 
   return handle
 }

--- a/packages/automerge-repo-react-hooks/src/useLocalAwareness.ts
+++ b/packages/automerge-repo-react-hooks/src/useLocalAwareness.ts
@@ -36,7 +36,7 @@ export const useLocalAwareness = ({
 }: UseLocalAwarenessProps) => {
   const [localState, setLocalState, localStateRef] = useStateRef(initialState)
 
-  const setState = stateOrUpdater => {
+  const setState = (stateOrUpdater: any) => {
     const state =
       typeof stateOrUpdater === "function"
         ? stateOrUpdater(localStateRef.current)
@@ -58,7 +58,7 @@ export const useLocalAwareness = ({
 
   useEffect(() => {
     // Send entire state to new peers
-    let broadcastTimeoutId
+    let broadcastTimeoutId: ReturnType<typeof setTimeout>
     const newPeerEvents = peerEvents.on("new_peer", e => {
       broadcastTimeoutId = setTimeout(
         () => handle.broadcast([userId, localStateRef.current]),

--- a/packages/automerge-repo-react-hooks/tsconfig.json
+++ b/packages/automerge-repo-react-hooks/tsconfig.json
@@ -9,8 +9,10 @@
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
- On `useDocument` and `useHandle`, changes the type of the id parameter from `AutomergeUrl` to `AnyDocumentId`, since that's what `repo.find()` takes. 
- Enables strict type checking for this package, and adds/modifies types as necessary. 