### PR TITLE
Remove unused function

### DIFF
--- a/packages/automerge-repo/src/helpers/pause.ts
+++ b/packages/automerge-repo/src/helpers/pause.ts
@@ -3,16 +3,4 @@
 export const pause = (t = 0) =>
   new Promise<void>(resolve => setTimeout(() => resolve(), t))
 
-export function rejectOnTimeout<T>(
-  promise: Promise<T>,
-  millis: number
-): Promise<T> {
-  return Promise.race([
-    promise,
-    pause(millis).then(() => {
-      throw new Error("timeout exceeded")
-    }),
-  ])
-}
-
 /* c8 ignore end */


### PR DESCRIPTION
the function `rejectOnTimeout` isn't used anywhere in the codebase - it was supplanted by [`withTimeout`](/automerge/automerge-repo/blob/main/packages/automerge-repo/src/helpers/withTimeout.ts). 