### PR TITLE
useDocuments hook

### DIFF
--- a/packages/automerge-repo-react-hooks/src/index.ts
+++ b/packages/automerge-repo-react-hooks/src/index.ts
@@ -2,51 +2,51 @@
  * @packageDocumentation
  *
  * # React Hooks for Automerge Repo
- * 
+ *
  * These hooks are provided as helpers for using Automerge in your React project.
- * 
+ *
  * #### {@link useBootstrap}
  * This hook is used to load a document based on the URL hash, for example `//myapp/#documentId=[document ID]`.
  * It can also load the document ID from localStorage, or create a new document if none is specified.
- * 
+ *
  * #### {@link useLocalAwareness} & {@link useRemoteAwareness}
  * These hooks implement ephemeral awareness/presence, similar to [Yjs Awareness](https://docs.yjs.dev/getting-started/adding-awareness).
- * They allow temporary state to be shared, such as cursor positions or peer online/offline status. 
- * 
+ * They allow temporary state to be shared, such as cursor positions or peer online/offline status.
+ *
  * Ephemeral messages are replicated between peers, but not saved to the Automerge doc, and are used for temporary updates that will be discarded.
- * 
+ *
  * #### {@link useRepo}/{@link RepoContext}
  * Use RepoContext to set up react context for an Automerge repo.
  * Use useRepo to lookup the repo from context.
  * Most hooks depend on RepoContext being available.
- * 
+ *
  * #### {@link useDocument }
  * Return a document & updater fn, by ID.
- * 
+ *
  * #### {@link useHandle }
  * Return a handle, by ID.
- * 
+ *
  * ## Example usage
- * 
+ *
  * ### App Setup
- * 
+ *
  * ```ts
  * import React, { StrictMode } from "react"
  * import ReactDOM from "react-dom/client"
- * 
+ *
  * import { Repo, DocCollection } from "@automerge/automerge-repo"
- * 
+ *
  * import { BroadcastChannelNetworkAdapter } from "@automerge/automerge-repo-network-broadcastchannel"
- * 
+ *
  * import App, { RootDocument } from "./App.js"
  * import { RepoContext } from "@automerge/automerge-repo-react-hooks"
- * 
+ *
  * // eslint-disable-next-line @typescript-eslint/no-unused-vars
  * const sharedWorker = new SharedWorker(
  *   new URL("./shared-worker.js", import.meta.url),
  *   { type: "module", name: "@automerge/automerge-repo-shared-worker" }
  * )
- * 
+ *
  * async function getRepo(): Promise<DocCollection> {
  *   return await Repo({
  *     network: [
@@ -55,17 +55,17 @@
  *     sharePolicy: peerId => peerId.includes("shared-worker"),
  *   })
  * }
- * 
+ *
  * const initFunction = (d: RootDocument) => {
  *   d.items = []
  * }
- * 
+ *
  * const queryString = window.location.search // Returns:'?q=123'
- * 
+ *
  * // Further parsing:
  * const params = new URLSearchParams(queryString)
  * const hostname = params.get("host") || "automerge-storage-demo.glitch.me"
- * 
+ *
  * getRepo().then(repo => {
  *   useBootstrap(repo, initFunction).then(rootDoc => {
  *     const rootElem = document.getElementById("root")
@@ -85,8 +85,17 @@
  * ```
  */
 export { useDocument } from "./useDocument.js"
-export { useBootstrap, type UseBootstrapOptions } from './useBootstrap.js'
+export { useDocuments } from "./useDocuments.js"
+export { useBootstrap, type UseBootstrapOptions } from "./useBootstrap.js"
 export { useHandle } from "./useHandle.js"
 export { RepoContext, useRepo } from "./useRepo.js"
-export { useLocalAwareness, type UseLocalAwarenessProps } from './useLocalAwareness.js'
-export { useRemoteAwareness, type PeerStates, type Heartbeats, type UseRemoteAwarenessProps } from './useRemoteAwareness.js'
+export {
+  useLocalAwareness,
+  type UseLocalAwarenessProps,
+} from "./useLocalAwareness.js"
+export {
+  useRemoteAwareness,
+  type PeerStates,
+  type Heartbeats,
+  type UseRemoteAwarenessProps,
+} from "./useRemoteAwareness.js"

--- a/packages/automerge-repo-react-hooks/src/useDocuments.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocuments.ts
@@ -1,0 +1,84 @@
+import {
+  AutomergeUrl,
+  DocHandle,
+  DocHandleChangePayload,
+  DocumentId,
+} from "@automerge/automerge-repo"
+import { useEffect, useState } from "react"
+import { useRepo } from "./useRepo.js"
+
+/**
+ * Maintains a map of document states, keyed by URL or DocumentId. Useful for collections of related
+ * documents.
+ */
+export const useDocuments = <T>(ids?: DocId[]) => {
+  const [documents, setDocuments] = useState({} as Record<DocId, T>)
+  const [listeners, setListeners] = useState({} as Record<DocId, Listener<T>>)
+  const repo = useRepo()
+
+  useEffect(
+    () => {
+      const updateDocument = (id: DocId, doc?: T) => {
+        if (doc) setDocuments(docs => ({ ...docs, [id]: doc }))
+      }
+
+      const addListener = (handle: DocHandle<T>) => {
+        const id = handle.documentId
+
+        // whenever a document changes, update our map
+        const listener: Listener<T> = ({ doc }) => updateDocument(id, doc)
+        handle.on("change", listener)
+
+        // store the listener so we can remove it later
+        setListeners(listeners => ({ ...listeners, [id]: listener }))
+      }
+
+      const removeDocument = (id: DocId) => {
+        // remove the listener
+        const handle = repo.find<T>(id)
+        handle.off("change", listeners[id])
+
+        // remove the document from the document map
+        setDocuments(docs => {
+          const { [id]: _removedDoc, ...remainingDocs } = docs
+          return remainingDocs
+        })
+      }
+
+      if (ids) {
+        // add any new documents
+        const newIds = ids.filter(id => !documents[id])
+        newIds.forEach(id => {
+          const handle = repo.find<T>(id)
+          // As each document loads, update our map
+          handle.doc().then(doc => {
+            updateDocument(id, doc)
+            addListener(handle)
+          })
+        })
+
+        // remove any documents that are no longer in the list
+        const removedIds = Object.keys(documents)
+          .map(id => id as DocId)
+          .filter(id => !ids.includes(id))
+        removedIds.forEach(removeDocument)
+      }
+
+      // on unmount, remove all listeners
+      const teardown = () => {
+        Object.entries(listeners).forEach(([id, listener]) => {
+          const handle = repo.find<T>(id as DocId)
+          handle.off("change", listener)
+        })
+      }
+
+      return teardown
+    },
+    [ids] // only run this effect when the list of ids changes
+  )
+
+  return documents
+}
+
+type DocId = DocumentId | AutomergeUrl
+type Listener<T> = (p: DocHandleChangePayload<T>) => void

--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -1,0 +1,111 @@
+import { DocumentId, PeerId, Repo } from "@automerge/automerge-repo"
+import { DummyStorageAdapter } from "@automerge/automerge-repo/test/helpers/DummyStorageAdapter"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { useDocuments } from "../src/useDocuments"
+import { RepoContext } from "../src/useRepo"
+
+describe("useDocuments", () => {
+  const setup = () => {
+    const repo = new Repo({
+      peerId: "alice" as PeerId,
+      network: [],
+      storage: new DummyStorageAdapter(),
+    })
+
+    const wrapper = getRepoWrapper(repo)
+
+    const documentIds = range(10).map(i => {
+      const handle = repo.create({ foo: i })
+      return handle.documentId
+    })
+
+    return { repo, wrapper, documentIds }
+  }
+
+  it("returns a collection of documents, given a list of ids", async () => {
+    const { documentIds, wrapper } = setup()
+    const { result } = renderHook(
+      () => {
+        const documents = useDocuments(documentIds)
+        return { documents }
+      },
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      const { documents } = result.current
+      documentIds.forEach((id, i) => expect(documents[id]).toEqual({ foo: i }))
+    })
+  })
+
+  it("updates documents when they change", async () => {
+    const { repo, documentIds, wrapper } = setup()
+
+    const { result } = renderHook(
+      () => {
+        const documents = useDocuments(documentIds)
+        return { documents }
+      },
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      const { documents } = result.current
+      documentIds.forEach((id, i) => expect(documents[id]).toEqual({ foo: i }))
+    })
+
+    // multiply the value of foo in each document by 10
+    documentIds.forEach(id => {
+      const handle = repo.find(id)
+      handle.change(s => (s.foo *= 10))
+    })
+
+    await waitFor(() => {
+      const { documents } = result.current
+      documentIds.forEach((id, i) =>
+        expect(documents[id]).toEqual({ foo: i * 10 })
+      )
+    })
+  })
+
+  it(`removes documents when they're removed from the list of ids`, async () => {
+    const { repo, documentIds, wrapper } = setup()
+    const { result } = renderHook(
+      () => {
+        const [ids, setIds] = React.useState(documentIds)
+        const documents = useDocuments(ids)
+        return { documents, setIds }
+      },
+      { wrapper }
+    )
+    const [firstId, ...restIds] = documentIds
+
+    await waitFor(() => {
+      const { documents } = result.current
+      expect(documents[firstId]).toEqual({ foo: 0 })
+    })
+
+    // remove the first document
+    act(() => result.current.setIds(restIds))
+    // 👆 Note that this only works because restIds is a different object from documentIds.
+    // If we modified documentIds directly, the hook wouldn't re-run.
+
+    await waitFor(() => {
+      const { documents } = result.current
+      expect(documents[firstId]).toBeUndefined()
+    })
+  })
+})
+
+const range = (n: number) => [...Array(n).keys()]
+
+const getRepoWrapper =
+  (repo: Repo) =>
+  ({ children }) =>
+    <RepoContext.Provider value={repo}>{children}</RepoContext.Provider>
+
+interface ExampleDoc {
+  foo: number
+}


### PR DESCRIPTION
replaces #196

`useDocuments` is a hook that takes a list of AutomergeUrls or DocumentIds, and maintains a map of IDs to document states. If the list of IDs changes, documents are added to or removed from the list. Document values are updated as the documents are changed in the repo. 

Includes 100% test coverage.