### PR TITLE
Add InvalidAutomergeUrlError

### DIFF
--- a/packages/automerge-repo/src/AutomergeUrl.ts
+++ b/packages/automerge-repo/src/AutomergeUrl.ts
@@ -134,7 +134,15 @@ export const interpretAsDocumentId = (id: AnyDocumentId) => {
   }
 
   // none of the above
-  throw new Error(`Invalid AutomergeUrl: '${id}'`)
+  throw new InvalidAutomergeUrlError(`Invalid AutomergeUrl: '${id}'`)
+}
+
+export class InvalidAutomergeUrlError extends Error {
+  constructor(message: string) {
+    super(message)
+    // https://github.com/microsoft/TypeScript/wiki/FAQ#why-doesnt-extending-built-ins-like-error-array-and-map-work
+    Object.setPrototypeOf(this, InvalidAutomergeUrlError.prototype)
+  }
 }
 
 // TYPES


### PR DESCRIPTION
This PR exports a custom error for invalid automerge URLs, as per #268. The intention is to allow `error instanceof InvalidAutomergeUrlError` to be used in try/catch blocks and react error boundaries.

For example:
```js
import { InvalidAutomergeUrlError } from 'automerge-repo'
import { ErrorBoundary } from 'react-error-boundary'

export const Bootstrap = () => {
  const handle = useBootstrap({
    onNoDocument: (repo) => {
      const handle = repo.create()
      handle.change((d) => Object.assign(d, { foo: {} }))
      return handle
    }
  })

  const [state] = useDocument(handle?.url)
  if (!state) return (<LoadingDocument />)

  return <Client automergeUrl={handle?.url} />
}

export const ErrorFallback = ({ error }) => {
  if (error instanceof InvalidAutomergeUrlError) {
    return (<p>Invalid document URL</p>)
  }
  return (<p>{error.message}</p>)
}

export const App = () => {
  return (
    <ErrorBoundary FallbackComponent={ErrorFallback}>
      <Bootstrap />
    </ErrorBoundary>
  )
}
```