### PR TITLE
Appease eslint, allow deliberate unused vars

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -49,6 +49,7 @@ module.exports = {
     "no-use-before-define": OFF,
     "@typescript-eslint/no-non-null-assertion": OFF,
     "@typescript-eslint/no-explicit-any": OFF,
+    "@typescript-eslint/no-unused-vars": [ERROR, {"varsIgnorePattern": "^_"}],
   },
   root: true,
 }

--- a/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts
@@ -24,7 +24,7 @@ abstract class WebSocketNetworkAdapter extends NetworkAdapter {
 }
 
 export class BrowserWebSocketClientAdapter extends WebSocketNetworkAdapter {
-  #isReady: boolean = false
+  #isReady = false
   #retryIntervalId?: TimeoutId
   #log = debug("automerge-repo:websocket:browser")
 

--- a/packages/automerge-repo-react-hooks/src/useDocuments.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocuments.ts
@@ -54,6 +54,8 @@ export const useDocuments = <T>(ids?: DocId[]) => {
           handle.doc().then(doc => {
             updateDocument(id, doc)
             addListener(handle)
+          }).catch(err => {
+            console.error(`Error loading document ${id} in useDocuments: `, err)
           })
         })
 

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -19,7 +19,7 @@ export class NodeFSStorageAdapter extends StorageAdapter {
   /**
    * @param baseDirectory - The path to the directory to store data in. Defaults to "./automerge-repo-data".
    */
-  constructor(baseDirectory: string = "automerge-repo-data") {
+  constructor(baseDirectory = "automerge-repo-data") {
     super()
     this.baseDirectory = baseDirectory
   }

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -39,7 +39,7 @@ export class DocHandle<T> //
   #log: debug.Debugger
 
   #machine: DocHandleXstateMachine<T>
-  #timeoutDelay: number = 60_000
+  #timeoutDelay = 60_000
   #remoteHeads: Record<StorageId, A.Heads> = {}
 
   /** The URL of this document


### PR DESCRIPTION
Along with a few small changes to fix eslint complaints add a rule which allows unused variables in typescript files if the variable in question is prefixed with "_".