### PR TITLE
Adapter peer metadata fix

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -56,7 +56,7 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
               senderId: this.peerId,
               targetId: senderId,
               type: "welcome",
-              peerMetadata,
+              peerMetadata: this.peerMetadata,
             })
             this.#announceConnection(senderId, message.peerMetadata)
             break
@@ -81,6 +81,7 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
     this.#broadcastChannel.postMessage({
       senderId: this.peerId,
       type: "arrive",
+      peerMetadata,
     })
 
     this.emit("ready", { network: this })

--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -56,11 +56,12 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
               senderId: this.peerId,
               targetId: senderId,
               type: "welcome",
+              peerMetadata,
             })
-            this.#announceConnection(senderId, peerMetadata)
+            this.#announceConnection(senderId, message.peerMetadata)
             break
           case "welcome":
-            this.#announceConnection(senderId, peerMetadata)
+            this.#announceConnection(senderId, message.peerMetadata)
             break
           default:
             if (!("data" in message)) {

--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -33,12 +33,12 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
   constructor(options?: BroadcastChannelNetworkAdapterOptions) {
     super()
     this.#options = { channelName: "broadcast", ...(options ?? {}) }
+    this.#broadcastChannel = new BroadcastChannel(this.#options.channelName)
   }
 
   connect(peerId: PeerId, peerMetadata: PeerMetadata) {
     this.peerId = peerId
     this.peerMetadata = peerMetadata
-    this.#broadcastChannel = new BroadcastChannel(this.#options.channelName)
 
     this.#broadcastChannel.addEventListener(
       "message",
@@ -52,16 +52,22 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
 
         switch (type) {
           case "arrive":
-            this.#broadcastChannel.postMessage({
-              senderId: this.peerId,
-              targetId: senderId,
-              type: "welcome",
-              peerMetadata: this.peerMetadata,
-            })
-            this.#announceConnection(senderId, message.peerMetadata)
+            {
+              const { peerMetadata } = message as ArriveMessage
+              this.#broadcastChannel.postMessage({
+                senderId: this.peerId,
+                targetId: senderId,
+                type: "welcome",
+                peerMetadata: this.peerMetadata,
+              })
+              this.#announceConnection(senderId, peerMetadata)
+            }
             break
           case "welcome":
-            this.#announceConnection(senderId, message.peerMetadata)
+            {
+              const { peerMetadata } = message as WelcomeMessage
+              this.#announceConnection(senderId, peerMetadata)
+            }
             break
           default:
             if (!("data" in message)) {
@@ -95,10 +101,12 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
     if ("data" in message) {
       this.#broadcastChannel.postMessage({
         ...message,
-        data: message.data.buffer.slice(
-          message.data.byteOffset,
-          message.data.byteOffset + message.data.byteLength
-        ),
+        data: message.data
+          ? message.data.buffer.slice(
+              message.data.byteOffset,
+              message.data.byteOffset + message.data.byteLength
+            )
+          : undefined,
       })
     } else {
       this.#broadcastChannel.postMessage(message)

--- a/packages/automerge-repo-network-broadcastchannel/tsconfig.json
+++ b/packages/automerge-repo-network-broadcastchannel/tsconfig.json
@@ -9,7 +9,7 @@
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts"]

--- a/packages/automerge-repo-network-messagechannel/src/index.ts
+++ b/packages/automerge-repo-network-messagechannel/src/index.ts
@@ -60,20 +60,18 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
         switch (type) {
           case "arrive":
             {
-              const { peerMetadata } = message as ArriveMessage
               this.messagePortRef.postMessage({
                 type: "welcome",
                 senderId: this.peerId,
                 peerMetadata: this.peerMetadata,
                 targetId: senderId,
               })
-              this.announceConnection(senderId, peerMetadata)
+              this.announceConnection(senderId, message.peerMetadata)
             }
             break
           case "welcome":
             {
-              const { peerMetadata } = message as WelcomeMessage
-              this.announceConnection(senderId, peerMetadata)
+              this.announceConnection(senderId, message.peerMetadata)
             }
             break
           default:
@@ -97,6 +95,7 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
     this.messagePortRef.postMessage({
       senderId: this.peerId,
       type: "arrive",
+      peerMetadata,
     })
 
     // Mark this messagechannel as ready after 50 ms, at this point there

--- a/packages/automerge-repo-network-messagechannel/src/index.ts
+++ b/packages/automerge-repo-network-messagechannel/src/index.ts
@@ -38,7 +38,7 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
       : new StrongMessagePortRef(messagePort)
   }
 
-  connect(peerId: PeerId, peerMetadata: PeerMetadata) {
+  connect(peerId: PeerId, peerMetadata?: PeerMetadata) {
     log("messageport connecting")
     this.peerId = peerId
     this.peerMetadata = peerMetadata
@@ -60,18 +60,20 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
         switch (type) {
           case "arrive":
             {
+              const { peerMetadata } = message as ArriveMessage
               this.messagePortRef.postMessage({
                 type: "welcome",
                 senderId: this.peerId,
                 peerMetadata: this.peerMetadata,
                 targetId: senderId,
               })
-              this.announceConnection(senderId, message.peerMetadata)
+              this.announceConnection(senderId, peerMetadata)
             }
             break
           case "welcome":
             {
-              this.announceConnection(senderId, message.peerMetadata)
+              const { peerMetadata } = message as WelcomeMessage
+              this.announceConnection(senderId, peerMetadata)
             }
             break
           default:
@@ -80,7 +82,7 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
             } else {
               this.emit("message", {
                 ...message,
-                data: new Uint8Array(message.data),
+                data: message.data ? new Uint8Array(message.data) : undefined,
               })
             }
             break

--- a/packages/automerge-repo-network-messagechannel/tsconfig.json
+++ b/packages/automerge-repo-network-messagechannel/tsconfig.json
@@ -9,7 +9,7 @@
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts"]

--- a/packages/automerge-repo-storage-indexeddb/tsconfig.json
+++ b/packages/automerge-repo-storage-indexeddb/tsconfig.json
@@ -9,7 +9,7 @@
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts"]

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -33,7 +33,7 @@ export class NodeFSStorageAdapter extends StorageAdapter {
     try {
       const fileContent = await fs.promises.readFile(filePath)
       return new Uint8Array(fileContent)
-    } catch (error) {
+    } catch (error: any) {
       // don't throw if file not found
       if (error.code === "ENOENT") return undefined
       throw error
@@ -57,7 +57,7 @@ export class NodeFSStorageAdapter extends StorageAdapter {
     const filePath = this.getFilePath(keyArray)
     try {
       await fs.promises.unlink(filePath)
-    } catch (error) {
+    } catch (error: any) {
       // don't throw if file not found
       if (error.code !== "ENOENT") throw error
     }
@@ -139,7 +139,7 @@ const walkdir = async (dirPath: string): Promise<string[]> => {
       })
     )
     return files.flat()
-  } catch (error) {
+  } catch (error: any) {
     // don't throw if directory not found
     if (error.code === "ENOENT") return []
     throw error

--- a/packages/automerge-repo-storage-nodefs/tsconfig.json
+++ b/packages/automerge-repo-storage-nodefs/tsconfig.json
@@ -9,7 +9,7 @@
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts"]

--- a/packages/automerge-repo-svelte-store/tsconfig.json
+++ b/packages/automerge-repo-svelte-store/tsconfig.json
@@ -9,7 +9,7 @@
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts"]

--- a/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
@@ -148,7 +148,7 @@ export function runAdapterTests(_setup: SetupFn, title?: string): void {
       teardown()
     })
 
-    it.only("emits a peer-candidate event with proper peer metadata when a peer connects", async () => {
+    it("emits a peer-candidate event with proper peer metadata when a peer connects", async () => {
       const { adapters, teardown } = await setup()
       const a = adapters[0][0]
       const b = adapters[1][0]

--- a/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
@@ -1,6 +1,12 @@
 import assert from "assert"
-import { describe, it } from "vitest"
-import { PeerId, Repo, type NetworkAdapter } from "../../index.js"
+import { describe, expect, it } from "vitest"
+import {
+  PeerId,
+  Repo,
+  type NetworkAdapter,
+  StorageId,
+  PeerMetadata,
+} from "../../index.js"
 import { eventPromise, eventPromises } from "../eventPromise.js"
 import { pause } from "../pause.js"
 
@@ -139,6 +145,28 @@ export function runAdapterTests(_setup: SetupFn, title?: string): void {
       const { message } = await eventPromise(charlieHandle, "ephemeral-message")
 
       assert.deepStrictEqual(message, alicePresenceData)
+      teardown()
+    })
+
+    it.only("emits a peer-candidate event with proper peer metadata when a peer connects", async () => {
+      const { adapters, teardown } = await setup()
+      const a = adapters[0][0]
+      const b = adapters[1][0]
+
+      const bPromise = eventPromise(b, "peer-candidate")
+
+      const aPeerMetadata: PeerMetadata = { storageId: "a" as StorageId }
+
+      b.connect("b" as PeerId, { storageId: "b" as StorageId })
+      a.connect("a" as PeerId, aPeerMetadata)
+
+      const peerCandidate = await bPromise
+
+      expect(peerCandidate).toMatchObject({
+        peerId: "a",
+        peerMetadata: aPeerMetadata,
+      })
+
       teardown()
     })
   })


### PR DESCRIPTION
Some of the network adapters were not correctly sending `peerMetadata`, nor were they properly passing the correct `peerMetadata` back to the network subsystem.

This fixes the bug and adds a test to the adapter acceptance test suite