### PR TITLE
fix: don't leave timers pending for 2 minutes on each waitForState call

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -244,13 +244,12 @@ export class DocHandle<T> //
 
   /** Returns a promise that resolves when the docHandle is in one of the given states */
   #statePromise(awaitStates: HandleState | HandleState[]) {
-    if (!Array.isArray(awaitStates)) awaitStates = [awaitStates]
-    return Promise.any(
-      awaitStates.map(state =>
-        waitFor(this.#machine, s => s.matches(state), {
-          timeout: this.#timeoutDelay * 2, // use a longer delay here so as not to race with other delays
-        })
-      )
+    const awaitStatesArray = Array.isArray(awaitStates) ? awaitStates : [awaitStates]
+    return waitFor(
+      this.#machine,
+      s => awaitStatesArray.some((state) => s.matches(state)),
+      // use a longer delay here so as not to race with other delays
+      {timeout: this.#timeoutDelay * 2}
     )
   }
 

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -1,7 +1,7 @@
 import * as A from "@automerge/automerge/next"
 import assert from "assert"
 import { decode } from "cbor-x"
-import { describe, it } from "vitest"
+import { describe, it, vi } from "vitest"
 import { generateAutomergeUrl, parseAutomergeUrl } from "../src/AutomergeUrl.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
@@ -70,6 +70,21 @@ describe("DocHandle", () => {
 
     assert.equal(handle.isReady(), true)
     assert.equal(doc?.foo, "bar")
+  })
+
+  it("no pending timers after a document is loaded", async () => {
+    vi.useFakeTimers();
+    const handle = new DocHandle<TestDoc>(TEST_ID)
+    assert.equal(handle.isReady(), false)
+
+    // simulate loading from storage
+    handle.update(doc => docFromMockStorage(doc))
+
+    const doc = await handle.doc()
+
+    assert.equal(handle.isReady(), true)
+    assert.equal(vi.getTimerCount(), 0);
+    vi.useRealTimers();
   })
 
   it("should block changes until ready()", async () => {

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -72,19 +72,27 @@ describe("DocHandle", () => {
     assert.equal(doc?.foo, "bar")
   })
 
+  /**
+   * Once there's a Repo#stop API this case should be covered in accompanying
+   * tests and the following test removed.
+   */
   it("no pending timers after a document is loaded", async () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers()
+    const timerCount = vi.getTimerCount()
+
     const handle = new DocHandle<TestDoc>(TEST_ID)
     assert.equal(handle.isReady(), false)
+
+    handle.doc()
+
+    assert(vi.getTimerCount() > timerCount)
 
     // simulate loading from storage
     handle.update(doc => docFromMockStorage(doc))
 
-    const doc = await handle.doc()
-
     assert.equal(handle.isReady(), true)
-    assert.equal(vi.getTimerCount(), 0);
-    vi.useRealTimers();
+    assert.equal(vi.getTimerCount(), timerCount)
+    vi.useRealTimers()
   })
 
   it("should block changes until ready()", async () => {


### PR DESCRIPTION
* doc can't go from ready to unavailable state
* doc() method starts a wait promise for each awaitStates entry (`awaitStates=[ready,unavailable]` by default) 
* for ready state documents that keeps creating unnecessary timers each with 2 minute timeouts 
* for some test runners this causes node process to hang until all timers resolve. we had to add [forceExit](https://github.com/dxos/dxos/blob/main/packages/apps/composer-app/project.json#L63) in our code after migrating to automerge as tests were not exiting