### PR TITLE
fix: peer doesn't receive a document on connecting with another peer

### DIFF
--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -227,8 +227,8 @@ export class DocSynchronizer extends Synchronizer {
   }
 
   beginSync(peerIds: PeerId[]) {
-    const newPeers = new Set(
-      peerIds.filter(peerId => !this.#peers.includes(peerId))
+    const noPeersWithDocument = peerIds.every(
+      (peerId) => this.#peerDocumentStatuses[peerId] in ["unavailable", "wants"]
     )
 
     // At this point if we don't have anything in our storage, we need to use an empty doc to sync
@@ -242,7 +242,7 @@ export class DocSynchronizer extends Synchronizer {
         this.#checkDocUnavailable()
 
         const wasUnavailable = doc === undefined
-        if (wasUnavailable && newPeers.size == 0) {
+        if (wasUnavailable && noPeersWithDocument) {
           return
         }
 


### PR DESCRIPTION
Fixes the following case:
* Alice has a document that Bob wants to discover.
* Bob appears as a peer candidate and Alice sends a sync message.
* Bob is recorded in the list of known peers, but sync message processing fails (in the new test this happens because Alice isn't yet in the list of known peers).
* Alice appears as peer candidate but Bob decides to skip sync, because he already saw Alice (even though her document status is recorded as "has" and he doesn't have a document).
