### PR TITLE
NodeWSServerAdapter.ts: use assert.js, not node.assert

### DIFF
--- a/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/NodeWSServerAdapter.ts
@@ -17,7 +17,7 @@ import {
   isLeaveMessage,
 } from "./messages.js"
 import { ProtocolV1, ProtocolVersion } from "./protocolVersion.js"
-import assert from "assert"
+import { assert } from "./assert.js"
 import { toArrayBuffer } from "./toArrayBuffer.js"
 
 const { encode, decode } = cborHelpers


### PR DESCRIPTION
This PR changes the `assert` import to use the local [`assert.js`](https://github.com/automerge/automerge-repo/blob/main/packages/automerge-repo-network-websocket/src/assert.ts) rather than Node's [`assert`](https://nodejs.org/api/assert.html#assert).

### Motivation

Node's `assert` isn't browser-compatible. 

There's normally no reason why this module should be run in the browser (although [apparently it's intended to be isomorphic](https://github.com/automerge/automerge-repo/blob/websocket-server-use-browser-compatible-assert/packages/automerge-repo-network-websocket/src/index.ts/#L10-L12)?) but I'm running into a Vite.js tree-shaking issue with [Remix in SPA mode](https://remix.run/docs/en/main/future/spa-mode), where the node websocket adapter is somehow ending up in my bundle in the browser. 

![image](https://github.com/automerge/automerge-repo/assets/2136620/7729bc38-20b4-400a-8381-e15109000af1)

I need to figure out why that is -- I suspect it's just because Remix's Vite integration was [just released](https://twitter.com/remix_run/status/1760052041156604381) and is still a little wobbly -- but this patch lets me make progress in the meantime. 
