### PR TITLE
Fix React warnings in `useDocuments` tests

### DIFF
--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -56,10 +56,12 @@ describe("useDocuments", () => {
       documentIds.forEach((id, i) => expect(documents[id]).toEqual({ foo: i }))
     })
 
-    // multiply the value of foo in each document by 10
-    documentIds.forEach(id => {
-      const handle = repo.find(id)
-      handle.change(s => (s.foo *= 10))
+    act(() => {
+      // multiply the value of foo in each document by 10
+      documentIds.forEach(id => {
+        const handle = repo.find(id)
+        handle.change(s => (s.foo *= 10))
+      })
     })
 
     await waitFor(() => {


### PR DESCRIPTION
When running tests we get several copies of this warning:

```
Warning: An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
    at TestComponent (automerge-repo/node_modules/.pnpm/@testing-library+react@14.1.2_react-dom@18.2.0_react@18.2.0/node_modules/@testing-library/react/dist/pure.js:278:5)
    at automerge-repo/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx:90:37
```

This PR follows the warning's advice and wraps the stuff that causes state updates in `act(...)`. 