### PR TITLE
Fix watch scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:log": "cross-env DEBUG='automerge-repo:*' vitest",
     "test:coverage": "vitest --coverage",
     "test:ui": "vitest --coverage --ui",
-    "watch": "pnpm -r watch --parallel --stream"
+    "watch": "pnpm run --parallel --stream -r watch "
   },
   "engines": {
     "node": ">= 18.x"

--- a/packages/automerge-repo-network-broadcastchannel/package.json
+++ b/packages/automerge-repo-network-broadcastchannel/package.json
@@ -9,7 +9,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "watch": "npm-watch",
+    "watch": "npm-watch build",
     "test": "vitest"
   },
   "dependencies": {

--- a/packages/automerge-repo-network-messagechannel/package.json
+++ b/packages/automerge-repo-network-messagechannel/package.json
@@ -9,7 +9,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "watch": "npm-watch",
+    "watch": "npm-watch build",
     "test": "vitest"
   },
   "dependencies": {

--- a/packages/automerge-repo-network-websocket/package.json
+++ b/packages/automerge-repo-network-websocket/package.json
@@ -9,7 +9,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "watch": "npm-watch",
+    "watch": "npm-watch build",
     "test": "vitest"
   },
   "dependencies": {

--- a/packages/automerge-repo-react-hooks/package.json
+++ b/packages/automerge-repo-react-hooks/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --noEmit && vite build",
     "test": "vitest run",
-    "watch": "npm-watch",
+    "watch": "npm-watch build",
     "visualize": "VISUALIZE=true vite build"
   },
   "dependencies": {

--- a/packages/automerge-repo-storage-indexeddb/package.json
+++ b/packages/automerge-repo-storage-indexeddb/package.json
@@ -9,7 +9,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "watch": "npm-watch"
+    "watch": "npm-watch build"
   },
   "dependencies": {
     "@automerge/automerge-repo": "workspace:*"

--- a/packages/automerge-repo-storage-nodefs/package.json
+++ b/packages/automerge-repo-storage-nodefs/package.json
@@ -9,7 +9,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "watch": "npm-watch"
+    "watch": "npm-watch build"
   },
   "dependencies": {
     "@automerge/automerge-repo": "workspace:*",

--- a/packages/automerge-repo-svelte-store/package.json
+++ b/packages/automerge-repo-svelte-store/package.json
@@ -8,7 +8,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "watch": "npm-watch"
+    "watch": "npm-watch build"
   },
   "peerDependencies": {
     "@automerge/automerge": "^2.1.9",

--- a/packages/create-repo-node-app/package.json
+++ b/packages/create-repo-node-app/package.json
@@ -9,8 +9,7 @@
   "bin": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "postbuild": "node postbuild.js",
-    "watch": "npm-watch build"
+    "postbuild": "node postbuild.js"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR gets `pnpm watch` working properly. After running the script, modifying any file in the monorepo will cause the corresponding package to be rebuilt. In combination with `pnpm link`, this makes it easier to see the results of changes to this library when developing an application consuming it. 


