### PR TITLE
tests: start moving away from renderHook

### DIFF
--- a/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
@@ -1,22 +1,21 @@
 import { AutomergeUrl, PeerId, Repo } from "@automerge/automerge-repo"
 import { DummyStorageAdapter } from "@automerge/automerge-repo/test/helpers/DummyStorageAdapter"
-import { renderHook, waitFor } from "@testing-library/react"
-import React, { useState } from "react"
-import { act } from "react-dom/test-utils"
-import { describe, expect, it } from "vitest"
+import { render, waitFor } from "@testing-library/react"
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
 import { useDocument } from "../src/useDocument"
 import { RepoContext } from "../src/useRepo"
 
 const SLOW_DOC_LOAD_TIME_MS = 10
 
 describe("useDocument", () => {
-  const repo = new Repo({
-    peerId: "bob" as PeerId,
-    network: [],
-    storage: new DummyStorageAdapter(),
-  })
-
   function setup() {
+    const repo = new Repo({
+      peerId: "bob" as PeerId,
+      network: [],
+      storage: new DummyStorageAdapter(),
+    })
+
     const handleA = repo.create<ExampleDoc>()
     handleA.change(doc => (doc.foo = "A"))
 
@@ -36,120 +35,97 @@ describe("useDocument", () => {
       return result
     }
 
+    const wrapper = ({ children }) => {
+      return <RepoContext.Provider value={repo}>{children}</RepoContext.Provider>
+    }
+
     return {
       repo,
       handleA,
       handleB,
       handleSlow,
-      wrapper: getRepoWrapper(repo),
+      wrapper,
     }
+  }
+
+  const Component = ({ url, onRender }: {
+    url: AutomergeUrl,
+    onRender: (doc: ExampleDoc) => void,
+  }) => {
+    const [doc] = useDocument(url)
+    onRender(doc)
+    return null
   }
 
   it("should load a document", async () => {
     const { handleA, wrapper } = setup()
+    const onRender = vi.fn()
 
-    const { result } = renderHook(() => useDocument(handleA.url), { wrapper })
-
-    await waitFor(() => {
-      const [doc] = result.current
-      expect(doc).toEqual({ foo: "A" })
-    })
+    render(<Component url={handleA.url} onRender={onRender} />, {wrapper})
+    await waitFor(() => expect(onRender).toHaveBeenLastCalledWith({ foo: "A" }))
   })
 
   it("should update if the url changes", async () => {
-    const { wrapper, handleA, handleB } = setup()
+    const { handleA, handleB, wrapper } = setup()
+    const onRender = vi.fn()
 
-    const { result } = await act(() =>
-      renderHook(
-        () => {
-          const [url, setUrl] = useState<AutomergeUrl>()
-          const [doc] = useDocument(url)
-          return { setUrl, doc }
-        },
-        { wrapper }
-      )
-    )
-
-    await waitFor(() => expect(result.current).not.toBeNull())
+    const { rerender } = render(<Component url={handleA.url} onRender={onRender} />, {wrapper})
+    await waitFor(() => expect(onRender).toHaveBeenLastCalledWith(undefined))
 
     // set url to doc A
-    act(() => result.current.setUrl(handleA.url))
-    await waitFor(() => expect(result.current.doc).toEqual({ foo: "A" }))
+    rerender(<Component url={handleA.url} onRender={onRender} />)
+    await waitFor(() => expect(onRender).toHaveBeenLastCalledWith({ foo: "A" }))
 
     // set url to doc B
-    act(() => result.current.setUrl(handleB.url))
-    await waitFor(() => expect(result.current.doc).toEqual({ foo: "B" }))
+    rerender(<Component url={handleB.url} onRender={onRender} />)
+    await waitFor(() => expect(onRender).toHaveBeenLastCalledWith({ foo: "B" }))
 
     // set url to undefined
-    act(() => result.current.setUrl(undefined))
-    await waitFor(() => expect(result.current.doc).toBeUndefined())
+    rerender(<Component url={undefined} onRender={onRender} />)
+    await waitFor(() => expect(onRender).toHaveBeenLastCalledWith(undefined))
   })
 
   it("sets the doc to undefined while the initial load is happening", async () => {
-    const { wrapper, handleA, handleSlow } = setup()
+    const { handleA, handleSlow, wrapper } = setup()
+    const onRender = vi.fn()
 
-    const { result } = await act(() =>
-      renderHook(
-        () => {
-          const [url, setUrl] = useState<AutomergeUrl>()
-          const [doc] = useDocument(url)
-          return { setUrl, doc }
-        },
-        { wrapper }
-      )
-    )
-
-    await waitFor(() => expect(result.current).not.toBeNull())
+    const { rerender } = render(<Component url={handleA.url} onRender={onRender} />, {wrapper})
+    await waitFor(() => expect(onRender).toHaveBeenLastCalledWith(undefined))
 
     // start by setting url to doc A
-    act(() => result.current.setUrl(handleA.url))
-    await waitFor(() => expect(result.current.doc).toEqual({ foo: "A" }))
+    rerender(<Component url={handleA.url} onRender={onRender} />)
+    await waitFor(() => expect(onRender).toHaveBeenLastCalledWith({ foo: "A" }))
 
     // Now we set the URL to a handle that's slow to load.
     // The doc should be undefined while the load is happening.
-    act(() => result.current.setUrl(handleSlow.url))
-    await waitFor(() => expect(result.current.doc).toBeUndefined())
-    await waitFor(() => expect(result.current.doc).toEqual({ foo: "slow" }))
+    rerender(<Component url={handleSlow.url} onRender={onRender} />)
+    await waitFor(() => expect(onRender).toHaveBeenLastCalledWith(undefined))
+    await waitFor(() => expect(onRender).toHaveBeenLastCalledWith({ foo: "slow" }))
   })
 
   it("avoids showing stale data", async () => {
-    const { wrapper, handleA, handleSlow } = setup()
-    const { result } = await act(() =>
-      renderHook(
-        () => {
-          const [url, setUrl] = useState<AutomergeUrl>()
-          const [doc] = useDocument(url)
-          return { setUrl, doc }
-        },
-        { wrapper }
-      )
-    )
+    const { handleA, handleSlow, wrapper } = setup()
+    const onRender = vi.fn()
 
-    await waitFor(() => expect(result.current).not.toBeNull())
+    const { rerender } = render(<Component url={handleA.url} onRender={onRender} />, {wrapper})
+    await waitFor(() => expect(onRender).toHaveBeenLastCalledWith(undefined))
 
     // Set the URL to a slow doc and then a fast doc.
     // We should see the fast doc forever, even after
     // the slow doc has had time to finish loading.
-    act(() => {
-      result.current.setUrl(handleSlow.url)
-      result.current.setUrl(handleA.url)
-    })
-    await waitFor(() => expect(result.current.doc).toEqual({ foo: "A" }))
+    rerender(<Component url={handleSlow.url} onRender={onRender} />)
+    rerender(<Component url={handleA.url} onRender={onRender} />)
+    await waitFor(() => expect(onRender).toHaveBeenLastCalledWith({ foo: "A" }))
 
     // wait for the slow doc to finish loading...
     await pause(SLOW_DOC_LOAD_TIME_MS * 2)
 
     // we didn't update the doc to the slow doc, so it should still be A
-    await waitFor(() => expect(result.current.doc).toEqual({ foo: "A" }))
+    expect(onRender).not.toHaveBeenCalledWith({ foo: "slow" })
   })
 })
 
 const pause = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
-
-const getRepoWrapper =
-  (repo: Repo) =>
-  ({ children }) =>
-    <RepoContext.Provider value={repo}>{children}</RepoContext.Provider>
 
 interface ExampleDoc {
   foo: string


### PR DESCRIPTION
I started writing tests for #296, and felt the hook-testing setup could be improved.

On `renderHook`, the [testing-library docs](https://testing-library.com/docs/react-testing-library/api#renderhook) say "You should prefer `render`", and I agree. `renderHook` is a strange wrapper around `render` – there's a component being rendered behind the scenes, but the interface doesn't look like a component. I'd rather have tests that show what the hooks do in the familiar setting of a component.

Relatedly, I feel uneasy with the current testing setup because they don't prove the hooks are causing the component to re-render when docs change. It might be that the hooks return mutable objects that are mutated by some listener somewhere, causing tests to pass, without triggering component renders (as is essential for reactivity).

The approach I like which addresses these concerns is to use a test component, which calls a mock function `onRender` on each render. This way, we get authoritative information about when the component renders and what it renders with.

I've implemented this approach for the `useDocument(s)` tests and I think it's a nice improvement. If you agree, I can follow this path for the rest of the tests.

Thanks!