### PR TITLE
chore: update storage adapters to use interface

### DIFF
--- a/packages/automerge-repo-storage-indexeddb/src/index.ts
+++ b/packages/automerge-repo-storage-indexeddb/src/index.ts
@@ -6,11 +6,11 @@
 
 import {
   Chunk,
-  StorageAdapter,
+  StorageAdapterInterface,
   type StorageKey,
 } from "@automerge/automerge-repo"
 
-export class IndexedDBStorageAdapter extends StorageAdapter {
+export class IndexedDBStorageAdapter implements StorageAdapterInterface {
   private dbPromise: Promise<IDBDatabase>
 
   /** Create a new {@link IndexedDBStorageAdapter}.
@@ -21,7 +21,6 @@ export class IndexedDBStorageAdapter extends StorageAdapter {
     private database: string = "automerge",
     private store: string = "documents"
   ) {
-    super()
     this.dbPromise = this.createDatabasePromise()
   }
 

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -5,14 +5,14 @@
 
 import {
   Chunk,
-  StorageAdapter,
+  StorageAdapterInterface,
   type StorageKey,
 } from "@automerge/automerge-repo"
 import fs from "fs"
 import path from "path"
 import { rimraf } from "rimraf"
 
-export class NodeFSStorageAdapter extends StorageAdapter {
+export class NodeFSStorageAdapter implements StorageAdapterInterface {
   private baseDirectory: string
   private cache: { [key: string]: Uint8Array } = {}
 
@@ -20,7 +20,6 @@ export class NodeFSStorageAdapter extends StorageAdapter {
    * @param baseDirectory - The path to the directory to store data in. Defaults to "./automerge-repo-data".
    */
   constructor(baseDirectory = "automerge-repo-data") {
-    super()
     this.baseDirectory = baseDirectory
   }
 

--- a/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
+++ b/packages/automerge-repo/test/helpers/DummyStorageAdapter.ts
@@ -1,6 +1,6 @@
-import { Chunk, StorageAdapter, type StorageKey } from "../../src/index.js"
+import { Chunk, StorageAdapterInterface, type StorageKey } from "../../src/index.js"
 
-export class DummyStorageAdapter implements StorageAdapter {
+export class DummyStorageAdapter implements StorageAdapterInterface {
   #data: Record<string, Uint8Array> = {}
 
   #keyToString(key: string[]): string {


### PR DESCRIPTION
I noticed some deprecation warnings as I was doing some other work, so swapped out `extends StorageAdapter` to `implements StorageAdapterInterface` per the deprecation notes.
