### PR TITLE
Tests suite for storage adapters

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
+++ b/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
@@ -1,7 +1,7 @@
 import { PeerId } from "@automerge/automerge-repo"
 import { describe, it } from "vitest"
 import {
-  runAdapterTests,
+  runNetworkAdapterTests,
   type SetupFn,
 } from "../../automerge-repo/src/helpers/tests/network-adapter-tests.js"
 import { BroadcastChannelNetworkAdapter } from "../src/index.js"
@@ -15,7 +15,7 @@ describe("BroadcastChannel", () => {
     return { adapters: [a, b, c] }
   }
 
-  runAdapterTests(setup)
+  runNetworkAdapterTests(setup)
 
   it("allows a channel name to be specified in the options and limits messages to that channel", async () => {
     const a = new BroadcastChannelNetworkAdapter()

--- a/packages/automerge-repo-network-messagechannel/test/index.test.ts
+++ b/packages/automerge-repo-network-messagechannel/test/index.test.ts
@@ -1,10 +1,10 @@
 import { describe } from "vitest"
-import { runAdapterTests } from "../../automerge-repo/src/helpers/tests/network-adapter-tests.js"
+import { runNetworkAdapterTests } from "../../automerge-repo/src/helpers/tests/network-adapter-tests.js"
 import { MessageChannelNetworkAdapter as Adapter } from "../src/index.js"
 
 // bob is the hub, alice and charlie are spokes
 describe("MessageChannelNetworkAdapter", () => {
-  runAdapterTests(async () => {
+  runNetworkAdapterTests(async () => {
     const aliceBobChannel = new MessageChannel()
     const bobCharlieChannel = new MessageChannel()
 
@@ -24,7 +24,7 @@ describe("MessageChannelNetworkAdapter", () => {
   }, "hub and spoke")
 
   // all 3 peers connected directly to each other
-  runAdapterTests(async () => {
+  runNetworkAdapterTests(async () => {
     const aliceBobChannel = new MessageChannel()
     const bobCharlieChannel = new MessageChannel()
     const aliceCharlieChannel = new MessageChannel()

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -10,7 +10,7 @@ import {
 import { generateAutomergeUrl } from "@automerge/automerge-repo/dist/AutomergeUrl"
 import { eventPromise } from "@automerge/automerge-repo/src/helpers/eventPromise"
 import { headsAreSame } from "@automerge/automerge-repo/src/helpers/headsAreSame.js"
-import { runAdapterTests } from "@automerge/automerge-repo/src/helpers/tests/network-adapter-tests.js"
+import { runNetworkAdapterTests } from "@automerge/automerge-repo/src/helpers/tests/network-adapter-tests.js"
 import { DummyStorageAdapter } from "@automerge/automerge-repo/test/helpers/DummyStorageAdapter.js"
 import assert from "assert"
 import * as CBOR from "cbor-x"
@@ -27,7 +27,7 @@ describe("Websocket adapters", () => {
   const serverPeerId = "server" as PeerId
   const documentId = parseAutomergeUrl(generateAutomergeUrl()).documentId
 
-  runAdapterTests(async () => {
+  runNetworkAdapterTests(async () => {
     const {
       clients: [aliceAdapter, bobAdapter],
       server,

--- a/packages/automerge-repo-storage-nodefs/package.json
+++ b/packages/automerge-repo-storage-nodefs/package.json
@@ -9,7 +9,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "watch": "npm-watch build"
+    "watch": "npm-watch build",
+    "test": "vitest"
   },
   "dependencies": {
     "@automerge/automerge-repo": "workspace:*",

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -121,9 +121,7 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
 // HELPERS
 
-const getKey = (keyArray: StorageKey): string => {
-  return keyArray.join(path.posix.sep)
-}
+const getKey = (key: StorageKey): string => path.join(...key)
 
 /** returns all files in a directory, recursively  */
 const walkdir = async (dirPath: string): Promise<string[]> => {

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -76,11 +76,10 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
     // The "keys" in the cache don't include the baseDirectory.
     // We want to de-dupe with the cached keys so we'll use getKey to normalize them.
-    const diskKeys: string[] = diskFiles
-      .map((fileName: string) => {
-        const k = getKey([path.relative(this.baseDirectory, fileName)])
-        return k.slice(0, 2) + k.slice(3)
-      })
+    const diskKeys: string[] = diskFiles.map((fileName: string) => {
+      const k = getKey([path.relative(this.baseDirectory, fileName)])
+      return k.slice(0, 2) + k.slice(3)
+    })
 
     // Combine and deduplicate the lists of keys
     const allKeys = [...new Set([...cachedKeys, ...diskKeys])]
@@ -115,7 +114,12 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
   private getFilePath(keyArray: string[]): string {
     const [firstKey, ...remainingKeys] = keyArray
-    return path.join(this.baseDirectory, firstKey.slice(0, 2), firstKey.slice(2), ...remainingKeys)
+    return path.join(
+      this.baseDirectory,
+      firstKey.slice(0, 2),
+      firstKey.slice(2),
+      ...remainingKeys
+    )
   }
 }
 

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -81,7 +81,7 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
     )
 
     // Combine and deduplicate the lists of keys
-    const allKeys = [...new Set([...cachedKeys, ...diskKeys])]
+    const allKeys = [...new Set([...cachedKeys, ...diskKeysToCachedKeys(diskKeys)])]
 
     // Load all files
     const chunks = await Promise.all(
@@ -112,15 +112,19 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
   }
 
   private getFilePath(keyArray: string[]): string {
-    return path.join(this.baseDirectory, getKey(keyArray))
+    const [firstKey, ...remainingKeys] = keyArray
+    return path.join(this.baseDirectory, firstKey.slice(0, 2), firstKey.slice(2), ...remainingKeys)
   }
 }
 
 // HELPERS
 
 const getKey = (keyArray: StorageKey): string => {
-  const [firstKey, ...remainingKeys] = keyArray
-  return path.join(firstKey.slice(0, 2), firstKey.slice(2), ...remainingKeys)
+  return keyArray.join(path.posix.sep)
+}
+
+const diskKeysToCachedKeys = (diskKeys: string[]): string[] => {
+  return diskKeys.map(k => k.slice(0, 2) + k.slice(3))
 }
 
 /** returns all files in a directory, recursively  */

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -76,12 +76,14 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
     // The "keys" in the cache don't include the baseDirectory.
     // We want to de-dupe with the cached keys so we'll use getKey to normalize them.
-    const diskKeys: string[] = diskFiles.map((fileName: string) =>
-      getKey([path.relative(this.baseDirectory, fileName)])
-    )
+    const diskKeys: string[] = diskFiles
+      .map((fileName: string) => {
+        const k = getKey([path.relative(this.baseDirectory, fileName)])
+        return k.slice(0, 2) + k.slice(3)
+      })
 
     // Combine and deduplicate the lists of keys
-    const allKeys = [...new Set([...cachedKeys, ...diskKeysToCachedKeys(diskKeys)])]
+    const allKeys = [...new Set([...cachedKeys, ...diskKeys])]
 
     // Load all files
     const chunks = await Promise.all(
@@ -121,10 +123,6 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
 const getKey = (keyArray: StorageKey): string => {
   return keyArray.join(path.posix.sep)
-}
-
-const diskKeysToCachedKeys = (diskKeys: string[]): string[] => {
-  return diskKeys.map(k => k.slice(0, 2) + k.slice(3))
 }
 
 /** returns all files in a directory, recursively  */

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -112,20 +112,16 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
   }
 
   private getFilePath(keyArray: string[]): string {
-    const [firstKey, ...remainingKeys] = keyArray
-    const firstKeyDir = path.join(
-      this.baseDirectory,
-      firstKey.slice(0, 2),
-      firstKey.slice(2)
-    )
-
-    return path.join(firstKeyDir, ...remainingKeys)
+    return path.join(this.baseDirectory, getKey(keyArray))
   }
 }
 
 // HELPERS
 
-const getKey = (key: StorageKey): string => path.join(...key)
+const getKey = (keyArray: StorageKey): string => {
+  const [firstKey, ...remainingKeys] = keyArray
+  return path.join(firstKey.slice(0, 2), firstKey.slice(2), ...remainingKeys)
+}
 
 /** returns all files in a directory, recursively  */
 const walkdir = async (dirPath: string): Promise<string[]> => {

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -13,45 +13,26 @@ function cleanDir(dir: string) {
   } catch (e) {}
 }
 
-describe('NodeFSStorageAdapter', () => {
-  let baseDirectory: string;
-  let adapter: NodeFSStorageAdapter;
-
-  beforeEach(async () => {
-    baseDirectory = path.join(os.tmpdir(), crypto.randomUUID())
-    adapter = new NodeFSStorageAdapter(baseDirectory)
-  })
-
-  afterAll(async() => {
-    cleanDir(baseDirectory);
-  })
-
-  describe('getFilePath', () => {
-    it('should compose keys correctly', () => {
-      // @ts-ignore
-      const actual = adapter.getFilePath(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"])
-      expect(actual).toStrictEqual(path.join(baseDirectory) + '/3x/uJ5sVKdBaYS6uGgGJH1cGhBLiC/sync-state/d99d4820-fb1f-4f3a-a40f-d5997b2012cf')
-    })
-  })
+function runStorageTests(sut: {adapter: NodeFSStorageAdapter}) {
 
   describe('load', () => {
     it('should return undefined if there is no data', async () => {
       expect(
-        await adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"])
+        await sut.adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"])
       ).toStrictEqual(undefined)
     })
   })
 
   describe('save and load', () => {
     it('should be possible to save and load', async () => {
-      await adapter.save(["storage-adapter-id"], new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'));
-      const actual = await adapter.load(["storage-adapter-id"]);
+      await sut.adapter.save(["storage-adapter-id"], new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'));
+      const actual = await sut.adapter.load(["storage-adapter-id"]);
       expect(actual).toStrictEqual(new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'))
     })
 
     it('should work with composed keys', async () => {
-      await adapter.save(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
-      const actual = await adapter.load(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"]);
+      await sut.adapter.save(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
+      const actual = await sut.adapter.load(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"]);
       expect(actual).toStrictEqual(new Uint8Array([0, 1, 127, 99, 154, 235 ]))
     })
   })
@@ -59,19 +40,19 @@ describe('NodeFSStorageAdapter', () => {
   describe('loadRange', () => {
     it('should return empty array if there is no data', async () => {
       expect(
-        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
       ).toStrictEqual([])
     })
   })
 
   describe('save and loadRange', () => {
     it('should return all the data that is present', async () => {
-      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
-      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
-      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]));
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]));
 
       expect(
-        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
       ).toStrictEqual([
         {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
         {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"]},
@@ -79,7 +60,7 @@ describe('NodeFSStorageAdapter', () => {
       ])
 
       expect(
-        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
+        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
       ).toStrictEqual([
         {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
         {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
@@ -89,28 +70,52 @@ describe('NodeFSStorageAdapter', () => {
 
   describe('save and remove', () => {
     it('should be no data', async () => {
-      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
-      await adapter.remove(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"]);
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
+      await sut.adapter.remove(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"]);
 
       expect(
-        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
       ).toStrictEqual([])
       expect(
-        await adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"])
+        await sut.adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"])
       ).toStrictEqual(undefined)
     })
   })
 
   describe('save and save', () => {
     it('should override the data', async () => {
-      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
-      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
 
       expect(
-        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
+        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
       ).toStrictEqual([
         {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
       ])
     })
   })
+}
+
+describe('NodeFSStorageAdapter', () => {
+  let baseDirectory: string = path.join(os.tmpdir(), crypto.randomUUID());
+  let sut: {adapter: NodeFSStorageAdapter} = {adapter: new NodeFSStorageAdapter(baseDirectory)}
+
+  beforeEach(async () => {
+    baseDirectory = path.join(os.tmpdir(), crypto.randomUUID())
+    sut.adapter = new NodeFSStorageAdapter(baseDirectory)
+  })
+
+  afterAll(async() => {
+    cleanDir(baseDirectory);
+  })
+
+  describe('getFilePath', () => {
+    it('should compose keys correctly', () => {
+      // @ts-ignore
+      const actual = sut.adapter.getFilePath(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"])
+      expect(actual).toStrictEqual(path.join(baseDirectory) + '/3x/uJ5sVKdBaYS6uGgGJH1cGhBLiC/sync-state/d99d4820-fb1f-4f3a-a40f-d5997b2012cf')
+    })
+  })
+
+  runStorageTests(sut);
 })

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -1,0 +1,116 @@
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import * as crypto from "node:crypto"
+
+import { afterAll, beforeEach, describe, expect, it } from "vitest"
+
+import { NodeFSStorageAdapter } from "../src"
+
+function cleanDir(dir: string) {
+  try {
+    fs.rmSync(dir, { force: true, recursive: true })
+  } catch (e) {}
+}
+
+describe('NodeFSStorageAdapter', () => {
+  let baseDirectory: string;
+  let adapter: NodeFSStorageAdapter;
+
+  beforeEach(async () => {
+    baseDirectory = path.join(os.tmpdir(), crypto.randomUUID())
+    adapter = new NodeFSStorageAdapter(baseDirectory)
+  })
+
+  afterAll(async() => {
+    cleanDir(baseDirectory);
+  })
+
+  describe('getFilePath', () => {
+    it('should compose keys correctly', () => {
+      // @ts-ignore
+      const actual = adapter.getFilePath(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"])
+      expect(actual).toStrictEqual(path.join(baseDirectory) + '/3x/uJ5sVKdBaYS6uGgGJH1cGhBLiC/sync-state/d99d4820-fb1f-4f3a-a40f-d5997b2012cf')
+    })
+  })
+
+  describe('load', () => {
+    it('should return undefined if there is no data', async () => {
+      expect(
+        await adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"])
+      ).toStrictEqual(undefined)
+    })
+  })
+
+  describe('save and load', () => {
+    it('should be possible to save and load', async () => {
+      await adapter.save(["storage-adapter-id"], new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'));
+      const actual = await adapter.load(["storage-adapter-id"]);
+      expect(actual).toStrictEqual(new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'))
+    })
+
+    it('should work with composed keys', async () => {
+      await adapter.save(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
+      const actual = await adapter.load(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"]);
+      expect(actual).toStrictEqual(new Uint8Array([0, 1, 127, 99, 154, 235 ]))
+    })
+  })
+
+  describe('loadRange', () => {
+    it('should return empty array if there is no data', async () => {
+      expect(
+        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+      ).toStrictEqual([])
+    })
+  })
+
+  describe('save and loadRange', () => {
+    it.fails('should return all the data that is present', async () => {
+      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
+      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
+      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]));
+
+      expect(
+        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+      ).toStrictEqual([
+        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
+        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"]},
+        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
+      ])
+
+      expect(
+        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
+      ).toStrictEqual([
+        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
+        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
+      ])
+    })
+  })
+
+  describe('save and remove', () => {
+    it('should be no data', async () => {
+      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
+      await adapter.remove(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"]);
+
+      expect(
+        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+      ).toStrictEqual([])
+      expect(
+        await adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"])
+      ).toStrictEqual(undefined)
+    })
+  })
+
+  describe('save and save', () => {
+    it.fails('should override the data', async () => {
+      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
+      await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
+
+      expect(
+        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
+      ).toStrictEqual([
+        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
+      ])
+    })
+  })
+})

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -1,7 +1,6 @@
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
-import * as crypto from "node:crypto"
 import { afterAll, beforeEach, describe, expect, it } from "vitest"
 import { runStorageAdapterTests } from "@automerge/automerge-repo/src/helpers/tests/storage-adapter-tests"
 import { NodeFSStorageAdapter } from "../src"

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -1,38 +1,19 @@
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
-import { afterAll, beforeEach, describe, expect, it } from "vitest"
-import { runStorageAdapterTests } from "@automerge/automerge-repo/src/helpers/tests/storage-adapter-tests"
+import { describe } from "vitest"
+import { runStorageAdapterTests } from "../../automerge-repo/src/helpers/tests/storage-adapter-tests"
 import { NodeFSStorageAdapter } from "../src"
 
-function cleanDir(dir: string) {
-  try {
-    fs.rmSync(dir, { force: true, recursive: true })
-  } catch (e) {}
-}
+describe("NodeFSStorageAdapter", () => {
+  const setup = async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "automerge-repo-tests"))
+    const teardown = () => {
+      fs.rmSync(dir, { force: true, recursive: true })
+    }
+    const adapter = new NodeFSStorageAdapter(dir)
+    return { adapter, teardown }
+  }
 
-const tempDir = () => fs.mkdtempSync(path.join(os.tmpdir(), "automerge-repo-tests"))
-
-describe('NodeFSStorageAdapter', () => {
-  let baseDirectory: string = tempDir()
-  let sut: {adapter: NodeFSStorageAdapter} = {adapter: new NodeFSStorageAdapter(baseDirectory)}
-
-  beforeEach(async () => {
-    baseDirectory = tempDir()
-    sut.adapter = new NodeFSStorageAdapter(baseDirectory)
-  })
-
-  afterAll(async() => {
-    cleanDir(baseDirectory)
-  })
-
-  describe('getFilePath', () => {
-    it('should compose keys correctly', () => {
-      // @ts-ignore
-      const actual = sut.adapter.getFilePath(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"])
-      expect(actual).toStrictEqual(path.join(baseDirectory) + '/3x/uJ5sVKdBaYS6uGgGJH1cGhBLiC/sync-state/d99d4820-fb1f-4f3a-a40f-d5997b2012cf')
-    })
-  })
-
-  runStorageAdapterTests(sut)
+  runStorageAdapterTests(setup)
 })

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -12,12 +12,14 @@ function cleanDir(dir: string) {
   } catch (e) {}
 }
 
+const tempDir = () => fs.mkdtempSync(path.join(os.tmpdir(), "automerge-repo-tests"))
+
 describe('NodeFSStorageAdapter', () => {
-  let baseDirectory: string = path.join(os.tmpdir(), crypto.randomUUID());
+  let baseDirectory: string = tempDir()
   let sut: {adapter: NodeFSStorageAdapter} = {adapter: new NodeFSStorageAdapter(baseDirectory)}
 
   beforeEach(async () => {
-    baseDirectory = path.join(os.tmpdir(), crypto.randomUUID())
+    baseDirectory = tempDir()
     sut.adapter = new NodeFSStorageAdapter(baseDirectory)
   })
 

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -65,7 +65,7 @@ describe('NodeFSStorageAdapter', () => {
   })
 
   describe('save and loadRange', () => {
-    it.fails('should return all the data that is present', async () => {
+    it('should return all the data that is present', async () => {
       await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
       await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
       await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]));
@@ -102,7 +102,7 @@ describe('NodeFSStorageAdapter', () => {
   })
 
   describe('save and save', () => {
-    it.fails('should override the data', async () => {
+    it('should override the data', async () => {
       await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
       await adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
 

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -22,7 +22,7 @@ describe('NodeFSStorageAdapter', () => {
   })
 
   afterAll(async() => {
-    cleanDir(baseDirectory);
+    cleanDir(baseDirectory)
   })
 
   describe('getFilePath', () => {
@@ -33,5 +33,5 @@ describe('NodeFSStorageAdapter', () => {
     })
   })
 
-  runStorageAdapterTests(sut);
+  runStorageAdapterTests(sut)
 })

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -2,98 +2,14 @@ import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
 import * as crypto from "node:crypto"
-
 import { afterAll, beforeEach, describe, expect, it } from "vitest"
-
+import { runStorageAdapterTests } from "@automerge/automerge-repo/src/helpers/tests/storage-adapter-tests"
 import { NodeFSStorageAdapter } from "../src"
 
 function cleanDir(dir: string) {
   try {
     fs.rmSync(dir, { force: true, recursive: true })
   } catch (e) {}
-}
-
-function runStorageTests(sut: {adapter: NodeFSStorageAdapter}) {
-
-  describe('load', () => {
-    it('should return undefined if there is no data', async () => {
-      expect(
-        await sut.adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"])
-      ).toStrictEqual(undefined)
-    })
-  })
-
-  describe('save and load', () => {
-    it('should be possible to save and load', async () => {
-      await sut.adapter.save(["storage-adapter-id"], new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'));
-      const actual = await sut.adapter.load(["storage-adapter-id"]);
-      expect(actual).toStrictEqual(new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'))
-    })
-
-    it('should work with composed keys', async () => {
-      await sut.adapter.save(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
-      const actual = await sut.adapter.load(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"]);
-      expect(actual).toStrictEqual(new Uint8Array([0, 1, 127, 99, 154, 235 ]))
-    })
-  })
-
-  describe('loadRange', () => {
-    it('should return empty array if there is no data', async () => {
-      expect(
-        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-      ).toStrictEqual([])
-    })
-  })
-
-  describe('save and loadRange', () => {
-    it('should return all the data that is present', async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]));
-
-      expect(
-        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-      ).toStrictEqual([
-        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
-        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"]},
-        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
-      ])
-
-      expect(
-        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
-      ).toStrictEqual([
-        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
-        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
-      ])
-    })
-  })
-
-  describe('save and remove', () => {
-    it('should be no data', async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
-      await sut.adapter.remove(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"]);
-
-      expect(
-        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-      ).toStrictEqual([])
-      expect(
-        await sut.adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"])
-      ).toStrictEqual(undefined)
-    })
-  })
-
-  describe('save and save', () => {
-    it('should override the data', async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
-
-      expect(
-        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
-      ).toStrictEqual([
-        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
-      ])
-    })
-  })
 }
 
 describe('NodeFSStorageAdapter', () => {
@@ -117,5 +33,5 @@ describe('NodeFSStorageAdapter', () => {
     })
   })
 
-  runStorageTests(sut);
+  runStorageAdapterTests(sut);
 })

--- a/packages/automerge-repo-storage-nodefs/tsconfig.json
+++ b/packages/automerge-repo-storage-nodefs/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "jsx": "react",
     "module": "NodeNext",
     "moduleResolution": "Node16",
     "declaration": true,

--- a/packages/automerge-repo-storage-nodefs/vitest.config.ts
+++ b/packages/automerge-repo-storage-nodefs/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig, mergeConfig } from "vitest/config"
+import rootConfig from '../../vitest.config'
+
+export default mergeConfig(rootConfig, defineConfig({
+  test: {
+    environment: "node"
+  },
+}))

--- a/packages/automerge-repo-storage-nodefs/vitest.config.ts
+++ b/packages/automerge-repo-storage-nodefs/vitest.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig, mergeConfig } from "vitest/config"
-import rootConfig from '../../vitest.config'
+import rootConfig from "../../vitest.config"
 
-export default mergeConfig(rootConfig, defineConfig({
-  test: {
-    environment: "node"
-  },
-}))
+export default mergeConfig(
+  rootConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+    },
+  })
+)

--- a/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
@@ -17,7 +17,7 @@ import { pause } from "../pause.js"
  * - `teardown`: An optional function that will be called after the tests have run. This can be used
  *   to clean up any resources that were created during the test.
  */
-export function runAdapterTests(_setup: SetupFn, title?: string): void {
+export function runNetworkAdapterTests(_setup: SetupFn, title?: string): void {
   // Wrap the provided setup function
   const setup = async () => {
     const { adapters, teardown = NO_OP } = await _setup()
@@ -28,7 +28,9 @@ export function runAdapterTests(_setup: SetupFn, title?: string): void {
     return { adapters: [a, b, c], teardown }
   }
 
-  describe(`Adapter acceptance tests ${title ? `(${title})` : ""}`, () => {
+  describe(`Network adapter acceptance tests ${
+    title ? `(${title})` : ""
+  }`, () => {
     it("can sync 2 repos", async () => {
       const doTest = async (
         a: NetworkAdapterInterface[],

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -2,138 +2,336 @@ import { describe, expect, it } from "vitest"
 
 import type { StorageAdapterInterface } from "../../storage/StorageAdapterInterface.js"
 
-export function runStorageAdapterTests(sut: {adapter: StorageAdapterInterface}) {
-
-  describe('load', () => {
-    it('should return undefined if there is no data', async () => {
+export function runStorageAdapterTests({ adapter }: Params) {
+  describe("load", () => {
+    it("should return undefined if there is no data", async () => {
       expect(
-        await sut.adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"])
+        await adapter.load([
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "sync-state",
+          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+        ])
       ).toStrictEqual(undefined)
     })
   })
 
-  describe('save and load', () => {
-    it('should return data that was saved', async () => {
-      await sut.adapter.save(["storage-adapter-id"], new Uint8Array([
-        56, 97, 51,  53,  99, 57, 98,  52,  45,
-        49, 48, 57, 101,  45, 52, 97,  55, 102,
-        45, 97, 51,  53, 101, 45, 97,  53,  52,
-        54, 52, 49,  50,  49, 98, 54, 100, 100
-      ]))
+  describe("save and load", () => {
+    it("should return data that was saved", async () => {
+      await adapter.save(
+        ["storage-adapter-id"],
+        new Uint8Array([
+          56, 97, 51, 53, 99, 57, 98, 52, 45, 49, 48, 57, 101, 45, 52, 97, 55,
+          102, 45, 97, 51, 53, 101, 45, 97, 53, 52, 54, 52, 49, 50, 49, 98, 54,
+          100, 100,
+        ])
+      )
 
-      const actual = await sut.adapter.load(["storage-adapter-id"])
+      const actual = await adapter.load(["storage-adapter-id"])
 
-      expect(actual).toStrictEqual(new Uint8Array([
-        56, 97, 51,  53,  99, 57, 98,  52,  45,
-        49, 48, 57, 101,  45, 52, 97,  55, 102,
-        45, 97, 51,  53, 101, 45, 97,  53,  52,
-        54, 52, 49,  50,  49, 98, 54, 100, 100
-      ]))
+      expect(actual).toStrictEqual(
+        new Uint8Array([
+          56, 97, 51, 53, 99, 57, 98, 52, 45, 49, 48, 57, 101, 45, 52, 97, 55,
+          102, 45, 97, 51, 53, 101, 45, 97, 53, 52, 54, 52, 49, 50, 49, 98, 54,
+          100, 100,
+        ])
+      )
     })
 
-    it('should work with composed keys', async () => {
-      await sut.adapter.save(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
-      const actual = await sut.adapter.load(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"])
-      expect(actual).toStrictEqual(new Uint8Array([0, 1, 127, 99, 154, 235 ]))
+    it("should work with composed keys", async () => {
+      await adapter.save(
+        [
+          "pSq9fP9ekr1zembLzBJkgHTo7Wn",
+          "sync-state",
+          "3761c9f0-bb1d-44b6-88ac-f85072fc3273",
+        ],
+        new Uint8Array([0, 1, 127, 99, 154, 235])
+      )
+      const actual = await adapter.load([
+        "pSq9fP9ekr1zembLzBJkgHTo7Wn",
+        "sync-state",
+        "3761c9f0-bb1d-44b6-88ac-f85072fc3273",
+      ])
+      expect(actual).toStrictEqual(new Uint8Array([0, 1, 127, 99, 154, 235]))
     })
   })
 
-  describe('loadRange', () => {
-    it('should return empty array if there is no data', async () => {
+  describe("loadRange", () => {
+    it("should return empty array if there is no data", async () => {
       expect(
-        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
       ).toStrictEqual([])
     })
   })
 
-  describe('save and loadRange', () => {
-    it('should return all the data that is present', async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]))
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]))
+  describe("save and loadRange", () => {
+    it("should return all the data that is present", async () => {
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "sync-state",
+          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+        ],
+        new Uint8Array([0, 1, 127, 99, 154, 235])
+      )
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "snapshot",
+          "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
+        ],
+        new Uint8Array([1, 76, 160, 53, 57, 10, 230])
+      )
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "sync-state",
+          "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+        ],
+        new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
+      )
 
       expect(
-        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-      ).toStrictEqual(expect.arrayContaining([
-        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
-        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"]},
-        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
-      ]))
+        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+      ).toStrictEqual(
+        expect.arrayContaining([
+          {
+            data: new Uint8Array([0, 1, 127, 99, 154, 235]),
+            key: [
+              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+              "sync-state",
+              "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+            ],
+          },
+          {
+            data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
+            key: [
+              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+              "snapshot",
+              "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
+            ],
+          },
+          {
+            data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
+            key: [
+              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+              "sync-state",
+              "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+            ],
+          },
+        ])
+      )
 
       expect(
-        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
-      ).toStrictEqual(expect.arrayContaining([
-        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
-        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
-      ]))
+        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC", "sync-state"])
+      ).toStrictEqual(
+        expect.arrayContaining([
+          {
+            data: new Uint8Array([0, 1, 127, 99, 154, 235]),
+            key: [
+              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+              "sync-state",
+              "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+            ],
+          },
+          {
+            data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
+            key: [
+              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+              "sync-state",
+              "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+            ],
+          },
+        ])
+      )
     })
 
     it("does not includes values which shouldn't be there", async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiD","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]))
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "sync-state",
+          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+        ],
+        new Uint8Array([0, 1, 127, 99, 154, 235])
+      )
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
+          "sync-state",
+          "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+        ],
+        new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
+      )
 
-      const actual = await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-      expect(actual).toStrictEqual(expect.arrayContaining([
-        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
-      ]))
-      expect(actual).toStrictEqual(expect.not.arrayContaining([
-        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiD","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]},
-      ]))
+      const actual = await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+      expect(actual).toStrictEqual(
+        expect.arrayContaining([
+          {
+            data: new Uint8Array([0, 1, 127, 99, 154, 235]),
+            key: [
+              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+              "sync-state",
+              "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+            ],
+          },
+        ])
+      )
+      expect(actual).toStrictEqual(
+        expect.not.arrayContaining([
+          {
+            data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
+            key: [
+              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
+              "sync-state",
+              "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+            ],
+          },
+        ])
+      )
     })
   })
 
-  describe('save and remove', () => {
-    it('should be no data', async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
-      await sut.adapter.remove(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"])
+  describe("save and remove", () => {
+    it("should be no data", async () => {
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "snapshot",
+          "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
+        ],
+        new Uint8Array([0, 1, 127, 99, 154, 235])
+      )
+      await adapter.remove([
+        "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+        "snapshot",
+        "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
+      ])
 
       expect(
-        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
       ).toStrictEqual([])
       expect(
-        await sut.adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"])
+        await adapter.load([
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "snapshot",
+          "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
+        ])
       ).toStrictEqual(undefined)
     })
   })
 
-  describe('save and save', () => {
-    it('should override the data', async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]))
+  describe("save and save", () => {
+    it("should override the data", async () => {
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "sync-state",
+          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+        ],
+        new Uint8Array([0, 1, 127, 99, 154, 235])
+      )
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "sync-state",
+          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+        ],
+        new Uint8Array([1, 76, 160, 53, 57, 10, 230])
+      )
 
       expect(
-        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
+        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC", "sync-state"])
       ).toStrictEqual([
-        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
+        {
+          data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
+          key: [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+          ],
+        },
       ])
     })
   })
 
-  describe('removeRange', () => {
-    it('should remove set of records', async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]))
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]))
+  describe("removeRange", () => {
+    it("should remove set of records", async () => {
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "sync-state",
+          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+        ],
+        new Uint8Array([0, 1, 127, 99, 154, 235])
+      )
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "snapshot",
+          "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
+        ],
+        new Uint8Array([1, 76, 160, 53, 57, 10, 230])
+      )
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "sync-state",
+          "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+        ],
+        new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
+      )
 
-      await sut.adapter.removeRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
+      await adapter.removeRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC", "sync-state"])
 
       expect(
-        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
       ).toStrictEqual([
-        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"]},
+        {
+          data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
+          key: [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "snapshot",
+            "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
+          ],
+        },
       ])
     })
 
-    it('should not remove set of records that doesn\'t match', async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiD","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]))
+    it("should not remove set of records that doesn't match", async () => {
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "sync-state",
+          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+        ],
+        new Uint8Array([0, 1, 127, 99, 154, 235])
+      )
+      await adapter.save(
+        [
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
+          "sync-state",
+          "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+        ],
+        new Uint8Array([1, 76, 160, 53, 57, 10, 230])
+      )
 
-      await sut.adapter.removeRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+      await adapter.removeRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
 
-      const actual = await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiD"])
+      const actual = await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiD"])
       expect(actual).toStrictEqual([
-        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiD","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]},
+        {
+          data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
+          key: [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
+            "sync-state",
+            "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+          ],
+        },
       ])
     })
   })
+}
+
+type Params = {
+  adapter: StorageAdapterInterface
 }

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from "vitest"
 
 import type { StorageAdapterInterface } from "../../storage/StorageAdapterInterface.js"
 
+const PAYLOAD_A = new Uint8Array([
+  56, 97, 51, 53, 99, 57, 98, 52, 45, 49, 48, 57, 101, 45, 52, 97, 55, 102, 45,
+  97, 51, 53, 101, 45, 97, 53, 52, 54, 52, 49, 50, 49, 98, 54, 100, 100,
+])
+const PAYLOAD_B = new Uint8Array([0, 1, 127, 99, 154, 235])
+const PAYLOAD_C = new Uint8Array([1, 76, 160, 53, 57, 10, 230])
+const PAYLOAD_D = new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
+
 export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
   const setup = async () => {
     const { adapter, teardown = NO_OP } = await _setup()
@@ -15,11 +23,7 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
       it("should return undefined if there is no data", async () => {
         const { adapter, teardown } = await setup()
         expect(
-          await adapter.load([
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-          ])
+          await adapter.load(["3xuJ5", "sync-state", "d99d4"])
         ).toStrictEqual(undefined)
         teardown()
       })
@@ -28,53 +32,27 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     describe("save and load", () => {
       it("should return data that was saved", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(
-          ["storage-adapter-id"],
-          new Uint8Array([
-            56, 97, 51, 53, 99, 57, 98, 52, 45, 49, 48, 57, 101, 45, 52, 97, 55,
-            102, 45, 97, 51, 53, 101, 45, 97, 53, 52, 54, 52, 49, 50, 49, 98,
-            54, 100, 100,
-          ])
-        )
+        await adapter.save(["storage-adapter-id"], PAYLOAD_A)
 
         const actual = await adapter.load(["storage-adapter-id"])
 
-        expect(actual).toStrictEqual(
-          new Uint8Array([
-            56, 97, 51, 53, 99, 57, 98, 52, 45, 49, 48, 57, 101, 45, 52, 97, 55,
-            102, 45, 97, 51, 53, 101, 45, 97, 53, 52, 54, 52, 49, 50, 49, 98,
-            54, 100, 100,
-          ])
-        )
+        expect(actual).toStrictEqual(PAYLOAD_A)
         teardown()
       })
 
-      it("should work with composed keys", async () => {
+      it("should work with composite keys", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(
-          [
-            "pSq9fP9ekr1zembLzBJkgHTo7Wn",
-            "sync-state",
-            "3761c9f0-bb1d-44b6-88ac-f85072fc3273",
-          ],
-          new Uint8Array([0, 1, 127, 99, 154, 235])
-        )
-        const actual = await adapter.load([
-          "pSq9fP9ekr1zembLzBJkgHTo7Wn",
-          "sync-state",
-          "3761c9f0-bb1d-44b6-88ac-f85072fc3273",
-        ])
-        expect(actual).toStrictEqual(new Uint8Array([0, 1, 127, 99, 154, 235]))
+        await adapter.save(["pSq9f", "sync-state", "3761c"], PAYLOAD_B)
+        const actual = await adapter.load(["pSq9f", "sync-state", "3761c"])
+        expect(actual).toStrictEqual(PAYLOAD_B)
         teardown()
       })
     })
 
     describe("loadRange", () => {
-      it("should return empty array if there is no data", async () => {
+      it("should return an empty array if there is no data", async () => {
         const { adapter, teardown } = await setup()
-        expect(
-          await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-        ).toStrictEqual([])
+        expect(await adapter.loadRange(["3xuJ5"])).toStrictEqual([])
         teardown()
       })
     })
@@ -82,131 +60,40 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     describe("save and loadRange", () => {
       it("should return all the data that is present", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-          ],
-          new Uint8Array([0, 1, 127, 99, 154, 235])
-        )
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "snapshot",
-            "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
-          ],
-          new Uint8Array([1, 76, 160, 53, 57, 10, 230])
-        )
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-            "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-          ],
-          new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
-        )
+        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_B)
+        await adapter.save(["3xuJ5", "snapshot", "7848c"], PAYLOAD_C)
+        await adapter.save(["3xuJ5", "sync-state", "0e05e"], PAYLOAD_D)
 
-        expect(
-          await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-        ).toStrictEqual(
+        expect(await adapter.loadRange(["3xuJ5"])).toStrictEqual(
           expect.arrayContaining([
-            {
-              data: new Uint8Array([0, 1, 127, 99, 154, 235]),
-              key: [
-                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-                "sync-state",
-                "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-              ],
-            },
-            {
-              data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
-              key: [
-                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-                "snapshot",
-                "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
-              ],
-            },
-            {
-              data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
-              key: [
-                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-                "sync-state",
-                "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-              ],
-            },
+            { key: ["3xuJ5", "sync-state", "d99d4"], data: PAYLOAD_B },
+            { key: ["3xuJ5", "snapshot", "7848c"], data: PAYLOAD_C },
+            { key: ["3xuJ5", "sync-state", "0e05e"], data: PAYLOAD_D },
           ])
         )
 
-        expect(
-          await adapter.loadRange([
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-          ])
-        ).toStrictEqual(
+        expect(await adapter.loadRange(["3xuJ5", "sync-state"])).toStrictEqual(
           expect.arrayContaining([
-            {
-              data: new Uint8Array([0, 1, 127, 99, 154, 235]),
-              key: [
-                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-                "sync-state",
-                "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-              ],
-            },
-            {
-              data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
-              key: [
-                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-                "sync-state",
-                "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-              ],
-            },
+            { key: ["3xuJ5", "sync-state", "d99d4"], data: PAYLOAD_B },
+            { key: ["3xuJ5", "sync-state", "0e05e"], data: PAYLOAD_D },
           ])
         )
       })
 
       it("does not includes values which shouldn't be there", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-          ],
-          new Uint8Array([0, 1, 127, 99, 154, 235])
-        )
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
-            "sync-state",
-            "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-          ],
-          new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
-        )
+        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_B)
+        await adapter.save(["3xuJ6", "sync-state", "0e05e"], PAYLOAD_D)
 
-        const actual = await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        const actual = await adapter.loadRange(["3xuJ5"])
         expect(actual).toStrictEqual(
           expect.arrayContaining([
-            {
-              data: new Uint8Array([0, 1, 127, 99, 154, 235]),
-              key: [
-                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-                "sync-state",
-                "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-              ],
-            },
+            { key: ["3xuJ5", "sync-state", "d99d4"], data: PAYLOAD_B },
           ])
         )
         expect(actual).toStrictEqual(
           expect.not.arrayContaining([
-            {
-              data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
-              key: [
-                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
-                "sync-state",
-                "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-              ],
-            },
+            { key: ["3xuJ6", "sync-state", "0e05e"], data: PAYLOAD_D },
           ])
         )
         teardown()
@@ -216,68 +103,25 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     describe("save and remove", () => {
       it("should be no data", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "snapshot",
-            "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
-          ],
-          new Uint8Array([0, 1, 127, 99, 154, 235])
-        )
-        await adapter.remove([
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "snapshot",
-          "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
-        ])
+        await adapter.save(["3xuJ5", "snapshot", "09014"], PAYLOAD_B)
+        await adapter.remove(["3xuJ5", "snapshot", "09014"])
 
+        expect(await adapter.loadRange(["3xuJ5"])).toStrictEqual([])
         expect(
-          await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-        ).toStrictEqual([])
-        expect(
-          await adapter.load([
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "snapshot",
-            "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
-          ])
+          await adapter.load(["3xuJ5", "snapshot", "09014"])
         ).toStrictEqual(undefined)
         teardown()
       })
     })
 
     describe("save and save", () => {
-      it("should override the data", async () => {
+      it("should overwrite data saved with the same key", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-          ],
-          new Uint8Array([0, 1, 127, 99, 154, 235])
-        )
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-          ],
-          new Uint8Array([1, 76, 160, 53, 57, 10, 230])
-        )
+        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_B)
+        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_C)
 
-        expect(
-          await adapter.loadRange([
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-          ])
-        ).toStrictEqual([
-          {
-            data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
-            key: [
-              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-              "sync-state",
-              "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-            ],
-          },
+        expect(await adapter.loadRange(["3xuJ5", "sync-state"])).toStrictEqual([
+          { key: ["3xuJ5", "sync-state", "d99d4"], data: PAYLOAD_C },
         ])
         teardown()
       })
@@ -286,82 +130,28 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     describe("removeRange", () => {
       it("should remove set of records", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-          ],
-          new Uint8Array([0, 1, 127, 99, 154, 235])
-        )
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "snapshot",
-            "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
-          ],
-          new Uint8Array([1, 76, 160, 53, 57, 10, 230])
-        )
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-            "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-          ],
-          new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
-        )
+        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_B)
+        await adapter.save(["3xuJ5", "snapshot", "7848c"], PAYLOAD_C)
+        await adapter.save(["3xuJ5", "sync-state", "0e05e"], PAYLOAD_D)
 
-        await adapter.removeRange([
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "sync-state",
-        ])
+        await adapter.removeRange(["3xuJ5", "sync-state"])
 
-        expect(
-          await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-        ).toStrictEqual([
-          {
-            data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
-            key: [
-              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-              "snapshot",
-              "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
-            ],
-          },
+        expect(await adapter.loadRange(["3xuJ5"])).toStrictEqual([
+          { key: ["3xuJ5", "snapshot", "7848c"], data: PAYLOAD_C },
         ])
         teardown()
       })
 
       it("should not remove set of records that doesn't match", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-          ],
-          new Uint8Array([0, 1, 127, 99, 154, 235])
-        )
-        await adapter.save(
-          [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
-            "sync-state",
-            "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-          ],
-          new Uint8Array([1, 76, 160, 53, 57, 10, 230])
-        )
+        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_B)
+        await adapter.save(["3xuJ6", "sync-state", "0e05e"], PAYLOAD_C)
 
-        await adapter.removeRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        await adapter.removeRange(["3xuJ5"])
 
-        const actual = await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiD"])
+        const actual = await adapter.loadRange(["3xuJ6"])
         expect(actual).toStrictEqual([
-          {
-            data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
-            key: [
-              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
-              "sync-state",
-              "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-            ],
-          },
+          { key: ["3xuJ6", "sync-state", "0e05e"], data: PAYLOAD_C },
         ])
         teardown()
       })

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -2,106 +2,323 @@ import { describe, expect, it } from "vitest"
 
 import type { StorageAdapterInterface } from "../../storage/StorageAdapterInterface.js"
 
-export function runStorageAdapterTests({ adapter }: Params) {
-  describe("load", () => {
-    it("should return undefined if there is no data", async () => {
-      expect(
-        await adapter.load([
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "sync-state",
-          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-        ])
-      ).toStrictEqual(undefined)
-    })
-  })
+export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
+  const setup = async () => {
+    const { adapter, teardown = NO_OP } = await _setup()
+    return { adapter, teardown }
+  }
 
-  describe("save and load", () => {
-    it("should return data that was saved", async () => {
-      await adapter.save(
-        ["storage-adapter-id"],
-        new Uint8Array([
-          56, 97, 51, 53, 99, 57, 98, 52, 45, 49, 48, 57, 101, 45, 52, 97, 55,
-          102, 45, 97, 51, 53, 101, 45, 97, 53, 52, 54, 52, 49, 50, 49, 98, 54,
-          100, 100,
-        ])
-      )
-
-      const actual = await adapter.load(["storage-adapter-id"])
-
-      expect(actual).toStrictEqual(
-        new Uint8Array([
-          56, 97, 51, 53, 99, 57, 98, 52, 45, 49, 48, 57, 101, 45, 52, 97, 55,
-          102, 45, 97, 51, 53, 101, 45, 97, 53, 52, 54, 52, 49, 50, 49, 98, 54,
-          100, 100,
-        ])
-      )
+  describe(`Network adapter acceptance tests ${
+    title ? `(${title})` : ""
+  }`, () => {
+    describe("load", () => {
+      it("should return undefined if there is no data", async () => {
+        const { adapter, teardown } = await setup()
+        expect(
+          await adapter.load([
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+          ])
+        ).toStrictEqual(undefined)
+        teardown()
+      })
     })
 
-    it("should work with composed keys", async () => {
-      await adapter.save(
-        [
+    describe("save and load", () => {
+      it("should return data that was saved", async () => {
+        const { adapter, teardown } = await setup()
+        await adapter.save(
+          ["storage-adapter-id"],
+          new Uint8Array([
+            56, 97, 51, 53, 99, 57, 98, 52, 45, 49, 48, 57, 101, 45, 52, 97, 55,
+            102, 45, 97, 51, 53, 101, 45, 97, 53, 52, 54, 52, 49, 50, 49, 98,
+            54, 100, 100,
+          ])
+        )
+
+        const actual = await adapter.load(["storage-adapter-id"])
+
+        expect(actual).toStrictEqual(
+          new Uint8Array([
+            56, 97, 51, 53, 99, 57, 98, 52, 45, 49, 48, 57, 101, 45, 52, 97, 55,
+            102, 45, 97, 51, 53, 101, 45, 97, 53, 52, 54, 52, 49, 50, 49, 98,
+            54, 100, 100,
+          ])
+        )
+        teardown()
+      })
+
+      it("should work with composed keys", async () => {
+        const { adapter, teardown } = await setup()
+        await adapter.save(
+          [
+            "pSq9fP9ekr1zembLzBJkgHTo7Wn",
+            "sync-state",
+            "3761c9f0-bb1d-44b6-88ac-f85072fc3273",
+          ],
+          new Uint8Array([0, 1, 127, 99, 154, 235])
+        )
+        const actual = await adapter.load([
           "pSq9fP9ekr1zembLzBJkgHTo7Wn",
           "sync-state",
           "3761c9f0-bb1d-44b6-88ac-f85072fc3273",
-        ],
-        new Uint8Array([0, 1, 127, 99, 154, 235])
-      )
-      const actual = await adapter.load([
-        "pSq9fP9ekr1zembLzBJkgHTo7Wn",
-        "sync-state",
-        "3761c9f0-bb1d-44b6-88ac-f85072fc3273",
-      ])
-      expect(actual).toStrictEqual(new Uint8Array([0, 1, 127, 99, 154, 235]))
+        ])
+        expect(actual).toStrictEqual(new Uint8Array([0, 1, 127, 99, 154, 235]))
+        teardown()
+      })
     })
-  })
 
-  describe("loadRange", () => {
-    it("should return empty array if there is no data", async () => {
-      expect(
-        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-      ).toStrictEqual([])
+    describe("loadRange", () => {
+      it("should return empty array if there is no data", async () => {
+        const { adapter, teardown } = await setup()
+        expect(
+          await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        ).toStrictEqual([])
+        teardown()
+      })
     })
-  })
 
-  describe("save and loadRange", () => {
-    it("should return all the data that is present", async () => {
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "sync-state",
-          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-        ],
-        new Uint8Array([0, 1, 127, 99, 154, 235])
-      )
-      await adapter.save(
-        [
+    describe("save and loadRange", () => {
+      it("should return all the data that is present", async () => {
+        const { adapter, teardown } = await setup()
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+          ],
+          new Uint8Array([0, 1, 127, 99, 154, 235])
+        )
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "snapshot",
+            "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
+          ],
+          new Uint8Array([1, 76, 160, 53, 57, 10, 230])
+        )
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+            "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+          ],
+          new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
+        )
+
+        expect(
+          await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        ).toStrictEqual(
+          expect.arrayContaining([
+            {
+              data: new Uint8Array([0, 1, 127, 99, 154, 235]),
+              key: [
+                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+                "sync-state",
+                "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+              ],
+            },
+            {
+              data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
+              key: [
+                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+                "snapshot",
+                "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
+              ],
+            },
+            {
+              data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
+              key: [
+                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+                "sync-state",
+                "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+              ],
+            },
+          ])
+        )
+
+        expect(
+          await adapter.loadRange([
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+          ])
+        ).toStrictEqual(
+          expect.arrayContaining([
+            {
+              data: new Uint8Array([0, 1, 127, 99, 154, 235]),
+              key: [
+                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+                "sync-state",
+                "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+              ],
+            },
+            {
+              data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
+              key: [
+                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+                "sync-state",
+                "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+              ],
+            },
+          ])
+        )
+      })
+
+      it("does not includes values which shouldn't be there", async () => {
+        const { adapter, teardown } = await setup()
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+          ],
+          new Uint8Array([0, 1, 127, 99, 154, 235])
+        )
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
+            "sync-state",
+            "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+          ],
+          new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
+        )
+
+        const actual = await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        expect(actual).toStrictEqual(
+          expect.arrayContaining([
+            {
+              data: new Uint8Array([0, 1, 127, 99, 154, 235]),
+              key: [
+                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+                "sync-state",
+                "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+              ],
+            },
+          ])
+        )
+        expect(actual).toStrictEqual(
+          expect.not.arrayContaining([
+            {
+              data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
+              key: [
+                "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
+                "sync-state",
+                "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+              ],
+            },
+          ])
+        )
+        teardown()
+      })
+    })
+
+    describe("save and remove", () => {
+      it("should be no data", async () => {
+        const { adapter, teardown } = await setup()
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "snapshot",
+            "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
+          ],
+          new Uint8Array([0, 1, 127, 99, 154, 235])
+        )
+        await adapter.remove([
           "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
           "snapshot",
-          "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
-        ],
-        new Uint8Array([1, 76, 160, 53, 57, 10, 230])
-      )
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "sync-state",
-          "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-        ],
-        new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
-      )
+          "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
+        ])
 
-      expect(
-        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-      ).toStrictEqual(
-        expect.arrayContaining([
+        expect(
+          await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        ).toStrictEqual([])
+        expect(
+          await adapter.load([
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "snapshot",
+            "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
+          ])
+        ).toStrictEqual(undefined)
+        teardown()
+      })
+    })
+
+    describe("save and save", () => {
+      it("should override the data", async () => {
+        const { adapter, teardown } = await setup()
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+          ],
+          new Uint8Array([0, 1, 127, 99, 154, 235])
+        )
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+          ],
+          new Uint8Array([1, 76, 160, 53, 57, 10, 230])
+        )
+
+        expect(
+          await adapter.loadRange([
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+          ])
+        ).toStrictEqual([
           {
-            data: new Uint8Array([0, 1, 127, 99, 154, 235]),
+            data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
             key: [
               "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
               "sync-state",
               "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
             ],
           },
+        ])
+        teardown()
+      })
+    })
+
+    describe("removeRange", () => {
+      it("should remove set of records", async () => {
+        const { adapter, teardown } = await setup()
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+          ],
+          new Uint8Array([0, 1, 127, 99, 154, 235])
+        )
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "snapshot",
+            "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
+          ],
+          new Uint8Array([1, 76, 160, 53, 57, 10, 230])
+        )
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+            "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+          ],
+          new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
+        )
+
+        await adapter.removeRange([
+          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+          "sync-state",
+        ])
+
+        expect(
+          await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+        ).toStrictEqual([
           {
             data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
             key: [
@@ -110,76 +327,35 @@ export function runStorageAdapterTests({ adapter }: Params) {
               "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
             ],
           },
-          {
-            data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
-            key: [
-              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-              "sync-state",
-              "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-            ],
-          },
         ])
-      )
+        teardown()
+      })
 
-      expect(
-        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC", "sync-state"])
-      ).toStrictEqual(
-        expect.arrayContaining([
-          {
-            data: new Uint8Array([0, 1, 127, 99, 154, 235]),
-            key: [
-              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-              "sync-state",
-              "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-            ],
-          },
-          {
-            data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
-            key: [
-              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-              "sync-state",
-              "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-            ],
-          },
-        ])
-      )
-    })
+      it("should not remove set of records that doesn't match", async () => {
+        const { adapter, teardown } = await setup()
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
+            "sync-state",
+            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
+          ],
+          new Uint8Array([0, 1, 127, 99, 154, 235])
+        )
+        await adapter.save(
+          [
+            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
+            "sync-state",
+            "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
+          ],
+          new Uint8Array([1, 76, 160, 53, 57, 10, 230])
+        )
 
-    it("does not includes values which shouldn't be there", async () => {
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "sync-state",
-          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-        ],
-        new Uint8Array([0, 1, 127, 99, 154, 235])
-      )
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
-          "sync-state",
-          "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-        ],
-        new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
-      )
+        await adapter.removeRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
 
-      const actual = await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-      expect(actual).toStrictEqual(
-        expect.arrayContaining([
+        const actual = await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiD"])
+        expect(actual).toStrictEqual([
           {
-            data: new Uint8Array([0, 1, 127, 99, 154, 235]),
-            key: [
-              "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-              "sync-state",
-              "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-            ],
-          },
-        ])
-      )
-      expect(actual).toStrictEqual(
-        expect.not.arrayContaining([
-          {
-            data: new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),
+            data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
             key: [
               "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
               "sync-state",
@@ -187,151 +363,15 @@ export function runStorageAdapterTests({ adapter }: Params) {
             ],
           },
         ])
-      )
-    })
-  })
-
-  describe("save and remove", () => {
-    it("should be no data", async () => {
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "snapshot",
-          "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
-        ],
-        new Uint8Array([0, 1, 127, 99, 154, 235])
-      )
-      await adapter.remove([
-        "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-        "snapshot",
-        "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
-      ])
-
-      expect(
-        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-      ).toStrictEqual([])
-      expect(
-        await adapter.load([
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "snapshot",
-          "090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056",
-        ])
-      ).toStrictEqual(undefined)
-    })
-  })
-
-  describe("save and save", () => {
-    it("should override the data", async () => {
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "sync-state",
-          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-        ],
-        new Uint8Array([0, 1, 127, 99, 154, 235])
-      )
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "sync-state",
-          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-        ],
-        new Uint8Array([1, 76, 160, 53, 57, 10, 230])
-      )
-
-      expect(
-        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC", "sync-state"])
-      ).toStrictEqual([
-        {
-          data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
-          key: [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "sync-state",
-            "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-          ],
-        },
-      ])
-    })
-  })
-
-  describe("removeRange", () => {
-    it("should remove set of records", async () => {
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "sync-state",
-          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-        ],
-        new Uint8Array([0, 1, 127, 99, 154, 235])
-      )
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "snapshot",
-          "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
-        ],
-        new Uint8Array([1, 76, 160, 53, 57, 10, 230])
-      )
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "sync-state",
-          "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-        ],
-        new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
-      )
-
-      await adapter.removeRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC", "sync-state"])
-
-      expect(
-        await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-      ).toStrictEqual([
-        {
-          data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
-          key: [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-            "snapshot",
-            "7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870",
-          ],
-        },
-      ])
-    })
-
-    it("should not remove set of records that doesn't match", async () => {
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiC",
-          "sync-state",
-          "d99d4820-fb1f-4f3a-a40f-d5997b2012cf",
-        ],
-        new Uint8Array([0, 1, 127, 99, 154, 235])
-      )
-      await adapter.save(
-        [
-          "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
-          "sync-state",
-          "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-        ],
-        new Uint8Array([1, 76, 160, 53, 57, 10, 230])
-      )
-
-      await adapter.removeRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
-
-      const actual = await adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiD"])
-      expect(actual).toStrictEqual([
-        {
-          data: new Uint8Array([1, 76, 160, 53, 57, 10, 230]),
-          key: [
-            "3xuJ5sVKdBaYS6uGgGJH1cGhBLiD",
-            "sync-state",
-            "0e05ed0c-41f5-4785-b27a-7cf334c1b741",
-          ],
-        },
-      ])
+        teardown()
+      })
     })
   })
 }
 
-type Params = {
+const NO_OP = () => {}
+
+export type SetupFn = () => Promise<{
   adapter: StorageAdapterInterface
-}
+  teardown?: () => void
+}>

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -72,7 +72,7 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
 
     describe("save and loadRange", () => {
       it("should return all the data that matches the key", async () => {
-        const { adapter } = await setup()
+        const { adapter, teardown } = await setup()
 
         await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A)
         await adapter.save(["AAAAA", "snapshot", "yyyyy"], PAYLOAD_B)
@@ -92,6 +92,8 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
             { key: ["AAAAA", "sync-state", "zzzzz"], data: PAYLOAD_C },
           ])
         )
+
+        teardown()
       })
 
       it("should only load values that match they key", async () => {

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -43,16 +43,16 @@ export function runStorageAdapterTests(sut: {adapter: StorageAdapterInterface}) 
       expect(
         await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
       ).toStrictEqual([
-        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
-        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"]},
-        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
+        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
+        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"]},
+        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
       ])
 
       expect(
         await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
       ).toStrictEqual([
-        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
-        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
+        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
+        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
       ])
     })
   })
@@ -79,7 +79,7 @@ export function runStorageAdapterTests(sut: {adapter: StorageAdapterInterface}) 
       expect(
         await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
       ).toStrictEqual([
-        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
+        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
       ])
     })
   })

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -14,14 +14,14 @@ export function runStorageAdapterTests(sut: {adapter: StorageAdapterInterface}) 
 
   describe('save and load', () => {
     it('should be possible to save and load', async () => {
-      await sut.adapter.save(["storage-adapter-id"], new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'));
-      const actual = await sut.adapter.load(["storage-adapter-id"]);
+      await sut.adapter.save(["storage-adapter-id"], new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'))
+      const actual = await sut.adapter.load(["storage-adapter-id"])
       expect(actual).toStrictEqual(new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'))
     })
 
     it('should work with composed keys', async () => {
       await sut.adapter.save(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
-      const actual = await sut.adapter.load(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"]);
+      const actual = await sut.adapter.load(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"])
       expect(actual).toStrictEqual(new Uint8Array([0, 1, 127, 99, 154, 235 ]))
     })
   })
@@ -36,9 +36,9 @@ export function runStorageAdapterTests(sut: {adapter: StorageAdapterInterface}) 
 
   describe('save and loadRange', () => {
     it('should return all the data that is present', async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]));
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]))
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]))
 
       expect(
         await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
@@ -59,8 +59,8 @@ export function runStorageAdapterTests(sut: {adapter: StorageAdapterInterface}) 
 
   describe('save and remove', () => {
     it('should be no data', async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
-      await sut.adapter.remove(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"]);
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
+      await sut.adapter.remove(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"])
 
       expect(
         await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
@@ -73,8 +73,8 @@ export function runStorageAdapterTests(sut: {adapter: StorageAdapterInterface}) 
 
   describe('save and save', () => {
     it('should override the data', async () => {
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
-      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]))
 
       expect(
         await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+
+import type { StorageAdapterInterface } from "../../storage/StorageAdapterInterface.js"
+
+export function runStorageAdapterTests(sut: {adapter: StorageAdapterInterface}) {
+
+  describe('load', () => {
+    it('should return undefined if there is no data', async () => {
+      expect(
+        await sut.adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"])
+      ).toStrictEqual(undefined)
+    })
+  })
+
+  describe('save and load', () => {
+    it('should be possible to save and load', async () => {
+      await sut.adapter.save(["storage-adapter-id"], new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'));
+      const actual = await sut.adapter.load(["storage-adapter-id"]);
+      expect(actual).toStrictEqual(new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'))
+    })
+
+    it('should work with composed keys', async () => {
+      await sut.adapter.save(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"], new Uint8Array([0, 1, 127, 99, 154, 235 ]))
+      const actual = await sut.adapter.load(["pSq9fP9ekr1zembLzBJkgHTo7Wn","sync-state","3761c9f0-bb1d-44b6-88ac-f85072fc3273"]);
+      expect(actual).toStrictEqual(new Uint8Array([0, 1, 127, 99, 154, 235 ]))
+    })
+  })
+
+  describe('loadRange', () => {
+    it('should return empty array if there is no data', async () => {
+      expect(
+        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+      ).toStrictEqual([])
+    })
+  })
+
+  describe('save and loadRange', () => {
+    it('should return all the data that is present', async () => {
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"], new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]));
+
+      expect(
+        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+      ).toStrictEqual([
+        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
+        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","7848c74d260d060ee02e12d69d43a21348fedf4f4a4783ac6aaaa2e338bca870"]},
+        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
+      ])
+
+      expect(
+        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
+      ).toStrictEqual([
+        {"data":new Uint8Array([0, 1, 127, 99, 154, 235 ]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
+        {"data":new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","0e05ed0c-41f5-4785-b27a-7cf334c1b741"]}
+      ])
+    })
+  })
+
+  describe('save and remove', () => {
+    it('should be no data', async () => {
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
+      await sut.adapter.remove(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"]);
+
+      expect(
+        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC"])
+      ).toStrictEqual([])
+      expect(
+        await sut.adapter.load(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","snapshot","090144be3cabe2848d4af81ebf6c3f0c93dfcf814fd34a43cdc93d8564fda056"])
+      ).toStrictEqual(undefined)
+    })
+  })
+
+  describe('save and save', () => {
+    it('should override the data', async () => {
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([0, 1, 127, 99, 154, 235 ]));
+      await sut.adapter.save(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"], new Uint8Array([1, 76, 160, 53, 57, 10, 230]));
+
+      expect(
+        await sut.adapter.loadRange(["3xuJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state"])
+      ).toStrictEqual([
+        {"data":new Uint8Array([1, 76, 160, 53, 57, 10, 230]),"key":["3x","uJ5sVKdBaYS6uGgGJH1cGhBLiC","sync-state","d99d4820-fb1f-4f3a-a40f-d5997b2012cf"]},
+      ])
+    })
+  })
+}

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest"
 
 import type { StorageAdapterInterface } from "../../storage/StorageAdapterInterface.js"
 
-const PAYLOAD_A = new Uint8Array([0, 1, 127, 99, 154, 235])
-const PAYLOAD_B = new Uint8Array([1, 76, 160, 53, 57, 10, 230])
-const PAYLOAD_C = new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
+const PAYLOAD_A = () => new Uint8Array([0, 1, 127, 99, 154, 235])
+const PAYLOAD_B = () => new Uint8Array([1, 76, 160, 53, 57, 10, 230])
+const PAYLOAD_C = () => new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
 
 const LARGE_PAYLOAD = new Uint8Array(100000).map(() => Math.random() * 256)
 
@@ -32,9 +32,9 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
       it("should return data that was saved", async () => {
         const { adapter, teardown } = await setup()
 
-        await adapter.save(["storage-adapter-id"], PAYLOAD_A)
+        await adapter.save(["storage-adapter-id"], PAYLOAD_A())
         const actual = await adapter.load(["storage-adapter-id"])
-        expect(actual).toStrictEqual(PAYLOAD_A)
+        expect(actual).toStrictEqual(PAYLOAD_A())
 
         teardown()
       })
@@ -42,9 +42,9 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
       it("should work with composite keys", async () => {
         const { adapter, teardown } = await setup()
 
-        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A)
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A())
         const actual = await adapter.load(["AAAAA", "sync-state", "xxxxx"])
-        expect(actual).toStrictEqual(PAYLOAD_A)
+        expect(actual).toStrictEqual(PAYLOAD_A())
 
         teardown()
       })
@@ -74,22 +74,22 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
       it("should return all the data that matches the key", async () => {
         const { adapter, teardown } = await setup()
 
-        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A)
-        await adapter.save(["AAAAA", "snapshot", "yyyyy"], PAYLOAD_B)
-        await adapter.save(["AAAAA", "sync-state", "zzzzz"], PAYLOAD_C)
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A())
+        await adapter.save(["AAAAA", "snapshot", "yyyyy"], PAYLOAD_B())
+        await adapter.save(["AAAAA", "sync-state", "zzzzz"], PAYLOAD_C())
 
         expect(await adapter.loadRange(["AAAAA"])).toStrictEqual(
           expect.arrayContaining([
-            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A },
-            { key: ["AAAAA", "snapshot", "yyyyy"], data: PAYLOAD_B },
-            { key: ["AAAAA", "sync-state", "zzzzz"], data: PAYLOAD_C },
+            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A() },
+            { key: ["AAAAA", "snapshot", "yyyyy"], data: PAYLOAD_B() },
+            { key: ["AAAAA", "sync-state", "zzzzz"], data: PAYLOAD_C() },
           ])
         )
 
         expect(await adapter.loadRange(["AAAAA", "sync-state"])).toStrictEqual(
           expect.arrayContaining([
-            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A },
-            { key: ["AAAAA", "sync-state", "zzzzz"], data: PAYLOAD_C },
+            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A() },
+            { key: ["AAAAA", "sync-state", "zzzzz"], data: PAYLOAD_C() },
           ])
         )
 
@@ -99,18 +99,18 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
       it("should only load values that match they key", async () => {
         const { adapter, teardown } = await setup()
 
-        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A)
-        await adapter.save(["BBBBB", "sync-state", "zzzzz"], PAYLOAD_C)
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A())
+        await adapter.save(["BBBBB", "sync-state", "zzzzz"], PAYLOAD_C())
 
         const actual = await adapter.loadRange(["AAAAA"])
         expect(actual).toStrictEqual(
           expect.arrayContaining([
-            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A },
+            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A() },
           ])
         )
         expect(actual).toStrictEqual(
           expect.not.arrayContaining([
-            { key: ["BBBBB", "sync-state", "zzzzz"], data: PAYLOAD_C },
+            { key: ["BBBBB", "sync-state", "zzzzz"], data: PAYLOAD_C() },
           ])
         )
 
@@ -122,7 +122,7 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
       it("after removing, should be empty", async () => {
         const { adapter, teardown } = await setup()
 
-        await adapter.save(["AAAAA", "snapshot", "xxxxx"], PAYLOAD_A)
+        await adapter.save(["AAAAA", "snapshot", "xxxxx"], PAYLOAD_A())
         await adapter.remove(["AAAAA", "snapshot", "xxxxx"])
 
         expect(await adapter.loadRange(["AAAAA"])).toStrictEqual([])
@@ -138,11 +138,11 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
       it("should overwrite data saved with the same key", async () => {
         const { adapter, teardown } = await setup()
 
-        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A)
-        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_B)
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A())
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_B())
 
         expect(await adapter.loadRange(["AAAAA", "sync-state"])).toStrictEqual([
-          { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_B },
+          { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_B() },
         ])
 
         teardown()
@@ -153,14 +153,14 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
       it("should remove a range of records", async () => {
         const { adapter, teardown } = await setup()
 
-        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A)
-        await adapter.save(["AAAAA", "snapshot", "yyyyy"], PAYLOAD_B)
-        await adapter.save(["AAAAA", "sync-state", "zzzzz"], PAYLOAD_C)
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A())
+        await adapter.save(["AAAAA", "snapshot", "yyyyy"], PAYLOAD_B())
+        await adapter.save(["AAAAA", "sync-state", "zzzzz"], PAYLOAD_C())
 
         await adapter.removeRange(["AAAAA", "sync-state"])
 
         expect(await adapter.loadRange(["AAAAA"])).toStrictEqual([
-          { key: ["AAAAA", "snapshot", "yyyyy"], data: PAYLOAD_B },
+          { key: ["AAAAA", "snapshot", "yyyyy"], data: PAYLOAD_B() },
         ])
 
         teardown()
@@ -169,14 +169,14 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
       it("should not remove records that don't match", async () => {
         const { adapter, teardown } = await setup()
 
-        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A)
-        await adapter.save(["BBBBB", "sync-state", "zzzzz"], PAYLOAD_B)
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A())
+        await adapter.save(["BBBBB", "sync-state", "zzzzz"], PAYLOAD_B())
 
         await adapter.removeRange(["AAAAA"])
 
         const actual = await adapter.loadRange(["BBBBB"])
         expect(actual).toStrictEqual([
-          { key: ["BBBBB", "sync-state", "zzzzz"], data: PAYLOAD_B },
+          { key: ["BBBBB", "sync-state", "zzzzz"], data: PAYLOAD_B() },
         ])
 
         teardown()

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -71,7 +71,7 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     })
 
     describe("save and loadRange", () => {
-      it("should return all the data that is present", async () => {
+      it("should return all the data that matches the key", async () => {
         const { adapter, teardown } = await setup()
 
         await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A)
@@ -94,7 +94,7 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
         )
       })
 
-      it("does not includes values which shouldn't be there", async () => {
+      it("should only load values that match they key", async () => {
         const { adapter, teardown } = await setup()
 
         await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A)
@@ -117,7 +117,7 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     })
 
     describe("save and remove", () => {
-      it("should be no data", async () => {
+      it("after removing, should be empty", async () => {
         const { adapter, teardown } = await setup()
 
         await adapter.save(["AAAAA", "snapshot", "xxxxx"], PAYLOAD_A)
@@ -164,7 +164,7 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
         teardown()
       })
 
-      it("should not remove records that doesn't match", async () => {
+      it("should not remove records that don't match", async () => {
         const { adapter, teardown } = await setup()
 
         await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A)

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -6,7 +6,7 @@ const PAYLOAD_A = new Uint8Array([0, 1, 127, 99, 154, 235])
 const PAYLOAD_B = new Uint8Array([1, 76, 160, 53, 57, 10, 230])
 const PAYLOAD_C = new Uint8Array([2, 111, 74, 131, 236, 96, 142, 193])
 
-const LARGE_PAYLOAD = new Uint8Array(100000).map((_, i) => Math.random() * 256)
+const LARGE_PAYLOAD = new Uint8Array(100000).map(() => Math.random() * 256)
 
 export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
   const setup = async () => {
@@ -72,7 +72,7 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
 
     describe("save and loadRange", () => {
       it("should return all the data that matches the key", async () => {
-        const { adapter, teardown } = await setup()
+        const { adapter } = await setup()
 
         await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_A)
         await adapter.save(["AAAAA", "snapshot", "yyyyy"], PAYLOAD_B)

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -22,9 +22,10 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     describe("load", () => {
       it("should return undefined if there is no data", async () => {
         const { adapter, teardown } = await setup()
-        expect(
-          await adapter.load(["3xuJ5", "sync-state", "d99d4"])
-        ).toStrictEqual(undefined)
+
+        const actual = await adapter.load(["AAAAA", "sync-state", "xxxxx"])
+        expect(actual).toBeUndefined()
+
         teardown()
       })
     })
@@ -32,19 +33,21 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     describe("save and load", () => {
       it("should return data that was saved", async () => {
         const { adapter, teardown } = await setup()
+
         await adapter.save(["storage-adapter-id"], PAYLOAD_A)
-
         const actual = await adapter.load(["storage-adapter-id"])
-
         expect(actual).toStrictEqual(PAYLOAD_A)
+
         teardown()
       })
 
       it("should work with composite keys", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(["pSq9f", "sync-state", "3761c"], PAYLOAD_B)
-        const actual = await adapter.load(["pSq9f", "sync-state", "3761c"])
+
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_B)
+        const actual = await adapter.load(["AAAAA", "sync-state", "xxxxx"])
         expect(actual).toStrictEqual(PAYLOAD_B)
+
         teardown()
       })
     })
@@ -52,7 +55,9 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     describe("loadRange", () => {
       it("should return an empty array if there is no data", async () => {
         const { adapter, teardown } = await setup()
-        expect(await adapter.loadRange(["3xuJ5"])).toStrictEqual([])
+
+        expect(await adapter.loadRange(["AAAAA"])).toStrictEqual([])
+
         teardown()
       })
     })
@@ -60,42 +65,45 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     describe("save and loadRange", () => {
       it("should return all the data that is present", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_B)
-        await adapter.save(["3xuJ5", "snapshot", "7848c"], PAYLOAD_C)
-        await adapter.save(["3xuJ5", "sync-state", "0e05e"], PAYLOAD_D)
 
-        expect(await adapter.loadRange(["3xuJ5"])).toStrictEqual(
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_B)
+        await adapter.save(["AAAAA", "snapshot", "yyyyy"], PAYLOAD_C)
+        await adapter.save(["AAAAA", "sync-state", "zzzzz"], PAYLOAD_D)
+
+        expect(await adapter.loadRange(["AAAAA"])).toStrictEqual(
           expect.arrayContaining([
-            { key: ["3xuJ5", "sync-state", "d99d4"], data: PAYLOAD_B },
-            { key: ["3xuJ5", "snapshot", "7848c"], data: PAYLOAD_C },
-            { key: ["3xuJ5", "sync-state", "0e05e"], data: PAYLOAD_D },
+            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_B },
+            { key: ["AAAAA", "snapshot", "yyyyy"], data: PAYLOAD_C },
+            { key: ["AAAAA", "sync-state", "zzzzz"], data: PAYLOAD_D },
           ])
         )
 
-        expect(await adapter.loadRange(["3xuJ5", "sync-state"])).toStrictEqual(
+        expect(await adapter.loadRange(["AAAAA", "sync-state"])).toStrictEqual(
           expect.arrayContaining([
-            { key: ["3xuJ5", "sync-state", "d99d4"], data: PAYLOAD_B },
-            { key: ["3xuJ5", "sync-state", "0e05e"], data: PAYLOAD_D },
+            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_B },
+            { key: ["AAAAA", "sync-state", "zzzzz"], data: PAYLOAD_D },
           ])
         )
       })
 
       it("does not includes values which shouldn't be there", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_B)
-        await adapter.save(["3xuJ6", "sync-state", "0e05e"], PAYLOAD_D)
 
-        const actual = await adapter.loadRange(["3xuJ5"])
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_B)
+        await adapter.save(["BBBBB", "sync-state", "zzzzz"], PAYLOAD_D)
+
+        const actual = await adapter.loadRange(["AAAAA"])
         expect(actual).toStrictEqual(
           expect.arrayContaining([
-            { key: ["3xuJ5", "sync-state", "d99d4"], data: PAYLOAD_B },
+            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_B },
           ])
         )
         expect(actual).toStrictEqual(
           expect.not.arrayContaining([
-            { key: ["3xuJ6", "sync-state", "0e05e"], data: PAYLOAD_D },
+            { key: ["BBBBB", "sync-state", "zzzzz"], data: PAYLOAD_D },
           ])
         )
+
         teardown()
       })
     })
@@ -103,13 +111,15 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     describe("save and remove", () => {
       it("should be no data", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(["3xuJ5", "snapshot", "09014"], PAYLOAD_B)
-        await adapter.remove(["3xuJ5", "snapshot", "09014"])
 
-        expect(await adapter.loadRange(["3xuJ5"])).toStrictEqual([])
+        await adapter.save(["AAAAA", "snapshot", "xxxxx"], PAYLOAD_B)
+        await adapter.remove(["AAAAA", "snapshot", "xxxxx"])
+
+        expect(await adapter.loadRange(["AAAAA"])).toStrictEqual([])
         expect(
-          await adapter.load(["3xuJ5", "snapshot", "09014"])
-        ).toStrictEqual(undefined)
+          await adapter.load(["AAAAA", "snapshot", "xxxxx"])
+        ).toBeUndefined()
+
         teardown()
       })
     })
@@ -117,42 +127,48 @@ export function runStorageAdapterTests(_setup: SetupFn, title?: string): void {
     describe("save and save", () => {
       it("should overwrite data saved with the same key", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_B)
-        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_C)
 
-        expect(await adapter.loadRange(["3xuJ5", "sync-state"])).toStrictEqual([
-          { key: ["3xuJ5", "sync-state", "d99d4"], data: PAYLOAD_C },
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_B)
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_C)
+
+        expect(await adapter.loadRange(["AAAAA", "sync-state"])).toStrictEqual([
+          { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_C },
         ])
+
         teardown()
       })
     })
 
     describe("removeRange", () => {
-      it("should remove set of records", async () => {
+      it("should remove a range of records", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_B)
-        await adapter.save(["3xuJ5", "snapshot", "7848c"], PAYLOAD_C)
-        await adapter.save(["3xuJ5", "sync-state", "0e05e"], PAYLOAD_D)
 
-        await adapter.removeRange(["3xuJ5", "sync-state"])
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_B)
+        await adapter.save(["AAAAA", "snapshot", "yyyyy"], PAYLOAD_C)
+        await adapter.save(["AAAAA", "sync-state", "zzzzz"], PAYLOAD_D)
 
-        expect(await adapter.loadRange(["3xuJ5"])).toStrictEqual([
-          { key: ["3xuJ5", "snapshot", "7848c"], data: PAYLOAD_C },
+        await adapter.removeRange(["AAAAA", "sync-state"])
+
+        expect(await adapter.loadRange(["AAAAA"])).toStrictEqual([
+          { key: ["AAAAA", "snapshot", "yyyyy"], data: PAYLOAD_C },
         ])
+
         teardown()
       })
 
-      it("should not remove set of records that doesn't match", async () => {
+      it("should not remove records that doesn't match", async () => {
         const { adapter, teardown } = await setup()
-        await adapter.save(["3xuJ5", "sync-state", "d99d4"], PAYLOAD_B)
-        await adapter.save(["3xuJ6", "sync-state", "0e05e"], PAYLOAD_C)
 
-        await adapter.removeRange(["3xuJ5"])
+        await adapter.save(["AAAAA", "sync-state", "xxxxx"], PAYLOAD_B)
+        await adapter.save(["BBBBB", "sync-state", "zzzzz"], PAYLOAD_C)
 
-        const actual = await adapter.loadRange(["3xuJ6"])
+        await adapter.removeRange(["AAAAA"])
+
+        const actual = await adapter.loadRange(["BBBBB"])
         expect(actual).toStrictEqual([
-          { key: ["3xuJ6", "sync-state", "0e05e"], data: PAYLOAD_C },
+          { key: ["BBBBB", "sync-state", "zzzzz"], data: PAYLOAD_C },
         ])
+
         teardown()
       })
     })

--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -13,10 +13,22 @@ export function runStorageAdapterTests(sut: {adapter: StorageAdapterInterface}) 
   })
 
   describe('save and load', () => {
-    it('should be possible to save and load', async () => {
-      await sut.adapter.save(["storage-adapter-id"], new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'))
+    it('should return data that was saved', async () => {
+      await sut.adapter.save(["storage-adapter-id"], new Uint8Array([
+        56, 97, 51,  53,  99, 57, 98,  52,  45,
+        49, 48, 57, 101,  45, 52, 97,  55, 102,
+        45, 97, 51,  53, 101, 45, 97,  53,  52,
+        54, 52, 49,  50,  49, 98, 54, 100, 100
+      ]))
+
       const actual = await sut.adapter.load(["storage-adapter-id"])
-      expect(actual).toStrictEqual(new TextEncoder().encode('8a35c9b4-109e-4a7f-a35e-a5464121b6dd'))
+
+      expect(actual).toStrictEqual(new Uint8Array([
+        56, 97, 51,  53,  99, 57, 98,  52,  45,
+        49, 48, 57, 101,  45, 52, 97,  55, 102,
+        45, 97, 51,  53, 101, 45, 97,  53,  52,
+        54, 52, 49,  50,  49, 98, 54, 100, 100
+      ]))
     })
 
     it('should work with composed keys', async () => {

--- a/packages/automerge-repo/test/DummyStorageAdapter.test.ts
+++ b/packages/automerge-repo/test/DummyStorageAdapter.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe } from "vitest"
 import { DummyStorageAdapter } from "./helpers/DummyStorageAdapter.js"
 import { runStorageAdapterTests } from "../src/helpers/tests/storage-adapter-tests.js"
 

--- a/packages/automerge-repo/test/DummyStorageAdapter.test.ts
+++ b/packages/automerge-repo/test/DummyStorageAdapter.test.ts
@@ -2,12 +2,10 @@ import { beforeEach, describe } from "vitest"
 import { DummyStorageAdapter } from "./helpers/DummyStorageAdapter.js"
 import { runStorageAdapterTests } from "../src/helpers/tests/storage-adapter-tests.js"
 
-describe('DummyStorageAdapter', () => {
-  let sut: {adapter: DummyStorageAdapter} = { adapter: new DummyStorageAdapter() }
-
-  beforeEach(async () => {
-    sut.adapter = new DummyStorageAdapter()
+describe("DummyStorageAdapter", () => {
+  const setup = async () => ({
+    adapter: new DummyStorageAdapter(),
   })
 
-  runStorageAdapterTests(sut);
+  runStorageAdapterTests(setup, "DummyStorageAdapter")
 })

--- a/packages/automerge-repo/test/DummyStorageAdapter.test.ts
+++ b/packages/automerge-repo/test/DummyStorageAdapter.test.ts
@@ -1,0 +1,13 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { DummyStorageAdapter } from "./helpers/DummyStorageAdapter.js"
+import { runStorageAdapterTests } from "../src/helpers/tests/storage-adapter-tests.js"
+
+describe('DummyStorageAdapter', () => {
+  let sut: {adapter: DummyStorageAdapter} = { adapter: new DummyStorageAdapter() }
+
+  beforeEach(async () => {
+    sut.adapter = new DummyStorageAdapter()
+  })
+
+  runStorageAdapterTests(sut);
+})


### PR DESCRIPTION
This test suite is based on the @acurrieclark [comment](https://github.com/automerge/automerge-repo/pull/304#issuecomment-1977446032):
> the only reason we know the existing adapters work is because we are using them in production!

To get production data, I launched the React to-do app from the example directory. I also launched the Node.js server and recorded calls to each public method of the `NodeFSStorageAdapter` instance. That recordings found its place in the test suite. I made buffers smaller for simplicity.

The reason why the storage adapter test suite function has such an interface and is used in this specific way is because I think it should be possible to execute suite hooks. For example, I think it's a good idea to clean up temp files after the execution of each test. The suit hooks are a good place for this, because they will be called even if a test fails. But it seems that for testing the NodeFSStoradgeAdapter, calling the suite hook is not necessary.

In addition to all above I have added comments to explain the decision behind and reasons for a change.