### PR TITLE
Un-deprecate the NetworkAdapter class

### DIFF
--- a/packages/automerge-repo/src/network/NetworkAdapter.ts
+++ b/packages/automerge-repo/src/network/NetworkAdapter.ts
@@ -7,12 +7,14 @@ import { Message } from "./messages.js"
 import { NetworkAdapterInterface } from "./NetworkAdapterInterface.js"
 
 /** An interface representing some way to connect to other peers
- * @deprecated use {@link NetworkAdapterInterface}
  *
  * @remarks
  * The {@link Repo} uses one or more `NetworkAdapter`s to connect to other peers.
  * Because the network may take some time to be ready the {@link Repo} will wait
  * until the adapter emits a `ready` event before it starts trying to use it
+ *
+ * This utility class can be used as a base to build a custom network adapter. It
+ * is most useful as a simple way to add the necessary event emitter functionality
  */
 export abstract class NetworkAdapter
   extends EventEmitter<NetworkAdapterEvents>

--- a/packages/automerge-repo/src/network/NetworkAdapterInterface.ts
+++ b/packages/automerge-repo/src/network/NetworkAdapterInterface.ts
@@ -22,8 +22,13 @@ export interface PeerMetadata {
  * The {@link Repo} uses one or more `NetworkAdapter`s to connect to other peers.
  * Because the network may take some time to be ready the {@link Repo} will wait
  * until the adapter emits a `ready` event before it starts trying to use it
+ *
+ * The {@link NetworkAdapter} is an abstract class that can be used as a base to build a
+ * custom network adapter. It is most useful as a simple way to add the necessary event
+ * emitter functionality
  */
-export interface NetworkAdapterInterface extends EventEmitter<NetworkAdapterEvents> {
+export interface NetworkAdapterInterface
+  extends EventEmitter<NetworkAdapterEvents> {
   peerId?: PeerId
   peerMetadata?: PeerMetadata
 


### PR DESCRIPTION
We had previously marked both the `StorageAdapter` and `NetworkAdapter` classes as deprecated. However, while the storage adapter offered no functionality, the Network adapter does offer a convenient way to include the `EventEmitter` functionality which a network adapter requires.

In the future we could likely augment the interface so that it only requires the `EventEmitter` methods we actually use (`emit` is the only one, I think), but for now the abstract class is actually useful to us and likely to others too.