### PR TITLE
examples: Don't useBootstrap

### DIFF
--- a/examples/react-counter/src/App.tsx
+++ b/examples/react-counter/src/App.tsx
@@ -1,5 +1,5 @@
+import { AutomergeUrl } from "@automerge/automerge-repo"
 import {
-  useBootstrap,
   useDocument,
 } from "@automerge/automerge-repo-react-hooks"
 
@@ -7,16 +7,7 @@ interface Doc {
   count: number
 }
 
-export function App() {
-  const { url } = useBootstrap({
-    onNoDocument: repo => {
-      const handle = repo.create<Doc>()
-      handle.change(d => {
-        d.count = 0
-      })
-      return handle
-    },
-  })
+export function App({ url }: { url: AutomergeUrl }) {
   const [doc, changeDoc] = useDocument<Doc>(url)
 
   if (!doc) {

--- a/examples/react-todo/src/App.tsx
+++ b/examples/react-todo/src/App.tsx
@@ -1,6 +1,5 @@
 import { AutomergeUrl } from "@automerge/automerge-repo"
 import {
-  useBootstrap,
   useDocument,
   useRepo,
 } from "@automerge/automerge-repo-react-hooks"
@@ -10,14 +9,7 @@ import { useRef, useState } from "react"
 import { Todo } from "./Todo.js"
 import { ExtendedArray, Filter, State, TodoData } from "./types.js"
 
-export function App() {
-  const { url } = useBootstrap({
-    onNoDocument: repo => {
-      const handle = repo.create<State>()
-      handle.change(d => (d.todos = []))
-      return handle
-    },
-  })
+export function App({url}: {url: AutomergeUrl}) {
   const [state, changeState] = useDocument<State>(url)
 
   const newTodoInput = useRef<HTMLInputElement>(null)

--- a/examples/react-todo/src/main.tsx
+++ b/examples/react-todo/src/main.tsx
@@ -1,4 +1,4 @@
-import { Repo } from "@automerge/automerge-repo"
+import { DocHandle, Repo, isValidAutomergeUrl } from "@automerge/automerge-repo"
 import { BroadcastChannelNetworkAdapter } from "@automerge/automerge-repo-network-broadcastchannel"
 import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket"
 import { RepoContext } from "@automerge/automerge-repo-react-hooks"
@@ -6,6 +6,7 @@ import { IndexedDBStorageAdapter } from "@automerge/automerge-repo-storage-index
 import React from "react"
 import ReactDOM from "react-dom/client"
 import { App } from "./App.js"
+import { State } from "./types.js"
 import "./index.css"
 
 const repo = new Repo({
@@ -16,10 +17,28 @@ const repo = new Repo({
   storage: new IndexedDBStorageAdapter("automerge-repo-demo-todo"),
 })
 
+declare global {
+  interface Window {
+    handle: DocHandle<unknown>
+    repo: Repo
+  }
+}
+
+const rootDocUrl = `${document.location.hash.substring(1)}`
+let handle
+if (isValidAutomergeUrl(rootDocUrl)) {
+  handle = repo.find(rootDocUrl)
+} else {
+  handle = repo.create<State>({ todos: [] })
+}
+const docUrl = (document.location.hash = handle.url)
+window.handle = handle // we'll use this later for experimentation
+window.repo = repo
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <RepoContext.Provider value={repo}>
     <React.StrictMode>
-      <App />
+      <App url={docUrl}/>
     </React.StrictMode>
   </RepoContext.Provider>
 )

--- a/examples/react-use-awareness/src/App.jsx
+++ b/examples/react-use-awareness/src/App.jsx
@@ -2,12 +2,10 @@ import {
   useDocument,
   useLocalAwareness,
   useRemoteAwareness,
-  useBootstrap,
 } from "@automerge/automerge-repo-react-hooks";
 
-export function App({ userId }) {
-  const handle = useBootstrap();
-  const [doc, changeDoc] = useDocument(handle.url);
+export function App({ userId, url }) {
+  const [doc, changeDoc] = useDocument(url);
 
   const [localState, updateLocalState] = useLocalAwareness({
     handle,

--- a/examples/react-use-awareness/src/main.jsx
+++ b/examples/react-use-awareness/src/main.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
-import { Repo } from "@automerge/automerge-repo";
+import { Repo, isValidAutomergeUrl } from "@automerge/automerge-repo";
 import { BroadcastChannelNetworkAdapter } from "@automerge/automerge-repo-network-broadcastchannel";
 import { RepoContext } from "@automerge/automerge-repo-react-hooks";
 import { v4 } from 'uuid'
@@ -16,10 +16,21 @@ const repo = new Repo({
 
 const userId = v4();
 
+const rootDocUrl = `${document.location.hash.substring(1)}`
+let handle
+if (isValidAutomergeUrl(rootDocUrl)) {
+  handle = repo.find(rootDocUrl)
+} else {
+  handle = repo.create()
+}
+const docUrl = (document.location.hash = handle.url)
+window.handle = handle // we'll use this later for experimentation
+window.repo = repo
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <RepoContext.Provider value={repo}>
     <React.StrictMode>
-      <App userId={userId} />
+      <App userId={userId} url={docUrl} />
     </React.StrictMode>
   </RepoContext.Provider>
 );


### PR DESCRIPTION
The `useBootstrap` hook is quite opinionated and a little bit magic, which makes it confusing in an example project where the goal is to understand what is going on. Switch to explicitly getting the doc URL from the url fragment or initializing it otherwise.