### PR TITLE
feat: Add `Repo.flush` method

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -505,6 +505,31 @@ export class Repo extends EventEmitter<RepoEvents> {
       return this.storageSubsystem.id()
     }
   }
+
+  /**
+   * Waits for Repo to finish write changes to disk.
+   * @deprecated
+   * @param documents - if provided, only waits for the specified documents
+   * @param timeout - if provided, the maximum time to wait in milliseconds
+   * @returns Promise<void>
+   */
+  async flush(documents?: DocumentId[], timeout?: number): Promise<void> {
+    if (!this.storageSubsystem) {
+      throw new Error("flush called without storage subsystem")
+    }
+    const handles = documents
+      ? documents.map(id => this.#handleCache[id])
+      : Object.values(this.#handleCache)
+    return Promise.all(
+      handles.map(async handle => {
+        const doc = handle.docSync()
+        if (!doc) {
+          return
+        }
+        return this.storageSubsystem!.flush(handle.documentId, doc, timeout)
+      })
+    ).then(() => {})
+  }
 }
 
 export interface RepoConfig {

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -528,7 +528,9 @@ export class Repo extends EventEmitter<RepoEvents> {
         }
         return this.storageSubsystem!.flush(handle.documentId, doc, timeout)
       })
-    ).then(() => { /* No-op. To return `voi`d and not `void[]` */ })
+    ).then(() => {
+      /* No-op. To return `voi`d and not `void[]` */
+    })
   }
 }
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -508,14 +508,14 @@ export class Repo extends EventEmitter<RepoEvents> {
 
   /**
    * Waits for Repo to finish write changes to disk.
-   * @deprecated
+   * @deprecated because it will be changed soon.
    * @param documents - if provided, only waits for the specified documents
    * @param timeout - if provided, the maximum time to wait in milliseconds
    * @returns Promise<void>
    */
   async flush(documents?: DocumentId[], timeout?: number): Promise<void> {
     if (!this.storageSubsystem) {
-      throw new Error("flush called without storage subsystem")
+      return Promise.resolve()
     }
     const handles = documents
       ? documents.map(id => this.#handleCache[id])
@@ -528,7 +528,7 @@ export class Repo extends EventEmitter<RepoEvents> {
         }
         return this.storageSubsystem!.flush(handle.documentId, doc, timeout)
       })
-    ).then(() => {})
+    ).then(() => { /* No-op. To return `voi`d and not `void[]` */ })
   }
 }
 

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -251,7 +251,7 @@ export class StorageSubsystem {
 
   /**
    * Waiting for document state to be written to disk.
-   * @deprecated
+   * @deprecated because it will be changed soon.
    */
   async flush(documentId: DocumentId, doc: A.Doc<unknown>, timeout?: number) {
     return new Promise<void>((resolve, reject) => {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -489,16 +489,17 @@ describe("Repo", () => {
           network: [],
         })
 
+        // Could not find the document that is not yet saved because of slow storage.
         const reloadedHandle = repo.find<{ foo: string }>(handle.url)
         expect(await reloadedHandle.doc()).toEqual(undefined)
       }
 
-      // check that the data is not yet saved
+      // Check that the data is not yet saved.
       expect(slowStorage.keys()).to.deep.equal([])
 
       await repo.flush()
 
-      // check that the data is now saved
+      // Check that the data is now saved.
       expect(slowStorage.keys().length).toBeGreaterThan(0)
 
       {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -481,7 +481,6 @@ describe("Repo", () => {
 
       expect((await handle.doc()).foo).toEqual("bar")
 
-
       {
         // Reload repo
         const repo = new Repo({


### PR DESCRIPTION
## Motivation 
Currently, there is no way to know if auto merge `Repo` finished writing all updates to disk. In our use-case, we want to know when it is safe to shut down the process (e.g. CLI) to preserve all data on disk.

related https://github.com/automerge/automerge-repo/issues/264
related [discord discussion](https://discord.com/channels/1200006940210757672/1214251439438827520)