### PR TITLE
fix test: "throws an error if we try to import an invalid document"

### DIFF
--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -451,11 +451,29 @@ describe("Repo", () => {
       expect(A.getHistory(v)).toEqual(A.getHistory(updatedDoc))
     })
 
-    it("throws an error if we try to import an invalid document", async () => {
+    it("throws an error if we try to import a nonsensical byte array", async () => {
       const { repo } = setup()
       expect(() => {
         repo.import<TestDoc>(new Uint8Array([1, 2, 3]))
       }).toThrow()
+    })
+
+    // TODO: not sure if this is the desired behavior from `import`.
+
+    it("makes an empty document if we try to import an automerge doc", async () => {
+      const { repo } = setup()
+      const handle = repo.import<TestDoc>(
+        A.from({ foo: 123 }) as unknown as Uint8Array
+      )
+      const doc = await handle.doc()
+      expect(doc).toEqual({})
+    })
+
+    it("makes an empty document if we try to import a plain object", async () => {
+      const { repo } = setup()
+      const handle = repo.import<TestDoc>({ foo: 123 } as unknown as Uint8Array)
+      const doc = await handle.doc()
+      expect(doc).toEqual({})
     })
   })
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -462,16 +462,16 @@ describe("Repo", () => {
 
     it("makes an empty document if we try to import an automerge doc", async () => {
       const { repo } = setup()
-      const handle = repo.import<TestDoc>(
-        A.from({ foo: 123 }) as unknown as Uint8Array
-      )
+      // @ts-ignore - passing something other than UInt8Array
+      const handle = repo.import<TestDoc>(A.from({ foo: 123 }))
       const doc = await handle.doc()
       expect(doc).toEqual({})
     })
 
     it("makes an empty document if we try to import a plain object", async () => {
       const { repo } = setup()
-      const handle = repo.import<TestDoc>({ foo: 123 } as unknown as Uint8Array)
+      // @ts-ignore - passing something other than UInt8Array
+      const handle = repo.import<TestDoc>({ foo: 123 })
       const doc = await handle.doc()
       expect(doc).toEqual({})
     })

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -454,7 +454,7 @@ describe("Repo", () => {
     it("throws an error if we try to import an invalid document", async () => {
       const { repo } = setup()
       expect(() => {
-        repo.import<TestDoc>(A.init<TestDoc> as unknown as Uint8Array)
+        repo.import<TestDoc>(new Uint8Array([1, 2, 3]))
       }).toThrow()
     })
   })


### PR DESCRIPTION
The VS Code test runner was choking on this test - not sure why, because it's syntactically valid, but upon inspection it did seem like it wasn't intended to be written the way it was. I've fixed it in a way that makes sense to me and the test runner is happy. 

before: 

```ts
expect(() => {
  repo.import<TestDoc>(A.init<TestDoc> as unknown as Uint8Array)
}).toThrow()
````

after: 

```ts
expect(() => {
  repo.import<TestDoc>(new Uint8Array([1, 2, 3]))
}).toThrow()
```

