### PR TITLE
Make VSCode test runner happy with loop in storage subsystem tests

### DIFF
--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -20,7 +20,7 @@ describe("StorageSubsystem", () => {
     nodeFSStorageAdapter: new NodeFSStorageAdapter(tempDir),
   }
 
-  Object.entries(adaptersToTest).forEach(([adapterName, adapter]) => {
+  for (const [adapterName, adapter] of Object.entries(adaptersToTest)) {
     describe(adapterName, () => {
       describe("Automerge document storage", () => {
         it("stores and retrieves an Automerge document", async () => {
@@ -227,5 +227,5 @@ describe("StorageSubsystem", () => {
         })
       })
     })
-  })
+  }
 })


### PR DESCRIPTION
For whatever reason, the VSCode test runner doesn't see tests inside a `forEach` loop:

```ts
Object.entries(adaptersToTest).forEach(([adapterName, adapter]) => {
    describe("Automerge document storage", () => {
      it("stores and retrieves an Automerge document", async () => {
         // ...
```

but it does if they're in a `for ... of` loop:

```ts
for (const [adapterName, adapter] of Object.entries(adaptersToTest)) {
    describe("Automerge document storage", () => {
      it("stores and retrieves an Automerge document", async () => {
         // ...
```