### PR TITLE
A simple heads API & optional Repo network config

### DIFF
--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -422,7 +422,7 @@ describe("Websocket adapters", () => {
         documentId: DocumentId
       }> {
         const storage = new DummyStorageAdapter()
-        const silentRepo = new Repo({ storage, network: [] })
+        const silentRepo = new Repo({ storage })
         const doc = A.from<T>(contents)
         const handle = silentRepo.create()
         handle.update(() => A.clone(doc))

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -587,7 +587,7 @@ describe("Websocket adapters", () => {
       }
 
       let localHeads = A.getHeads(clientDoc)
-      let remoteHeads = A.getHeads(handle.docSync())
+      let remoteHeads = handle.heads()
       if (!headsAreSame(localHeads, remoteHeads)) {
         throw new Error("heads not equal")
       }

--- a/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
@@ -1,5 +1,4 @@
 import { AutomergeUrl, PeerId, Repo } from "@automerge/automerge-repo"
-import { DummyStorageAdapter } from "@automerge/automerge-repo/test/helpers/DummyStorageAdapter"
 import { render, waitFor } from "@testing-library/react"
 import React from "react"
 import { act } from "react-dom/test-utils"
@@ -13,8 +12,6 @@ describe("useDocument", () => {
   function setup() {
     const repo = new Repo({
       peerId: "bob" as PeerId,
-      network: [],
-      storage: new DummyStorageAdapter(),
     })
 
     const handleA = repo.create<ExampleDoc>()

--- a/packages/automerge-repo-react-hooks/test/useHandle.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useHandle.test.tsx
@@ -24,8 +24,6 @@ function getRepoWrapper(repo: Repo) {
 describe("useHandle", () => {
   const repo = new Repo({
     peerId: "bob" as PeerId,
-    network: [],
-    storage: new DummyStorageAdapter(),
   })
 
   function setup() {

--- a/packages/automerge-repo-react-hooks/test/useRepo.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useRepo.test.tsx
@@ -12,7 +12,7 @@ describe("useRepo", () => {
   }
 
   test("should error when context unavailable", () => {
-    const repo = new Repo({ network: [] })
+    const repo = new Repo()
     // Prevent console spam by swallowing console.error "uncaught error" message
     const spy = vi.spyOn(console, "error")
     spy.mockImplementation(() => {})
@@ -23,7 +23,7 @@ describe("useRepo", () => {
   })
 
   test("should return repo from context", () => {
-    const repo = new Repo({ network: [] })
+    const repo = new Repo()
     const wrapper = ({ children }) => (
       <RepoContext.Provider value={repo} children={children} />
     )

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -328,6 +328,19 @@ export class DocHandle<T> //
     return this.#doc
   }
 
+  /**
+   * Returns the current "heads" of the document, akin to a git commit.
+   * This precisely defines the state of a document. In the event of multiple heads,
+   * there are unmerged concurrent changes to the document.
+   * @returns the current document's heads, or undefined if the document is not ready
+   */
+  heads(): A.Heads | undefined {
+    if (!this.isReady()) {
+      return undefined
+    }
+    return A.getHeads(this.#doc)
+  }
+
   /** `update` is called by the repo when we receive changes from the network
    * @hidden
    * */

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -60,12 +60,12 @@ export class Repo extends EventEmitter<RepoEvents> {
 
   constructor({
     storage,
-    network,
+    network = [],
     peerId,
     sharePolicy,
     isEphemeral = storage === undefined,
     enableRemoteHeadsGossiping = false,
-  }: RepoConfig) {
+  }: RepoConfig = {}) {
     super()
     this.#remoteHeadsGossipingEnabled = enableRemoteHeadsGossiping
     this.#log = debug(`automerge-repo:repo`)
@@ -545,8 +545,8 @@ export interface RepoConfig {
   /** A storage adapter can be provided, or not */
   storage?: StorageAdapterInterface
 
-  /** One or more network adapters must be provided */
-  network: NetworkAdapterInterface[]
+  /** A list of network adapters (more can be added at runtime). */
+  network?: NetworkAdapterInterface[]
 
   /**
    * Normal peers typically share generously with everyone (meaning we sync all our documents with

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -8,9 +8,7 @@ describe("CollectionSynchronizer", () => {
   let synchronizer: CollectionSynchronizer
 
   beforeEach(() => {
-    repo = new Repo({
-      network: [],
-    })
+    repo = new Repo()
     synchronizer = new CollectionSynchronizer(repo)
   })
 

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -72,6 +72,24 @@ describe("DocHandle", () => {
     assert.equal(doc?.foo, "bar")
   })
 
+  it("should return the heads when requested", async () => {
+    const handle = new DocHandle<TestDoc>(TEST_ID, {
+      isNew: true,
+      initialValue: { foo: "bar" },
+    })
+    assert.equal(handle.isReady(), true)
+
+    const heads = A.getHeads(handle.docSync())
+    assert.notDeepEqual(handle.heads(), [])
+    assert.deepEqual(heads, handle.heads())
+  })
+
+  it("should return undefined if the heads aren't loaded", async () => {
+    const handle = new DocHandle<TestDoc>(TEST_ID)
+    assert.equal(handle.isReady(), false)
+    assert.deepEqual(handle.heads(), undefined)
+  })
+
   /**
    * Once there's a Repo#stop API this case should be covered in accompanying
    * tests and the following test removed.
@@ -319,7 +337,7 @@ describe("DocHandle", () => {
       doc.foo = "bar"
     })
 
-    const headsBefore = A.getHeads(handle.docSync()!)
+    const headsBefore = handle.heads()!
 
     handle.change(doc => {
       doc.foo = "rab"

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -68,10 +68,7 @@ describe("DocSynchronizer", () => {
 
     assert.equal(message2.peerId, "alice")
     assert.equal(message2.documentId, handle.documentId)
-    assert.deepEqual(
-      message2.syncState.lastSentHeads,
-      A.getHeads(handle.docSync())
-    )
+    assert.deepEqual(message2.syncState.lastSentHeads, handle.heads())
   })
 
   it("still syncs with a peer after it disconnects and reconnects", async () => {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -33,10 +33,8 @@ import { StorageId } from "../src/storage/types.js"
 
 describe("Repo", () => {
   describe("constructor", () => {
-    it("can be instantiated without network adapters", () => {
-      const repo = new Repo({
-        network: [],
-      })
+    it("can be instantiated without any configuration", () => {
+      const repo = new Repo()
       expect(repo).toBeInstanceOf(Repo)
     })
   })
@@ -126,8 +124,7 @@ describe("Repo", () => {
       })
       const v = await handle.doc()
       assert.equal(handle.isReady(), true)
-
-      assert.equal(v?.foo, "bar")
+      assert.equal(v.foo, "bar")
     })
 
     it("can clone a document", () => {
@@ -255,7 +252,6 @@ describe("Repo", () => {
 
       const repo2 = new Repo({
         storage: storageAdapter,
-        network: [],
       })
 
       const bobHandle = repo2.find<TestDoc>(handle.url)
@@ -277,7 +273,6 @@ describe("Repo", () => {
 
       const repo2 = new Repo({
         storage: storageAdapter,
-        network: [],
       })
 
       const bobHandle = repo2.find<TestDoc>(handle.url)
@@ -364,7 +359,6 @@ describe("Repo", () => {
 
       const repo = new Repo({
         storage,
-        network: [],
       })
 
       const handle = repo.create<{ count: number }>()
@@ -382,7 +376,6 @@ describe("Repo", () => {
 
       const repo2 = new Repo({
         storage,
-        network: [],
       })
       const handle2 = repo2.find(handle.url)
       await handle2.doc()
@@ -395,7 +388,6 @@ describe("Repo", () => {
 
       const repo = new Repo({
         storage,
-        network: [],
       })
 
       const handle = repo.create<{ count: number }>()
@@ -410,7 +402,6 @@ describe("Repo", () => {
       for (let i = 0; i < 3; i++) {
         const repo2 = new Repo({
           storage,
-          network: [],
         })
         const handle2 = repo2.find(handle.url)
         await handle2.doc()
@@ -482,7 +473,6 @@ describe("Repo", () => {
 
       const repo = new Repo({
         storage: pausedStorage,
-        network: [],
       })
 
       // Create a pair of handles
@@ -499,7 +489,6 @@ describe("Repo", () => {
       // Reload repo
       const repo2 = new Repo({
         storage: pausedStorage,
-        network: [],
       })
 
       // Could not find the document that is not yet saved because of slow storage.
@@ -522,7 +511,6 @@ describe("Repo", () => {
         // Reload repo
         const repo = new Repo({
           storage: pausedStorage,
-          network: [],
         })
 
         expect(
@@ -548,7 +536,6 @@ describe("Repo", () => {
         // Reload repo
         const repo = new Repo({
           storage: pausedStorage,
-          network: [],
         })
 
         expect(
@@ -910,7 +897,6 @@ describe("Repo", () => {
       // we have a storage containing the document to pass to a new repo later
       const storage = new DummyStorageAdapter()
       const isolatedRepo = new Repo({
-        network: [],
         storage,
       })
       const unsyncedHandle = isolatedRepo.create<TestDoc>()
@@ -1115,7 +1101,6 @@ describe("Repo", () => {
       // setup new repo which uses bob's storage
       const bob2Repo = new Repo({
         storage: bobStorage,
-        network: [],
         peerId: "bob-2" as PeerId,
       })
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1062,8 +1062,7 @@ describe("Repo", () => {
         bobHandle.documentId,
         await charlieRepo!.storageSubsystem.id()
       )
-      const docHeads = A.getHeads(bobHandle.docSync())
-      assert.deepStrictEqual(storedSyncState.sharedHeads, docHeads)
+      assert.deepStrictEqual(storedSyncState.sharedHeads, bobHandle.heads())
 
       teardown()
     })
@@ -1180,18 +1179,15 @@ describe("Repo", () => {
       // pause to let the sync happen
       await pause(100)
 
-      const charlieHeads = A.getHeads(charlieHandle.docSync())
-      const bobHeads = A.getHeads(handle.docSync())
-
-      assert.deepStrictEqual(charlieHeads, bobHeads)
+      assert.deepStrictEqual(charlieHandle.heads(), handle.heads())
 
       const nextRemoteHeads = await nextRemoteHeadsPromise
       assert.deepStrictEqual(nextRemoteHeads.storageId, charliedStorageId)
-      assert.deepStrictEqual(nextRemoteHeads.heads, charlieHeads)
+      assert.deepStrictEqual(nextRemoteHeads.heads, charlieHandle.heads())
 
       assert.deepStrictEqual(
         handle.getRemoteHeads(charliedStorageId),
-        A.getHeads(charlieHandle.docSync())
+        charlieHandle.heads()
       )
 
       teardown()

--- a/packages/automerge-repo/test/remoteHeads.test.ts
+++ b/packages/automerge-repo/test/remoteHeads.test.ts
@@ -152,7 +152,7 @@ describe("DocHandle.remoteHeads", () => {
       // wait for alice's service worker to acknowledge the change
       const { heads } = await aliceSeenByBobPromise
 
-      assert.deepStrictEqual(heads, A.getHeads(aliceServiceWorkerDoc.docSync()))
+      assert.deepStrictEqual(heads, aliceServiceWorkerDoc.heads())
     })
 
     it("should report remoteHeads only for documents the subscriber has open", async () => {


### PR DESCRIPTION
Was working on some related stuff and noticed we didn't have an API for .heads() so I added it. Didn't add a promise form... didn't feel necessary in the moment but I could do so if anyone thinks it makes sense. Tests included.

I also fixed a small annoyance en passant which I noticed while I was in there (separate patch but same PR). You can now instantiate a Repo with no config at all! No more passing in `network: []` to prevent complaints in tests.

I wanted to do a bit more about the syncState API (which is why I was in here in the first place) but I think there's a bit more of a conversation / design task to be done first so I'm going to file an issue about it and discuss there.