### PR TITLE
Re-export commonly used Automerge core types through Automerge Repo

### DIFF
--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -107,11 +107,29 @@ export type {
   Mark,
   MarkSet,
   MarkRange,
-  MarkValue
+  MarkValue,
 } from "@automerge/automerge/next"
 
 // export a few utility functions that aren't in automerge-repo
-export { getChanges, getAllChanges, applyChanges, view, getConflicts } from "@automerge/automerge/next"
+// NB that these should probably all just be available via the dochandle
+export {
+  getChanges,
+  getAllChanges,
+  applyChanges,
+  view,
+  getConflicts,
+} from "@automerge/automerge/next"
 
 // export type-specific utility functions
-export { getCursor, getCursorPosition, splice, updateText, insertAt, deleteAt } from "@automerge/automerge/next"
+// these mostly can't be on the data-type in question because
+// JS strings can't have methods added to them
+export {
+  getCursor,
+  getCursorPosition,
+  splice,
+  updateText,
+  insertAt,
+  deleteAt,
+  mark,
+  unmark,
+} from "@automerge/automerge/next"

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -90,3 +90,11 @@ export type {
 } from "./storage/types.js"
 
 export * from "./types.js"
+
+// Reexport lower-level Automerge namespace under a different name to avoid requiring an additional import.
+// Use the `next` export since that's what we use internally.
+export {next as AutomergeCore} from "@automerge/automerge"
+export type { Counter, RawString, Cursor } from "@automerge/automerge/next" 
+export type { Doc, Heads, Patch, Prop, ActorId, Change, ChangeFn } from "@automerge/automerge/next" 
+
+export { getChanges, getAllChanges, applyChanges, getCursor, getCursorPosition, view } from "@automerge/automerge/next"

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -91,18 +91,27 @@ export type {
 
 export * from "./types.js"
 
-// Reexport lower-level Automerge namespace under a different name to avoid requiring an additional import.
-// Use the `next` export since that's what we use internally.
-export {next as AutomergeCore} from "@automerge/automerge"
-
 // export commonly used data types
-export type { Counter, RawString, Cursor } from "@automerge/automerge/next" 
+export type { Counter, RawString, Cursor } from "@automerge/automerge/next"
 
 // export some automerge API types
-export type { Doc, Heads, Patch, Prop, ActorId, Change, ChangeFn } from "@automerge/automerge" 
+export type {
+  Doc,
+  Heads,
+  Patch,
+  PatchCallback,
+  Prop,
+  ActorId,
+  Change,
+  ChangeFn,
+  Mark,
+  MarkSet,
+  MarkRange,
+  MarkValue
+} from "@automerge/automerge/next"
 
 // export a few utility functions that aren't in automerge-repo
-export { getChanges, getAllChanges, applyChanges, view } from "@automerge/automerge"
+export { getChanges, getAllChanges, applyChanges, view, getConflicts } from "@automerge/automerge/next"
 
-import { next } from "@automerge/automerge"
-export const { getCursor, getCursorPosition, splice, updateText } = next
+// export type-specific utility functions
+export { getCursor, getCursorPosition, splice, updateText, insertAt, deleteAt } from "@automerge/automerge/next"

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -94,7 +94,15 @@ export * from "./types.js"
 // Reexport lower-level Automerge namespace under a different name to avoid requiring an additional import.
 // Use the `next` export since that's what we use internally.
 export {next as AutomergeCore} from "@automerge/automerge"
-export type { Counter, RawString, Cursor } from "@automerge/automerge/next" 
-export type { Doc, Heads, Patch, Prop, ActorId, Change, ChangeFn } from "@automerge/automerge/next" 
 
-export { getChanges, getAllChanges, applyChanges, getCursor, getCursorPosition, view } from "@automerge/automerge/next"
+// export commonly used data types
+export type { Counter, RawString, Cursor } from "@automerge/automerge/next" 
+
+// export some automerge API types
+export type { Doc, Heads, Patch, Prop, ActorId, Change, ChangeFn } from "@automerge/automerge" 
+
+// export a few utility functions that aren't in automerge-repo
+export { getChanges, getAllChanges, applyChanges, view } from "@automerge/automerge"
+
+import { next } from "@automerge/automerge"
+export const { getCursor, getCursorPosition, splice, updateText } = next


### PR DESCRIPTION
In order to avoid problems created by importing mismatched versions of automerge's core CRDT library (and just the annoyance of having an extra import statement), in this PR I'm re-exporting "commonly used" Automerge types and functions.

Arguably some of these should just be better baked into DocHandle or something but I didn't want to let perfect be the enemy of good here and this is definitely an improvement.

Rarely used or more "internal" types and functions are also reexported via the AutomergeCore export which simply forwards on everything in `next` for now.

Questions for reviewers: did I miss any functions or types you commonly use? (We can always add more later.) Is there a better way to re-export this stuff? Do you hate `AutomergeCore` as the re-exported name? (I am leaning towards rebranding the existing automerge-js library to "core" as repo matures and making it the main "Automerge" export in a future release to hopefully reduce some confusion for new users.)