### PR TITLE
Fix: Fix race condition in `Repo.flush` method

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -507,10 +507,9 @@ export class Repo extends EventEmitter<RepoEvents> {
   }
 
   /**
-   * Waits for Repo to finish write changes to disk.
-   * @hidden this API is experimental and may change
-   * @param documents - if provided, only waits for the specified documents
-   * @param timeout - if provided, the maximum time to wait in milliseconds (rejects on timeout)
+   * Writes Documents to a disk.
+   * @hidden this API is experimental and may change.
+   * @param documents - if provided, only writes the specified documents.
    * @returns Promise<void>
    */
   async flush(documents?: DocumentId[]): Promise<void> {

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -84,7 +84,7 @@ export class Repo extends EventEmitter<RepoEvents> {
         }: DocHandleEncodedChangePayload<any>) => {
           void storageSubsystem.saveDoc(handle.documentId, doc)
         }
-        handle.on("heads-changed", saveFn)
+        handle.on("heads-changed", throttle(saveFn, this.saveDebounceRate))
 
         if (isNew) {
           // this is a new document, immediately save it

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -515,7 +515,7 @@ export class Repo extends EventEmitter<RepoEvents> {
    */
   async flush(documents?: DocumentId[]): Promise<void> {
     if (!this.storageSubsystem) {
-      return Promise.resolve()
+      return
     }
     const handles = documents
       ? documents.map(id => this.#handleCache[id])

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -1,5 +1,4 @@
 import { next as Automerge } from "@automerge/automerge"
-import { Mutex } from "@dxos/async"
 import debug from "debug"
 import { EventEmitter } from "eventemitter3"
 import {
@@ -33,7 +32,6 @@ import type { AnyDocumentId, DocumentId, PeerId } from "./types.js"
  * obtain {@link DocHandle}s.
  */
 export class Repo extends EventEmitter<RepoEvents> {
-  #mutex = new Mutex()
   #log: debug.Debugger
 
   /** @hidden */

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -8,7 +8,6 @@ import { ChunkInfo, StorageKey, StorageId } from "./types.js"
 import { keyHash, headsHash } from "./keyHash.js"
 import { chunkTypeFromKey } from "./chunkTypeFromKey.js"
 import * as Uuid from "uuid"
-import { EventEmitter } from "eventemitter3"
 
 /**
  * The storage subsystem is responsible for saving and loading Automerge documents to and from

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -454,12 +454,12 @@ describe("Repo", () => {
     const setup = () => {
       let blockedSaves = new Set<{ path: StorageKey; resolve: () => void }>()
       let resume = (documentIds?: DocumentId[]) => {
-        ;(documentIds
+        const savesToUnblock = documentIds
           ? Array.from(blockedSaves).filter(({ path }) =>
               documentIds.some(documentId => path.includes(documentId))
             )
           : Array.from(blockedSaves)
-        ).forEach(({ resolve }) => resolve())
+        savesToUnblock.forEach(({ resolve }) => resolve())
       }
       const pausedStorage = new DummyStorageAdapter()
       {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -29,7 +29,7 @@ import {
 } from "./helpers/generate-large-object.js"
 import { getRandomItem } from "./helpers/getRandomItem.js"
 import { TestDoc } from "./types.js"
-import { StorageId } from "../src/storage/types.js"
+import { StorageId, StorageKey } from "../src/storage/types.js"
 
 describe("Repo", () => {
   describe("constructor", () => {
@@ -452,17 +452,28 @@ describe("Repo", () => {
 
   describe("flush behaviour", () => {
     const setup = () => {
-      let blockedSaves = []
-      let resume = () => {
-        blockedSaves.forEach(resolve => resolve())
-        blockedSaves = []
+      let blockedSaves = new Set<{ path: StorageKey; resolve: () => void }>()
+      let resume = (documentIds?: DocumentId[]) => {
+        ;(documentIds
+          ? Array.from(blockedSaves).filter(({ path }) =>
+              documentIds.some(documentId => path.includes(documentId))
+            )
+          : Array.from(blockedSaves)
+        ).forEach(({ resolve }) => resolve())
       }
       const pausedStorage = new DummyStorageAdapter()
       {
         const originalSave = pausedStorage.save.bind(pausedStorage)
         pausedStorage.save = async (...args) => {
-          await new Promise(resolve => {
-            blockedSaves.push(resolve)
+          await new Promise<void>(resolve => {
+            const blockedSave = {
+              path: args[0],
+              resolve: () => {
+                resolve()
+                blockedSaves.delete(blockedSave)
+              },
+            }
+            blockedSaves.add(blockedSave)
           })
           await pause(0)
           // otherwise all the save promises resolve together
@@ -526,7 +537,7 @@ describe("Repo", () => {
       const { resume, pausedStorage, repo, handle, handle2 } = setup()
 
       const flushPromise = repo.flush([handle.documentId])
-      resume()
+      resume([handle.documentId])
       await flushPromise
 
       // Check that the data is now saved.
@@ -547,16 +558,6 @@ describe("Repo", () => {
           await repo.find<{ foo: string }>(handle2.documentId).doc()
         ).toEqual(undefined)
       }
-    })
-
-    it("should time out with failure after a specified delay", async () => {
-      const { resume, pausedStorage, repo, handle, handle2 } = setup()
-
-      const flushPromise = repo.flush([handle.documentId], 10)
-      expect(flushPromise).rejects.toThrowError("Timed out waiting for save")
-
-      // Check that the data is now saved.
-      expect(pausedStorage.keys().length).toBe(0)
     })
   })
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -559,6 +559,24 @@ describe("Repo", () => {
         ).toEqual(undefined)
       }
     })
+
+    it("flush right before change should resolve correctly", async () => {
+      const repo = new Repo({
+        network: [],
+        storage: new DummyStorageAdapter(),
+      })
+      const handle = repo.create<{ field?: string }>()
+
+      for (let i = 0; i < 10; i++) {
+        const flushPromise = repo.flush([handle.documentId])
+        handle.change((doc: any) => {
+          doc.field += Array(1024)
+            .fill(Math.random() * 10)
+            .join("")
+        })
+        await flushPromise
+      }
+    })
   })
 
   describe("with peers (linear network)", async () => {


### PR DESCRIPTION
### Motivation
The `Flush` method waits for specific heads to be written on the disk, there was a race condition when you do change exactly after the `flush` heads on the disk would never be equal to the flushing heads.
This snippet shows what exactly was happening in the storage subsystem (and before this PR it would hang forever):
```ts
      it.only("Flush should resolve even if doc is getting changed afterwards", async () => {
        const storage = new StorageSubsystem(new NodeFSStorageAdapter())

        const doc = A.change(A.init<any>(), "first change", d => {
          d.foo = "bar"
        })
       
        // start flushing (with current heads).
        const key = parseAutomergeUrl(generateAutomergeUrl()).documentId
        const flush = storage.flush(key, doc)

        // make a change (changes heads).
        const changedDoc = A.change<any>(doc, "second change", d => {
          d.foo = "baz"
        })
        await storage.saveDoc(key, changedDoc)

        await flush // <- hangs here forever.
      }) 
 ```
 
 ### Fix
 Invoke save on flush method, because of how automerge storage works it will not break it, it could just make additional useless write, which is already pending, or save mutations which are already saved.