### PR TITLE
fix bugs in useDocuments

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocuments.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocuments.ts
@@ -4,101 +4,120 @@ import {
   DocHandleChangePayload,
   DocHandleDeletePayload,
   DocumentId,
+  isValidAutomergeUrl,
+  parseAutomergeUrl,
 } from "@automerge/automerge-repo"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useRepo } from "./useRepo.js"
 
 /**
- * Maintains a map of document states, keyed by URL or DocumentId. Useful for collections of related
+ * Maintains a map of document states, keyed by DocumentId. Useful for collections of related
  * documents.
+ * Accepts either URLs or document IDs in the input array, but all get converted to IDs
+ * for the output map.
  */
-export const useDocuments = <T>(ids?: DocId[]) => {
-  const [documents, setDocuments] = useState({} as Record<DocId, T>)
-  const [listeners, setListeners] = useState({} as Record<DocId, Listeners<T>>)
+export const useDocuments = <T>(idsOrUrls?: DocId[]) => {
+  const [documents, setDocuments] = useState({} as Record<DocumentId, T>)
   const repo = useRepo()
-
-  useEffect(
-    () => {
-      const updateDocument = (id: DocId, doc?: T) => {
-        if (doc) setDocuments(docs => ({ ...docs, [id]: doc }))
-      }
-      const updateDocumentDeleted = (id: DocId) => {
-        // (don't remove listeners)
-        // remove the document from the document map
-        setDocuments(docs => {
-          const { [id]: _removedDoc, ...remainingDocs } = docs
-          return remainingDocs
-        })
-      }
-
-      const addListener = (handle: DocHandle<T>) => {
-        const id = handle.documentId
-
-        // whenever a document changes, update our map
-        const listeners: Listeners<T> = {
-          change: ({ doc }) => updateDocument(id, doc),
-          delete: () => updateDocumentDeleted(id),
+  const ids = useMemo(
+    () =>
+      idsOrUrls?.map(idOrUrl => {
+        if (isValidAutomergeUrl(idOrUrl)) {
+          const { documentId } = parseAutomergeUrl(idOrUrl)
+          return documentId
+        } else {
+          return idOrUrl as DocumentId
         }
-        handle.on("change", listeners.change)
-        handle.on("delete", listeners.delete)
-
-        // store the listener so we can remove it later
-        setListeners(listeners => ({ ...listeners, [id]: listeners }))
-      }
-
-      const removeDocument = (id: DocId) => {
-        // remove the listener
-        const handle = repo.find<T>(id)
-        handle.off("change", listeners[id].change)
-        handle.off("delete", listeners[id].delete)
-
-        // remove the document from the document map
-        setDocuments(docs => {
-          const { [id]: _removedDoc, ...remainingDocs } = docs
-          return remainingDocs
-        })
-      }
-
-      if (ids) {
-        // add any new documents
-        const newIds = ids.filter(id => !documents[id])
-        newIds.forEach(id => {
-          const handle = repo.find<T>(id)
-          // As each document loads, update our map
-          handle
-            .doc()
-            .then(doc => {
-              updateDocument(id, doc)
-              addListener(handle)
-            })
-            .catch(err => {
-              console.error(
-                `Error loading document ${id} in useDocuments: `,
-                err
-              )
-            })
-        })
-
-        // remove any documents that are no longer in the list
-        const removedIds = Object.keys(documents)
-          .map(id => id as DocId)
-          .filter(id => !ids.includes(id))
-        removedIds.forEach(removeDocument)
-      }
-
-      // on unmount, remove all listeners
-      const teardown = () => {
-        Object.entries(listeners).forEach(([id, listeners]) => {
-          const handle = repo.find<T>(id as DocId)
-          handle.off("change", listeners.change)
-          handle.off("delete", listeners.delete)
-        })
-      }
-
-      return teardown
-    },
-    [ids] // only run this effect when the list of ids changes
+      }) ?? [],
+    [idsOrUrls]
   )
+  const prevIds = useRef<DocumentId[]>([])
+
+  useEffect(() => {
+    // These listeners will live for the lifetime of this useEffect
+    // and be torn down when the useEffect is rerun.
+    const listeners = {} as Record<DocumentId, Listeners<T>>
+    const updateDocument = (id: DocId, doc?: T) => {
+      if (doc) setDocuments(docs => ({ ...docs, [id]: doc }))
+    }
+    const addListener = (handle: DocHandle<T>) => {
+      const id = handle.documentId
+
+      // whenever a document changes, update our map
+      const listenersForDoc: Listeners<T> = {
+        change: ({ doc }) => updateDocument(id, doc),
+        delete: () => removeDocument(id),
+      }
+      handle.on("change", listenersForDoc.change)
+      handle.on("delete", listenersForDoc.delete)
+
+      // store the listener so we can remove it later
+      listeners[id] = listenersForDoc
+    }
+
+    const removeDocument = (id: DocumentId) => {
+      // remove the document from the document map
+      setDocuments(docs => {
+        const { [id]: _removedDoc, ...remainingDocs } = docs
+        return remainingDocs
+      })
+    }
+
+    // Add a new document to our map
+    const addNewDocument = (id: DocumentId) => {
+      const handle = repo.find<T>(id)
+      if (handle.docSync()) {
+        updateDocument(id, handle.docSync())
+        addListener(handle)
+      } else {
+        // As each document loads, update our map
+        handle
+          .doc()
+          .then(doc => {
+            updateDocument(id, doc)
+            addListener(handle)
+          })
+          .catch(err => {
+            console.error(`Error loading document ${id} in useDocuments: `, err)
+          })
+      }
+    }
+
+    const teardown = () => {
+      Object.entries(listeners).forEach(([id, listeners]) => {
+        const handle = repo.find<T>(id as DocId)
+        handle.off("change", listeners.change)
+        handle.off("delete", listeners.delete)
+      })
+    }
+
+    if (!ids) {
+      return teardown
+    }
+
+    for (const id of ids) {
+      const handle = repo.find<T>(id)
+      if (prevIds.current.includes(id)) {
+        // the document was already in our list before.
+        // we only need to register new listeners.
+        addListener(handle)
+      } else {
+        // This is a new document that was not in our list before.
+        // We need to update its state in the documents array and register
+        // new listeners.
+        addNewDocument(id)
+      }
+    }
+
+    // remove any documents that are no longer in the list
+    const removedIds = prevIds.current.filter(id => !ids.includes(id))
+    removedIds.forEach(removeDocument)
+
+    // Update the ref so we remember the old IDs for next time
+    prevIds.current = ids
+
+    return teardown
+  }, [ids, repo])
 
   return documents
 }

--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -1,4 +1,10 @@
-import { DocumentId, PeerId, Repo } from "@automerge/automerge-repo"
+import {
+  AutomergeUrl,
+  DocumentId,
+  PeerId,
+  Repo,
+  stringifyAutomergeUrl,
+} from "@automerge/automerge-repo"
 import { DummyStorageAdapter } from "@automerge/automerge-repo/test/helpers/DummyStorageAdapter"
 import { act, render, waitFor } from "@testing-library/react"
 import React from "react"
@@ -33,13 +39,13 @@ describe("useDocuments", () => {
   }
 
   const Component = ({
-    ids,
+    idsOrUrls,
     onDocs,
   }: {
-    ids: DocumentId[]
+    idsOrUrls: (DocumentId | AutomergeUrl)[]
     onDocs: (documents: Record<DocumentId, unknown>) => void
   }) => {
-    const documents = useDocuments(ids)
+    const documents = useDocuments(idsOrUrls)
     onDocs(documents)
     return null
   }
@@ -48,7 +54,7 @@ describe("useDocuments", () => {
     const { documentIds, wrapper } = setup()
     const onDocs = vi.fn()
 
-    render(<Component ids={documentIds} onDocs={onDocs} />, { wrapper })
+    render(<Component idsOrUrls={documentIds} onDocs={onDocs} />, { wrapper })
     await waitFor(() =>
       expect(onDocs).toHaveBeenCalledWith(
         Object.fromEntries(documentIds.map((id, i) => [id, { foo: i }]))
@@ -56,11 +62,66 @@ describe("useDocuments", () => {
     )
   })
 
+  it("cleans up listeners properly", async () => {
+    const { documentIds, wrapper, repo } = setup()
+    const onDocs = vi.fn()
+
+    // The goal here is to check that we're not leaking listeners.
+    // We do this by mounting the component a set number of times and then
+    // checking the number of listeners on the handle at the end.
+    const numMounts = 5 // arbitrary number here
+    for (let i = 0; i < numMounts; i++) {
+      const { unmount } = render(
+        <Component idsOrUrls={documentIds} onDocs={onDocs} />,
+        { wrapper }
+      )
+      await waitFor(() => unmount())
+    }
+
+    for (const id of documentIds) {
+      const handle = repo.find(id)
+
+      // You might expect we'd check that it's equal to 0 here.
+      // but it turns out that automerge-repo registers an internal
+      // change handler which remain on the doc even after unmount,
+      // so we can't do that.
+      // By comparing to numMounts, we ensure that if mount+unmount
+      // does leak a listener, it'll fail this test.
+      expect(handle.listenerCount("change")).toBeLessThan(numMounts)
+    }
+  })
+
   it("updates documents when they change", async () => {
     const { repo, documentIds, wrapper } = setup()
     const onDocs = vi.fn()
 
-    render(<Component ids={documentIds} onDocs={onDocs} />, { wrapper })
+    render(<Component idsOrUrls={documentIds} onDocs={onDocs} />, { wrapper })
+    await waitFor(() =>
+      expect(onDocs).toHaveBeenCalledWith(
+        Object.fromEntries(documentIds.map((id, i) => [id, { foo: i }]))
+      )
+    )
+
+    act(() => {
+      // multiply the value of foo in each document by 10
+      documentIds.forEach(id => {
+        const handle = repo.find(id)
+        handle.change(s => (s.foo *= 10))
+      })
+    })
+    await waitFor(() =>
+      expect(onDocs).toHaveBeenCalledWith(
+        Object.fromEntries(documentIds.map((id, i) => [id, { foo: i * 10 }]))
+      )
+    )
+  })
+
+  it("updates documents when they change, if URLs are passed in", async () => {
+    const { repo, documentIds, wrapper } = setup()
+    const onDocs = vi.fn()
+    const documentUrls = documentIds.map(id => stringifyAutomergeUrl(id))
+
+    render(<Component idsOrUrls={documentUrls} onDocs={onDocs} />, { wrapper })
     await waitFor(() =>
       expect(onDocs).toHaveBeenCalledWith(
         Object.fromEntries(documentIds.map((id, i) => [id, { foo: i }]))
@@ -86,7 +147,7 @@ describe("useDocuments", () => {
     const onDocs = vi.fn()
 
     const { rerender } = render(
-      <Component ids={documentIds} onDocs={onDocs} />,
+      <Component idsOrUrls={documentIds} onDocs={onDocs} />,
       { wrapper }
     )
     await waitFor(() =>
@@ -96,7 +157,7 @@ describe("useDocuments", () => {
     )
 
     // remove the first document
-    rerender(<Component ids={documentIds.slice(1)} onDocs={onDocs} />)
+    rerender(<Component idsOrUrls={documentIds.slice(1)} onDocs={onDocs} />)
     // 👆 Note that this only works because documentIds.slice(1) is a different
     // object from documentIds. If we modified documentIds directly, the hook
     // wouldn't re-run.
@@ -108,10 +169,70 @@ describe("useDocuments", () => {
       )
     )
   })
+
+  it(`keeps updating documents after the list has changed`, async () => {
+    const { documentIds, wrapper, repo } = setup()
+    const onDocs = vi.fn()
+
+    const { rerender } = render(
+      <Component idsOrUrls={documentIds} onDocs={onDocs} />,
+      { wrapper }
+    )
+    await waitFor(() =>
+      expect(onDocs).toHaveBeenCalledWith(
+        Object.fromEntries(documentIds.map((id, i) => [id, { foo: i }]))
+      )
+    )
+
+    // remove the first document
+    act(() => {
+      rerender(<Component idsOrUrls={documentIds.slice(1)} onDocs={onDocs} />)
+    })
+    // 👆 Note that this only works because documentIds.slice(1) is a different
+    // object from documentIds. If we modified documentIds directly, the hook
+    // wouldn't re-run.
+    await waitFor(() =>
+      expect(onDocs).toHaveBeenCalledWith(
+        Object.fromEntries(
+          documentIds.map((id, i) => [id, { foo: i }]).slice(1)
+        )
+      )
+    )
+
+    // update all the docs that are still in the list
+
+    act(() => {
+      // multiply the value of foo in each document by 10
+      documentIds.slice(1).forEach(id => {
+        const handle = repo.find(id)
+        handle.change(s => (s.foo *= 10))
+      })
+    })
+
+    await waitFor(() =>
+      expect(onDocs).toHaveBeenCalledWith(
+        Object.fromEntries(
+          documentIds.map((id, i) => [id, { foo: i * 10 }]).slice(1)
+        )
+      )
+    )
+
+    act(() => {
+      // multiply the value of foo in each document by 10
+      documentIds.slice(1).forEach(id => {
+        const handle = repo.find(id)
+        handle.change(s => (s.foo *= 10))
+      })
+    })
+
+    await waitFor(() => {
+      expect(onDocs).toHaveBeenCalledWith(
+        Object.fromEntries(
+          documentIds.map((id, i) => [id, { foo: i * 100 }]).slice(1)
+        )
+      )
+    })
+  })
 })
 
 const range = (n: number) => [...Array(n).keys()]
-
-interface ExampleDoc {
-  foo: number
-}


### PR DESCRIPTION
This commit fixes two bugs in the useDocuments hook, and adds corresponding tests.

1) The hook was leaking handlers and not cleaning up properly.
   The useEffect teardown was trying to clean up listeners,
   but the useEffect wasn't rerun when listeners were updated,
   so it didn't actually work. Now we don't save listeners
   in state, and instead we re-initialize them whenever the
   documents list changes.

   (I believe there may have been a related bug where
   updates weren't being processed correctly, but I wasn't
   able to get that to happen in unit tests; regardless,
   I'm confident the new approach to listeners is better.)

2) The hook accepts document URLs or IDs in the list.
   If URLs were passed in, updates wouldn't actually get
   processed correctly because of how the internal state is
   structured. Now that works.

There was also an issue where the dependency array to the useEffect was incomplete, which was working out fine in practice but seemed dangerous. I've restructured the hook to avoid that incomplete dependency array as well.

In addition to the 2 new unit tests which fail on old code and pass on new, I've also been using this modified hook in some app code which was broken by these bugs and the new version seems to be working well.

One note: I considered exporting a URL-keyed map instead of a DocumentId-keyed map, but that would be a breaking API change so I avoided that for now.