### PR TITLE
Use "export type" to export Cursor type

### DIFF
--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -92,7 +92,7 @@ export type {
 export * from "./types.js"
 
 // export commonly used data types
-export { Counter, RawString, Cursor } from "@automerge/automerge/next"
+export { Counter, RawString } from "@automerge/automerge/next"
 
 // export some automerge API types
 export type {
@@ -108,6 +108,7 @@ export type {
   MarkSet,
   MarkRange,
   MarkValue,
+  Cursor,
 } from "@automerge/automerge/next"
 
 // export a few utility functions that aren't in automerge-repo


### PR DESCRIPTION
If the export keyword is used to export the TS type for 'Cursor', it can cause downstream TS projects using the 'isolatedModules' flag. This fixes that problem; tested by running tsc on a downstream project.