### PR TITLE
bugfix: avoid returning stale data in useDocument and useHandle

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -50,12 +50,11 @@ export function useDocument<T>(
         // This avoids problem with out-of-order loads when the handle is changing faster
         // than documents are loading.
         if (handleRef.current !== handle) return
-          setDoc(v)
+        setDoc(v)
       })
       .catch(e => console.error(e))
 
-    const onChange = (h: DocHandleChangePayload<T>) =>
-      setDoc(h.doc)
+    const onChange = (h: DocHandleChangePayload<T>) => setDoc(h.doc)
     handle.on("change", onChange)
     const onDelete = () => setDoc(undefined)
     handle.on("delete", onDelete)
@@ -67,13 +66,13 @@ export function useDocument<T>(
     return cleanup
   }, [id, handle])
 
-  const changeDoc = useCallback((
-    changeFn: ChangeFn<T>,
-    options?: ChangeOptions<T> | undefined
-  ) => {
-    if (!handle) return
-    handle.change(changeFn, options)
-  }, [handle])
+  const changeDoc = useCallback(
+    (changeFn: ChangeFn<T>, options?: ChangeOptions<T> | undefined) => {
+      if (!handle) return
+      handle.change(changeFn, options)
+    },
+    [handle]
+  )
 
   return [handle?.docSync(), changeDoc] as const
 }

--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -15,7 +15,12 @@ import { useRepo } from "./useRepo.js"
  * @remarks
  * This requires a {@link RepoContext} to be provided by a parent component.
  * */
-export function useDocument<T>(id?: AnyDocumentId) {
+export function useDocument<T>(
+  id?: AnyDocumentId
+): [
+  Doc<T> | undefined,
+  (changeFn: ChangeFn<T>, options?: ChangeOptions<T> | undefined) => void
+] {
   const repo = useRepo()
 
   const handle = id ? repo.find<T>(id) : null
@@ -77,7 +82,7 @@ export function useDocument<T>(id?: AnyDocumentId) {
   }
 
   if (!docWithId || docWithId.id !== id) {
-    return [undefined, changeDoc]
+    return [undefined, () => {}]
   }
 
   return [docWithId.doc, changeDoc] as const

--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -33,12 +33,6 @@ export function useDocument<T>(
       return
     }
 
-    // When the handle has changed, reset the doc to the current value of docSync().
-    // For already-loaded documents this will be the last known value, for unloaded documents
-    // this will be undefined.
-    // This ensures that if loading the doc takes a long time, the UI
-    // shows a loading state during that time rather than a stale doc.
-
     handleRef.current = handle
     handle
       .doc()

--- a/packages/automerge-repo-react-hooks/src/useHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useHandle.ts
@@ -1,9 +1,7 @@
 import {
   AnyDocumentId,
   DocHandle,
-  interpretAsDocumentId,
 } from "@automerge/automerge-repo"
-import { useEffect, useState } from "react"
 import { useRepo } from "./useRepo.js"
 
 /** A hook which returns a {@link DocHandle} identified by a URL.

--- a/packages/automerge-repo-react-hooks/src/useHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useHandle.ts
@@ -11,24 +11,6 @@ import { useRepo } from "./useRepo.js"
  * @remarks
  * This requires a {@link RepoContext} to be provided by a parent component.
  */
-export function useHandle<T>(id?: AnyDocumentId) {
-  const repo = useRepo()
-  const [handle, setHandle] = useState<DocHandle<T> | undefined>(
-    id ? repo.find(id) : undefined
-  )
-
-  useEffect(() => {
-    setHandle(id ? repo.find(id) : undefined)
-  }, [id])
-
-  if (
-    !id ||
-    !handle ||
-    // Don't return a handle if it doesn't match the currently passed-in ID
-    interpretAsDocumentId(handle.url) !== interpretAsDocumentId(id)
-  ) {
-    return undefined
-  }
-
-  return handle
+export function useHandle<T>(id?: AnyDocumentId): DocHandle<T> | undefined {
+  return (id ? useRepo().find(id) : undefined)
 }

--- a/packages/automerge-repo-react-hooks/src/useHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useHandle.ts
@@ -1,7 +1,10 @@
-import { AnyDocumentId, DocHandle } from "@automerge/automerge-repo"
+import {
+  AnyDocumentId,
+  DocHandle,
+  interpretAsDocumentId,
+} from "@automerge/automerge-repo"
 import { useEffect, useState } from "react"
 import { useRepo } from "./useRepo.js"
-import { interpretAsDocumentId } from "@automerge/automerge-repo/dist/AutomergeUrl.js"
 
 /** A hook which returns a {@link DocHandle} identified by a URL.
  *

--- a/packages/automerge-repo-react-hooks/src/useHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useHandle.ts
@@ -1,7 +1,4 @@
-import {
-  AnyDocumentId,
-  DocHandle,
-} from "@automerge/automerge-repo"
+import { AnyDocumentId, DocHandle } from "@automerge/automerge-repo"
 import { useRepo } from "./useRepo.js"
 
 /** A hook which returns a {@link DocHandle} identified by a URL.
@@ -10,5 +7,5 @@ import { useRepo } from "./useRepo.js"
  * This requires a {@link RepoContext} to be provided by a parent component.
  */
 export function useHandle<T>(id?: AnyDocumentId): DocHandle<T> | undefined {
-  return (id ? useRepo().find(id) : undefined)
+  return id ? useRepo().find(id) : undefined
 }

--- a/packages/automerge-repo-react-hooks/src/useHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useHandle.ts
@@ -1,6 +1,7 @@
 import { AnyDocumentId, DocHandle } from "@automerge/automerge-repo"
 import { useEffect, useState } from "react"
 import { useRepo } from "./useRepo.js"
+import { interpretAsDocumentId } from "@automerge/automerge-repo/dist/AutomergeUrl.js"
 
 /** A hook which returns a {@link DocHandle} identified by a URL.
  *
@@ -16,6 +17,15 @@ export function useHandle<T>(id?: AnyDocumentId) {
   useEffect(() => {
     setHandle(id ? repo.find(id) : undefined)
   }, [id])
+
+  if (
+    !id ||
+    !handle ||
+    // Don't return a handle if it doesn't match the currently passed-in ID
+    interpretAsDocumentId(handle.url) !== interpretAsDocumentId(id)
+  ) {
+    return undefined
+  }
 
   return handle
 }

--- a/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
@@ -134,7 +134,7 @@ describe("useDocument", () => {
     await waitFor(() => expect(onDoc).toHaveBeenLastCalledWith(undefined))
   })
 
-  it("does not return a document for a previous url after the url is updated", async () => {
+  it("returns new doc on first render after url changes", async () => {
     const { handleA, handleB, wrapper } = setup()
     const onDoc = vi.fn()
 
@@ -151,7 +151,15 @@ describe("useDocument", () => {
 
     // set url to doc B
     rerender(<Component url={handleB.url} onDoc={onDoc2} />)
-    await waitFor(() => expect(onDoc2).not.toHaveBeenCalledWith({ foo: "A" }))
+    await waitFor(() => {
+      // no stale data
+      expect(onDoc2).not.toHaveBeenCalledWith({ foo: "A" })
+      // no render with undefined data
+      expect(onDoc2).not.toHaveBeenCalledWith(undefined)
+
+      // render with new data
+      expect(onDoc2).toHaveBeenCalledWith({ foo: "B" })
+    })
   })
 
   it("sets the doc to undefined while the initial load is happening", async () => {

--- a/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
@@ -125,6 +125,26 @@ describe("useDocument", () => {
     await waitFor(() => expect(onDoc).toHaveBeenLastCalledWith(undefined))
   })
 
+  it("does not return a document for a previous url after the url is updated", async () => {
+    const { handleA, handleB, wrapper } = setup()
+    const onDoc = vi.fn()
+
+    const { rerender } = render(<Component url={undefined} onDoc={onDoc} />, {
+      wrapper,
+    })
+    await waitFor(() => expect(onDoc).toHaveBeenLastCalledWith(undefined))
+
+    // set url to doc A
+    rerender(<Component url={handleA.url} onDoc={onDoc} />)
+    await waitFor(() => expect(onDoc).toHaveBeenLastCalledWith({ foo: "A" }))
+
+    const onDoc2 = vi.fn()
+
+    // set url to doc B
+    rerender(<Component url={handleB.url} onDoc={onDoc2} />)
+    await waitFor(() => expect(onDoc2).not.toHaveBeenCalledWith({ foo: "A" }))
+  })
+
   it("sets the doc to undefined while the initial load is happening", async () => {
     const { handleA, handleSlow, wrapper } = setup()
     const onDoc = vi.fn()

--- a/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
@@ -59,7 +59,7 @@ describe("useDocument", () => {
     url,
     onDoc,
   }: {
-    url: AutomergeUrl
+    url: AutomergeUrl | undefined
     onDoc: (doc: ExampleDoc) => void
   }) => {
     const [doc] = useDocument(url)

--- a/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
@@ -28,7 +28,12 @@ describe("useDocument", () => {
     handleSlow.change(doc => (doc.foo = "slow"))
     const oldDoc = handleSlow.doc.bind(handleSlow)
     let loaded = false
-    const delay = new Promise(resolve => setTimeout(() => { loaded = true; resolve(true) }, SLOW_DOC_LOAD_TIME_MS))
+    const delay = new Promise(resolve =>
+      setTimeout(() => {
+        loaded = true
+        resolve(true)
+      }, SLOW_DOC_LOAD_TIME_MS)
+    )
     handleSlow.doc = async () => {
       await delay
       const result = await oldDoc()

--- a/packages/automerge-repo-react-hooks/test/useHandle.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useHandle.test.tsx
@@ -91,4 +91,21 @@ describe("useHandle", () => {
     rerender(<Component url={undefined} onHandle={onHandle} />)
     await waitFor(() => expect(onHandle).toHaveBeenLastCalledWith(undefined))
   })
+
+  it("does not return a handle for a different url after the url is updated", async () => {
+    const { wrapper, handleA, handleB } = setup()
+    const onHandle = vi.fn()
+
+    const { rerender } = render(
+      <Component url={handleA.url} onHandle={onHandle} />,
+      { wrapper }
+    )
+    await waitFor(() => expect(onHandle).toHaveBeenLastCalledWith(handleA))
+
+    const onHandle2 = vi.fn()
+
+    // set url to doc B
+    rerender(<Component url={handleB.url} onHandle={onHandle2} />)
+    await waitFor(() => expect(onHandle2).not.toHaveBeenCalledWith(handleA))
+  })
 })

--- a/packages/automerge-repo-react-hooks/test/useHandle.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useHandle.test.tsx
@@ -92,6 +92,23 @@ describe("useHandle", () => {
     await waitFor(() => expect(onHandle).toHaveBeenLastCalledWith(undefined))
   })
 
+  it("does not return undefined after the url is updated", async () => {
+    const { wrapper, handleA, handleB } = setup()
+    const onHandle = vi.fn()
+
+    const { rerender } = render(
+      <Component url={handleA.url} onHandle={onHandle} />,
+      { wrapper }
+    )
+    await waitFor(() => expect(onHandle).toHaveBeenLastCalledWith(handleA))
+
+    const onHandle2 = vi.fn()
+
+    // set url to doc B
+    rerender(<Component url={handleB.url} onHandle={onHandle2} />)
+    await waitFor(() => expect(onHandle2).not.toHaveBeenCalledWith(undefined))
+  })
+
   it("does not return a handle for a different url after the url is updated", async () => {
     const { wrapper, handleA, handleB } = setup()
     const onHandle = vi.fn()

--- a/packages/automerge-repo-react-hooks/test/useHandle.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useHandle.test.tsx
@@ -45,7 +45,7 @@ describe("useHandle", () => {
     url,
     onHandle,
   }: {
-    url: AutomergeUrl
+    url: AutomergeUrl | undefined
     onHandle: (handle: DocHandle<unknown> | undefined) => void
   }) => {
     const handle = useHandle(url)

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -31,6 +31,7 @@ export {
   isValidAutomergeUrl,
   parseAutomergeUrl,
   stringifyAutomergeUrl,
+  interpretAsDocumentId,
 } from "./AutomergeUrl.js"
 export { Repo } from "./Repo.js"
 export { NetworkAdapter } from "./network/NetworkAdapter.js"


### PR DESCRIPTION
useDocument and useHandle had a footgun where after the input url changed, they would continue returning the old doc/handle for the previous input for 1 or more renders.

This behavior could cause problems in downstream computations or useEffect hooks which did not account for this brief inconsistency.

This patch fixes the problem by checking whether the input and output match before returning out of the hook. In useHandle we can just check the handle URL directly; in useDocument we need to store some additional state to remember the URL associated with a given doc.

## tests

- added unit tests which fail on old code and pass on new
- using these updated hooks in https://github.com/inkandswitch/tiny-essay-editor/pull/42 and it instantly solved a ton of weird bugs throughout the app
