### PR TITLE
fix useHandle to always call useRepo

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useHandle.ts
@@ -7,5 +7,6 @@ import { useRepo } from "./useRepo.js"
  * This requires a {@link RepoContext} to be provided by a parent component.
  */
 export function useHandle<T>(id?: AnyDocumentId): DocHandle<T> | undefined {
-  return id ? useRepo().find(id) : undefined
+  const repo = useRepo()
+  return id ? repo.find(id) : undefined
 }


### PR DESCRIPTION
Currently useHandle calls useRepo only if an id is passed in. This violates a rule of hooks that you always have to call the same hooks in the same order