### PR TITLE
Add syncPolicy callback for per-document authorization

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -51,6 +51,10 @@ export class Repo extends EventEmitter<RepoEvents> {
   /** @hidden */
   sharePolicy: SharePolicy = async () => true
 
+  /** By default, we sync with all peers. */
+  /** @hidden */
+  syncPolicy: SyncPolicy = async () => true
+
   /** maps peer id to to persistence information (storageId, isEphemeral), access by collection synchronizer  */
   /** @hidden */
   peerMetadataByPeerId: Record<PeerId, PeerMetadata> = {}
@@ -63,6 +67,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     network = [],
     peerId,
     sharePolicy,
+    syncPolicy,
     isEphemeral = storage === undefined,
     enableRemoteHeadsGossiping = false,
   }: RepoConfig = {}) {
@@ -70,6 +75,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     this.#remoteHeadsGossipingEnabled = enableRemoteHeadsGossiping
     this.#log = debug(`automerge-repo:repo`)
     this.sharePolicy = sharePolicy ?? this.sharePolicy
+    this.syncPolicy = syncPolicy ?? this.syncPolicy
 
     // DOC COLLECTION
 
@@ -551,6 +557,8 @@ export interface RepoConfig {
    */
   sharePolicy?: SharePolicy
 
+  syncPolicy?: SyncPolicy
+
   /**
    * Whether to enable the experimental remote heads gossiping feature
    */
@@ -566,6 +574,12 @@ export interface RepoConfig {
  * document with the peer given by `peerId`.
  * */
 export type SharePolicy = (
+  peerId: PeerId,
+  documentId?: DocumentId
+) => Promise<boolean>
+
+// TODO document
+export type SyncPolicy = (
   peerId: PeerId,
   documentId?: DocumentId
 ) => Promise<boolean>

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -557,6 +557,9 @@ export interface RepoConfig {
    */
   sharePolicy?: SharePolicy
 
+  /**
+   * A callback can be provided to implement authorization based on document ID and peer ID.
+   */
   syncPolicy?: SyncPolicy
 
   /**
@@ -578,7 +581,13 @@ export type SharePolicy = (
   documentId?: DocumentId
 ) => Promise<boolean>
 
-// TODO document
+/** A function that determines whether we should sync a document with a peer
+ *
+ * @remarks
+ * This function is called by the {@link Repo} every time a peer requests to
+ * sync a document. If this function returns `true` the document syncs normally;
+ * if `false`, it reports the document as unavailable.
+ * */
 export type SyncPolicy = (
   peerId: PeerId,
   documentId?: DocumentId

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -85,6 +85,18 @@ export class CollectionSynchronizer extends Synchronizer {
     )
 
     const documentId = message.documentId
+    const senderId = message.senderId
+    const okToSync = await this.repo.syncPolicy(senderId, documentId)
+    if (!okToSync) {
+      log(`sync blocked by policy: ${message.senderId}, ${message.documentId}`)
+      this.emit("message", {
+        type: "doc-unavailable",
+        targetId: senderId,
+        documentId
+      })
+      return
+    }
+
     if (!documentId) {
       throw new Error("received a message with an invalid documentId")
     }

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -8,7 +8,7 @@ import {
   generateAutomergeUrl,
   stringifyAutomergeUrl,
 } from "../src/AutomergeUrl.js"
-import { Repo } from "../src/Repo.js"
+import { Repo, SyncPolicy } from "../src/Repo.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
 import {
@@ -673,6 +673,7 @@ describe("Repo", () => {
     const setup = async ({
       connectAlice = true,
       isCharlieEphemeral = false,
+      charlieForbiddenDoc = false
     } = {}) => {
       const charlieExcludedDocuments: DocumentId[] = []
       const bobExcludedDocuments: DocumentId[] = []
@@ -694,6 +695,18 @@ describe("Repo", () => {
         return true
       }
 
+      const syncPolicy: SyncPolicy = async (peerId, documentId) => {
+        if (
+          charlieForbiddenDoc &&
+          charlieExcludedDocuments.includes(documentId) &&
+          peerId === "charlie"
+        ) {
+          return false
+        }
+
+        return true
+      }
+
       // Set up three repos; connect Alice to Bob, and Bob to Charlie
 
       const abChannel = new MessageChannel()
@@ -709,6 +722,7 @@ describe("Repo", () => {
         network: connectAlice ? [aliceNetworkAdapter] : [],
         peerId: alice,
         sharePolicy,
+        syncPolicy
       })
 
       const bob = "bob" as PeerId
@@ -721,6 +735,7 @@ describe("Repo", () => {
         ],
         peerId: bob,
         sharePolicy,
+        syncPolicy
       })
 
       const charlie = "charlie" as PeerId
@@ -837,6 +852,18 @@ describe("Repo", () => {
       const doc = await handle.doc()
 
       assert.deepStrictEqual(doc, { foo: "baz" })
+
+      teardown()
+    })
+
+    it("charlieRepo can't sync with a document when forbidden by syncPolicy", async () => {
+      const { charlieRepo, notForCharlie, teardown } = await setup({charlieForbiddenDoc: true})
+
+      const handle = charlieRepo.find<TestDoc>(notForCharlie)
+
+      await pause(50)
+
+      assert(handle.isUnavailable())
 
       teardown()
     })


### PR DESCRIPTION
This PR adds a `syncPolicy` callback to the repo configuration. It will be called whenever a sync message is received from a peer, and if it returns false, syncing will be blocked, and the repo will respond with a `doc-unavailable` message.

Currently, if `sharePolicy` returns true, the repo will still send sync messages to peers even if `syncPolicy` would return false. If this is undesirable, another possibility is to only share if `syncPolicy` and `sharePolicy` both return true.