### PR TITLE
expose isValidDocumentId

### DIFF
--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -29,6 +29,7 @@
 export { DocHandle } from "./DocHandle.js"
 export {
   isValidAutomergeUrl,
+  isValidDocumentId,
   parseAutomergeUrl,
   stringifyAutomergeUrl,
   interpretAsDocumentId,


### PR DESCRIPTION
It's useful to have`isValidDocumentId` exposed so if we can check validity of an `id` when it comes from outside.