### PR TITLE
fix(websocket): ProtocolV1 shouldn't be exported as type because it's a string

### DIFF
--- a/packages/automerge-repo-network-websocket/src/index.ts
+++ b/packages/automerge-repo-network-websocket/src/index.ts
@@ -22,4 +22,5 @@ export type {
   ErrorMessage,
   PeerMessage,
 } from "./messages.js"
-export type { ProtocolVersion, ProtocolV1 } from "./protocolVersion.js"
+export type { ProtocolVersion } from "./protocolVersion.js"
+export { ProtocolV1 } from "./protocolVersion.js"


### PR DESCRIPTION
Hi everyone! :) Thank you for the great project.

I have noticed that the example WebSocket code doesn't work with `ProtocolV1` being exported as type:
<img width="1187" alt="image" src="https://github.com/automerge/automerge-repo/assets/4187729/c2731eff-858a-415a-94b2-68cbf17cca36">

This PR fixes that.