### PR TITLE
remove the awaiting_network states from dochandle

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -99,15 +99,8 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
           on: {
             REQUEST: "requesting",
             DOC_READY: "ready",
-            AWAIT_NETWORK: "awaitingNetwork",
           },
           after: { [delay]: "unavailable" },
-        },
-        awaitingNetwork: {
-          on: {
-            DOC_READY: "ready",
-            NETWORK_READY: "requesting"
-          },
         },
         requesting: {
           on: {
@@ -429,17 +422,6 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
     if (this.#state === "loading") this.#machine.send({ type: REQUEST })
   }
 
-  /** @hidden */
-  awaitNetwork() {
-    if (this.#state === "loading") this.#machine.send({ type: AWAIT_NETWORK })
-  }
-
-  /** @hidden */
-  networkReady() {
-    if (this.#state === "awaitingNetwork")
-      this.#machine.send({ type: NETWORK_READY })
-  }
-
   /** Called by the repo when the document is deleted. */
   delete() {
     this.#machine.send({ type: DELETE })
@@ -554,8 +536,6 @@ export const HandleState = {
   IDLE: "idle",
   /** We are waiting for storage to finish loading */
   LOADING: "loading",
-  /** We are waiting for the network to be come ready */
-  AWAITING_NETWORK: "awaitingNetwork",
   /** We are waiting for someone in the network to respond to a sync request */
   REQUESTING: "requesting",
   /** The document is available */
@@ -567,15 +547,8 @@ export const HandleState = {
 } as const
 export type HandleState = (typeof HandleState)[keyof typeof HandleState]
 
-export const {
-  IDLE,
-  LOADING,
-  AWAITING_NETWORK,
-  REQUESTING,
-  READY,
-  DELETED,
-  UNAVAILABLE,
-} = HandleState
+export const { IDLE, LOADING, REQUESTING, READY, DELETED, UNAVAILABLE } =
+  HandleState
 
 // context
 
@@ -598,14 +571,10 @@ type DocHandleEvent<T> =
   | { type: typeof TIMEOUT }
   | { type: typeof DELETE }
   | { type: typeof DOC_UNAVAILABLE }
-  | { type: typeof AWAIT_NETWORK }
-  | { type: typeof NETWORK_READY }
 
 const FIND = "FIND"
 const REQUEST = "REQUEST"
 const DOC_READY = "DOC_READY"
-const AWAIT_NETWORK = "AWAIT_NETWORK"
-const NETWORK_READY = "NETWORK_READY"
 const UPDATE = "UPDATE"
 const DELETE = "DELETE"
 const TIMEOUT = "TIMEOUT"

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -91,8 +91,7 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
       states: {
         idle: {
           on: {
-            CREATE: "ready",
-            FIND: "loading",
+            BEGIN: "loading",
           },
         },
         loading: {
@@ -132,7 +131,7 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
 
     // Start the machine, and send a create or find event to get things going
     this.#machine.start()
-    this.#machine.send({ type: FIND })
+    this.#machine.send({ type: BEGIN })
   }
 
   // PRIVATE
@@ -448,19 +447,19 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
 export type DocHandleOptions<T> =
   // NEW DOCUMENTS
   | {
-      /** If we know this is a new document (because we're creating it) this should be set to true. */
-      isNew: true
+    /** If we know this is a new document (because we're creating it) this should be set to true. */
+    isNew: true
 
-      /** The initial value of the document. */
-      initialValue?: T
-    }
+    /** The initial value of the document. */
+    initialValue?: T
+  }
   // EXISTING DOCUMENTS
   | {
-      isNew?: false
+    isNew?: false
 
-      /** The number of milliseconds before we mark this document as unavailable if we don't have it and nobody shares it with us. */
-      timeoutDelay?: number
-    }
+    /** The number of milliseconds before we mark this document as unavailable if we don't have it and nobody shares it with us. */
+    timeoutDelay?: number
+  }
 
 // EXTERNAL EVENTS
 
@@ -561,18 +560,18 @@ interface DocHandleContext<T> {
 
 /** These are the (internal) events that can be sent to the state machine */
 type DocHandleEvent<T> =
-  | { type: typeof FIND }
+  | { type: typeof BEGIN }
   | { type: typeof REQUEST }
   | { type: typeof DOC_READY }
   | {
-      type: typeof UPDATE
-      payload: { callback: (doc: A.Doc<T>) => A.Doc<T> }
-    }
+    type: typeof UPDATE
+    payload: { callback: (doc: A.Doc<T>) => A.Doc<T> }
+  }
   | { type: typeof TIMEOUT }
   | { type: typeof DELETE }
   | { type: typeof DOC_UNAVAILABLE }
 
-const FIND = "FIND"
+const BEGIN = "BEGIN"
 const REQUEST = "REQUEST"
 const DOC_READY = "DOC_READY"
 const UPDATE = "UPDATE"

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -447,19 +447,19 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
 export type DocHandleOptions<T> =
   // NEW DOCUMENTS
   | {
-    /** If we know this is a new document (because we're creating it) this should be set to true. */
-    isNew: true
+      /** If we know this is a new document (because we're creating it) this should be set to true. */
+      isNew: true
 
-    /** The initial value of the document. */
-    initialValue?: T
-  }
+      /** The initial value of the document. */
+      initialValue?: T
+    }
   // EXISTING DOCUMENTS
   | {
-    isNew?: false
+      isNew?: false
 
-    /** The number of milliseconds before we mark this document as unavailable if we don't have it and nobody shares it with us. */
-    timeoutDelay?: number
-  }
+      /** The number of milliseconds before we mark this document as unavailable if we don't have it and nobody shares it with us. */
+      timeoutDelay?: number
+    }
 
 // EXTERNAL EVENTS
 
@@ -564,9 +564,9 @@ type DocHandleEvent<T> =
   | { type: typeof REQUEST }
   | { type: typeof DOC_READY }
   | {
-    type: typeof UPDATE
-    payload: { callback: (doc: A.Doc<T>) => A.Doc<T> }
-  }
+      type: typeof UPDATE
+      payload: { callback: (doc: A.Doc<T>) => A.Doc<T> }
+    }
   | { type: typeof TIMEOUT }
   | { type: typeof DELETE }
   | { type: typeof DOC_UNAVAILABLE }

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -157,7 +157,10 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
   }
 
   isReady = () => {
-    return this.#readyAdapterCount === this.#adapters.length
+    return (
+      this.#adapters.length === 0 ||
+      this.#readyAdapterCount === this.#adapters.length
+    )
   }
 
   whenReady = async () => {

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -79,8 +79,7 @@ export class CollectionSynchronizer extends Synchronizer {
    */
   async receiveMessage(message: DocMessage) {
     log(
-      `onSyncMessage: ${message.senderId}, ${message.documentId}, ${
-        "data" in message ? message.data.byteLength + "bytes" : ""
+      `onSyncMessage: ${message.senderId}, ${message.documentId}, ${"data" in message ? message.data.byteLength + "bytes" : ""
       }`
     )
 

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -79,7 +79,8 @@ export class CollectionSynchronizer extends Synchronizer {
    */
   async receiveMessage(message: DocMessage) {
     log(
-      `onSyncMessage: ${message.senderId}, ${message.documentId}, ${"data" in message ? message.data.byteLength + "bytes" : ""
+      `onSyncMessage: ${message.senderId}, ${message.documentId}, ${
+        "data" in message ? message.data.byteLength + "bytes" : ""
       }`
     )
 

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -12,7 +12,7 @@ describe("DocHandle", () => {
   const TEST_ID = parseAutomergeUrl(generateAutomergeUrl()).documentId
   const setup = (options?) => {
     const handle = new DocHandle<TestDoc>(TEST_ID, options)
-    handle.update( () => A.init() )
+    handle.update(() => A.init())
     handle.doneLoading()
     return handle
   }
@@ -58,7 +58,7 @@ describe("DocHandle", () => {
 
   it("should return the heads when requested", async () => {
     const handle = setup()
-    handle.change( d => d.foo = "bar")
+    handle.change(d => (d.foo = "bar"))
     assert.equal(handle.isReady(), true)
 
     const heads = A.getHeads(handle.docSync())
@@ -143,7 +143,7 @@ describe("DocHandle", () => {
 
   it("should emit a change message when changes happen", async () => {
     const handle = setup()
-    
+
     const p = new Promise<DocHandleChangePayload<TestDoc>>(resolve =>
       handle.once("change", d => resolve(d))
     )
@@ -174,7 +174,7 @@ describe("DocHandle", () => {
 
   it("should update the internal doc prior to emitting the change message", async () => {
     const handle = setup()
-    
+
     const p = new Promise<void>(resolve =>
       handle.once("change", ({ handle, doc }) => {
         assert.equal(handle.docSync()?.foo, doc.foo)
@@ -192,7 +192,7 @@ describe("DocHandle", () => {
 
   it("should emit distinct change messages when consecutive changes happen", async () => {
     const handle = setup()
-    
+
     let calls = 0
     const p = new Promise(resolve =>
       handle.on("change", async ({ doc: d }) => {
@@ -284,7 +284,7 @@ describe("DocHandle", () => {
 
   it("should not time out if the document is updated in time", async () => {
     // set docHandle time out after 5 ms
-    const handle = setup({timeoutDelay:1})
+    const handle = setup({ timeoutDelay: 1 })
 
     // simulate requesting from the network
     handle.request()

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -24,11 +24,11 @@ describe("DocSynchronizer", () => {
     const docId = parseAutomergeUrl(generateAutomergeUrl()).documentId
     handle = new DocHandle<TestDoc>(docId)
     handle.doneLoading()
-    
+
     docSynchronizer = new DocSynchronizer({
       handle: handle as DocHandle<unknown>,
     })
-    
+
     return { handle, docSynchronizer }
   }
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -198,8 +198,11 @@ describe("Repo", () => {
     it("doesn't find a document that doesn't exist", async () => {
       const { repo } = setup()
       const handle = repo.find<TestDoc>(generateAutomergeUrl())
-      assert.equal(handle.isReady(), false)
 
+      await handle.whenReady(["ready", "unavailable"])
+
+      assert.equal(handle.isReady(), false)
+      assert.equal(handle.state, "unavailable")
       const doc = await handle.doc()
       assert.equal(doc, undefined)
     })
@@ -221,6 +224,7 @@ describe("Repo", () => {
       handle.on("unavailable", () => {
         wasUnavailable = true
       })
+
       await pause(50)
       assert.equal(wasUnavailable, false)
 
@@ -399,6 +403,8 @@ describe("Repo", () => {
       handle.change(d => {
         d.count = 1
       })
+
+      await repo.flush()
 
       for (let i = 0; i < 3; i++) {
         const repo2 = new Repo({

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -490,8 +490,8 @@ describe("Repo", () => {
       let resume = (documentIds?: DocumentId[]) => {
         const savesToUnblock = documentIds
           ? Array.from(blockedSaves).filter(({ path }) =>
-            documentIds.some(documentId => path.includes(documentId))
-          )
+              documentIds.some(documentId => path.includes(documentId))
+            )
           : Array.from(blockedSaves)
         savesToUnblock.forEach(({ resolve }) => resolve())
       }
@@ -1029,9 +1029,9 @@ describe("Repo", () => {
         const doc =
           Math.random() < 0.5
             ? // heads, create a new doc
-            repo.create<TestDoc>()
+              repo.create<TestDoc>()
             : // tails, pick a random doc
-            (getRandomItem(docs) as DocHandle<TestDoc>)
+              (getRandomItem(docs) as DocHandle<TestDoc>)
 
         // make sure the doc is ready
         if (!doc.isReady()) {
@@ -1414,7 +1414,7 @@ describe("Repo", () => {
 })
 
 const warn = console.warn
-const NO_OP = () => { }
+const NO_OP = () => {}
 
 const disableConsoleWarn = () => {
   console.warn = NO_OP


### PR DESCRIPTION
This removes the AWAITING_NETWORK and NETWORK_READY states from DocHandle -- instead, the Repo just waits until the networksubsystem is in a sync-able state before triggering synchronization.

Note that this patch caused me to notice (but not yet fix) a subtle problem: if you have no local data AND you try but do not succeed in connecting to the network, you will never enter "unavailable" and your handle will lurk in "loading" forever more.

I suspect we can untangle that particular problem as we go on the cleanup but I wanted to note it.