### PR TITLE
make sure we start synchronising & save documents even if initially loaded from storage

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -441,8 +441,8 @@ export class Repo extends EventEmitter<RepoEvents> {
             .catch(err => {
               this.#log("error waiting for network", { err })
             })
-          this.emit("document", { handle })
         }
+        this.emit("document", { handle })
       })
     } else {
       handle.request()


### PR DESCRIPTION
We found using `IndexedDBStorageAdapter` storage adapter, documents wouldn't start syncing in case they were found in the storage. Equally, they wouldn't get stored to the storage system. 
I *think* there's a `document` event missing, which in the end adds the doc to both the storage & sync machinery.

This PR adds the missing event and a test.

I'm sure there's a better way for testing than hooking into the `document` event? Happy to adjust! 