### PR TITLE
fix: changes are not delivered after a sync message wasn't delivered

### DIFF
--- a/packages/automerge-repo/src/helpers/DummyNetworkAdapter.ts
+++ b/packages/automerge-repo/src/helpers/DummyNetworkAdapter.ts
@@ -5,10 +5,21 @@ export class DummyNetworkAdapter extends NetworkAdapter {
   #sendMessage?: SendMessageFn
 
   #ready = false
+  #isDroppingMessages = false;
   #readyResolver?: () => void
   #readyPromise: Promise<void> = new Promise<void>(resolve => {
     this.#readyResolver = resolve
   })
+
+  #droppedMessages: Message[] = [];
+
+  dropMessages(drop: boolean) {
+    this.#isDroppingMessages = drop;
+  }
+
+  getDroppedMessages() {
+    return [...this.#droppedMessages];
+  }
 
   isReady() {
     return this.#ready
@@ -49,11 +60,19 @@ export class DummyNetworkAdapter extends NetworkAdapter {
   }
 
   override send(message: Message) {
-    this.#sendMessage?.(message)
+    if (this.#isDroppingMessages) {
+      this.#droppedMessages.push(message);
+    } else {
+      this.#sendMessage?.(message)
+    }
   }
 
   receive(message: Message) {
-    this.emit("message", message)
+    if (this.#isDroppingMessages) {
+      this.#droppedMessages.push(message);
+    } else {
+      this.emit("message", message)
+    }
   }
 
   static createConnectedPair({ latency = 10 }: { latency?: number } = {}) {

--- a/packages/automerge-repo/src/helpers/DummyNetworkAdapter.ts
+++ b/packages/automerge-repo/src/helpers/DummyNetworkAdapter.ts
@@ -5,20 +5,20 @@ export class DummyNetworkAdapter extends NetworkAdapter {
   #sendMessage?: SendMessageFn
 
   #ready = false
-  #isDroppingMessages = false;
+  #isDroppingMessages = false
   #readyResolver?: () => void
   #readyPromise: Promise<void> = new Promise<void>(resolve => {
     this.#readyResolver = resolve
   })
 
-  #droppedMessages: Message[] = [];
+  #droppedMessages: Message[] = []
 
   dropMessages(drop: boolean) {
-    this.#isDroppingMessages = drop;
+    this.#isDroppingMessages = drop
   }
 
   getDroppedMessages() {
-    return [...this.#droppedMessages];
+    return [...this.#droppedMessages]
   }
 
   isReady() {
@@ -61,7 +61,7 @@ export class DummyNetworkAdapter extends NetworkAdapter {
 
   override send(message: Message) {
     if (this.#isDroppingMessages) {
-      this.#droppedMessages.push(message);
+      this.#droppedMessages.push(message)
     } else {
       this.#sendMessage?.(message)
     }
@@ -69,7 +69,7 @@ export class DummyNetworkAdapter extends NetworkAdapter {
 
   receive(message: Message) {
     if (this.#isDroppingMessages) {
-      this.#droppedMessages.push(message);
+      this.#droppedMessages.push(message)
     } else {
       this.emit("message", message)
     }

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -353,7 +353,7 @@ export class DocSynchronizer extends Synchronizer {
       this.#handle.update(doc => {
         // Retry if message sending failed.
         for (const need of A.decodeSyncMessage(message.data).need) {
-          delete syncState.sentHashes[need];
+          delete (syncState.sentHashes as any)[need]
         }
 
         const [newDoc, newSyncState] = A.receiveSyncMessage(

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -351,6 +351,11 @@ export class DocSynchronizer extends Synchronizer {
 
     this.#withSyncState(message.senderId, syncState => {
       this.#handle.update(doc => {
+        // Retry if message sending failed.
+        for (const need of A.decodeSyncMessage(message.data).need) {
+          delete syncState.sentHashes[need];
+        }
+
         const [newDoc, newSyncState] = A.receiveSyncMessage(
           doc,
           syncState,

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1275,6 +1275,82 @@ describe("Repo", () => {
     assert.equal(bobDoc.isReady(), true)
   })
 
+  it("changes get replicated after the next change if a sync message was dropped", async () => {
+    const alice = "alice" as PeerId
+    const bob = "bob" as PeerId
+    const [aliceAdapter, bobAdapter] = DummyNetworkAdapter.createConnectedPair()
+    const aliceRepo = new Repo({
+      network: [aliceAdapter],
+      peerId: alice,
+    })
+    const bobRepo = new Repo({
+      network: [bobAdapter],
+      peerId: bob,
+    })
+    aliceAdapter.peerCandidate(bob);
+    bobAdapter.peerCandidate(alice);
+
+    const bobHandle = bobRepo.create<TestDoc>()
+    bobHandle.change(d => {
+      d.foo = "bar"
+    })
+    const aliceHandle = await aliceRepo.find(bobHandle.documentId)
+    await eventPromise(aliceHandle, "heads-changed")
+    assert.deepEqual(aliceHandle.docSync(), bobHandle.docSync())
+
+    bobAdapter.dropMessages(true);
+    bobHandle.change(d => {
+      d.bar = "foo"
+    })
+    await pause(10);
+    assert.equal(bobAdapter.getDroppedMessages()[0].type, "sync");
+
+    bobAdapter.dropMessages(false);
+    bobHandle.change(d => {
+      d.baz = "42"
+    })
+    await eventPromise(aliceHandle, "heads-changed")
+  })
+
+  it("changes get replicated the peer's next change if a sync message was dropped", async () => {
+    const alice = "alice" as PeerId
+    const bob = "bob" as PeerId
+    const [aliceAdapter, bobAdapter] = DummyNetworkAdapter.createConnectedPair()
+    const aliceRepo = new Repo({
+      network: [aliceAdapter],
+      peerId: alice,
+    })
+    const bobRepo = new Repo({
+      network: [bobAdapter],
+      peerId: bob,
+    })
+    aliceAdapter.peerCandidate(bob);
+    bobAdapter.peerCandidate(alice);
+
+    const bobHandle = bobRepo.create<TestDoc>()
+    bobHandle.change(d => {
+      d.foo = "bar"
+    })
+    const aliceHandle = await aliceRepo.find(bobHandle.documentId)
+    await eventPromise(aliceHandle, "heads-changed")
+    assert.deepEqual(aliceHandle.docSync(), bobHandle.docSync())
+
+    bobAdapter.dropMessages(true);
+    bobHandle.change(d => {
+      d.bar = "foo"
+    })
+    await pause(10);
+    assert.equal(bobAdapter.getDroppedMessages()[0].type, "sync");
+
+    bobAdapter.dropMessages(false);
+    aliceHandle.change(d => {
+      d.baz = "42"
+    })
+    await eventPromise(bobHandle, "heads-changed")
+    await pause(200);
+    assert.deepEqual(aliceHandle.docSync(), bobHandle.docSync())
+  })
+
   describe("with peers (mesh network)", () => {
     const setup = async () => {
       // Set up three repos; connect Alice to Bob, Bob to Charlie, and Alice to Charlie

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1287,8 +1287,8 @@ describe("Repo", () => {
       network: [bobAdapter],
       peerId: bob,
     })
-    aliceAdapter.peerCandidate(bob);
-    bobAdapter.peerCandidate(alice);
+    aliceAdapter.peerCandidate(bob)
+    bobAdapter.peerCandidate(alice)
 
     const bobHandle = bobRepo.create<TestDoc>()
     bobHandle.change(d => {
@@ -1298,14 +1298,14 @@ describe("Repo", () => {
     await eventPromise(aliceHandle, "heads-changed")
     assert.deepEqual(aliceHandle.docSync(), bobHandle.docSync())
 
-    bobAdapter.dropMessages(true);
+    bobAdapter.dropMessages(true)
     bobHandle.change(d => {
       d.bar = "foo"
     })
-    await pause(10);
-    assert.equal(bobAdapter.getDroppedMessages()[0].type, "sync");
+    await pause(10)
+    assert.equal(bobAdapter.getDroppedMessages()[0].type, "sync")
 
-    bobAdapter.dropMessages(false);
+    bobAdapter.dropMessages(false)
     bobHandle.change(d => {
       d.baz = "42"
     })
@@ -1324,8 +1324,8 @@ describe("Repo", () => {
       network: [bobAdapter],
       peerId: bob,
     })
-    aliceAdapter.peerCandidate(bob);
-    bobAdapter.peerCandidate(alice);
+    aliceAdapter.peerCandidate(bob)
+    bobAdapter.peerCandidate(alice)
 
     const bobHandle = bobRepo.create<TestDoc>()
     bobHandle.change(d => {
@@ -1335,19 +1335,19 @@ describe("Repo", () => {
     await eventPromise(aliceHandle, "heads-changed")
     assert.deepEqual(aliceHandle.docSync(), bobHandle.docSync())
 
-    bobAdapter.dropMessages(true);
+    bobAdapter.dropMessages(true)
     bobHandle.change(d => {
       d.bar = "foo"
     })
-    await pause(10);
-    assert.equal(bobAdapter.getDroppedMessages()[0].type, "sync");
+    await pause(10)
+    assert.equal(bobAdapter.getDroppedMessages()[0].type, "sync")
 
-    bobAdapter.dropMessages(false);
+    bobAdapter.dropMessages(false)
     aliceHandle.change(d => {
       d.baz = "42"
     })
     await eventPromise(bobHandle, "heads-changed")
-    await pause(200);
+    await pause(200)
     assert.deepEqual(aliceHandle.docSync(), bobHandle.docSync())
   })
 


### PR DESCRIPTION
1. `syncState` is saved locally right after `A.generateSyncMessage`, even if the message delivery fails because there's no feedback from the network subsystem.
2. We'll get into an infinite loop of `sync` messages with the peer after they or us make the next change. `theirNeed` will be ignored because these hashes are true in `sentHashes`.
3. We won't send these changes until the Repo gets recreated (in-memory syncState gets lost and storage only has `sharedHeads`).

![image](https://github.com/user-attachments/assets/868cbdc2-58c0-4903-8d99-caefd8ed2b60)

Also I have a cast to any because the [real types](https://github.com/automerge/automerge/blob/main/rust/automerge-wasm/src/sync.rs#L38) are not what [the declaration](https://github.com/automerge/automerge/blob/main/rust/automerge-wasm/index.d.ts#L314) states. Some exposed fields are missing as well (inFlight, haveResponded).

In the tests I added:
1. Alice and Bob share a document.
2. Bob gets into a state where messages will fail and makes a change to the document.
3. Connectivity gets restored.
4. In the first test Bob makes another change. No changes are ever delivered to Alice.
5. In the second test Alice make a change and it gets delivered to Bob, but Bob's change never gets delivered to Alice.