### PR TITLE
failing test: loading empty doc from network

### DIFF
--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -153,6 +153,22 @@ describe("DocHandle", () => {
     assert.equal(doc?.foo, "bar")
   })
 
+  it("should become ready if the network returns an empty document", async () => {
+    const handle = new DocHandle<TestDoc>(TEST_ID)
+
+    // we don't have it in storage, so we request it from the network
+    handle.request()
+
+    // simulate updating from the network with an empty document
+    handle.update(doc => {
+      return A.init()
+    })
+
+    const doc = await handle.doc()
+    assert.equal(handle.isReady(), true)
+    assert.deepEqual(doc, {})
+  })
+
   it("should emit a change message when changes happen", async () => {
     const handle = setup()
 


### PR DESCRIPTION
In Jacquard, we have a use case where we sometimes try to load an empty doc from network. It's a metadata doc which sometimes has some stuff in it, but other times it starts out just being empty.

It turns out that if you do this, automerge-repo will never resolve the `.doc()` promise, so our app hangs. (This PR has a failing test for that)

The underlying cause is this code in DocHandle, which uses heads to decide whether to do a state transition:

```
 #checkForChanges(before: A.Doc<T>, after: A.Doc<T>) {
    const beforeHeads = A.getHeads(before)
    const afterHeads = A.getHeads(after)
    const docChanged = !headsAreSame(afterHeads, beforeHeads)
    if (docChanged) {
      this.emit("heads-changed", { handle: this, doc: after })
```

The "empty" handle pre-load has heads `[]`, and the doc loaded from network also has heads `[]`, so the state transition doesn't happen.

@joshuahhh and I got this far and we weren't sure what made sense to do next, thoughts @alexjg ?

For now we were able to workaround in our app by just making a change in the empty docs to avoid this case.