### PR TITLE
Remove .init call from fullfat.ts

### DIFF
--- a/packages/automerge-repo/src/entrypoints/fullfat.ts
+++ b/packages/automerge-repo/src/entrypoints/fullfat.ts
@@ -8,4 +8,3 @@ export * from "../index.js"
 //
 // eslint-disable-next-line automerge-slimport/enforce-automerge-slim-import
 import { next as Am } from "@automerge/automerge"
-Am.init()

--- a/packages/automerge-repo/src/entrypoints/fullfat.ts
+++ b/packages/automerge-repo/src/entrypoints/fullfat.ts
@@ -7,4 +7,4 @@ export * from "../index.js"
 // disable
 //
 // eslint-disable-next-line automerge-slimport/enforce-automerge-slim-import
-import { next as Am } from "@automerge/automerge"
+import "@automerge/automerge"


### PR DESCRIPTION
This has meant that `automerge-repo` couldn't even be _imported_ in an environment without access to `crypto.getRandomValues` (for example, outside the handler of a Cloudflare worker) because it needs to generate ids.

`init` is called correctly already any time a document is created or loaded, so this is only a bug fix and shouldn't have any other effects