### PR TITLE
Allow useDocuments to immediately return already-loaded documents

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocuments.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocuments.ts
@@ -17,7 +17,6 @@ import { useRepo } from "./useRepo.js"
  * for the output map.
  */
 export const useDocuments = <T>(idsOrUrls?: DocId[]) => {
-  const [documents, setDocuments] = useState({} as Record<DocumentId, T>)
   const repo = useRepo()
   const ids = useMemo(
     () =>
@@ -32,6 +31,16 @@ export const useDocuments = <T>(idsOrUrls?: DocId[]) => {
     [idsOrUrls]
   )
   const prevIds = useRef<DocumentId[]>([])
+  const [documents, setDocuments] = useState(() => {
+    return ids.reduce((docs, id) => {
+      const handle = repo.find<T>(id)
+      const doc = handle.docSync()
+      if (doc) {
+        docs[id] = doc
+      }
+      return docs
+    }, {} as Record<DocumentId, T>)
+  })
 
   useEffect(() => {
     // These listeners will live for the lifetime of this useEffect

--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -62,6 +62,18 @@ describe("useDocuments", () => {
     )
   })
 
+  it("returns a collection of loaded documents immediately, given a list of ids", async () => {
+    const { documentIds, wrapper } = setup()
+    const onDocs = vi.fn()
+
+    render(<Component idsOrUrls={documentIds} onDocs={onDocs} />, { wrapper })
+
+    expect(onDocs).not.toHaveBeenCalledWith({})
+    expect(onDocs).toHaveBeenCalledWith(
+      Object.fromEntries(documentIds.map((id, i) => [id, { foo: i }]))
+    )
+  })
+
   it("cleans up listeners properly", async () => {
     const { documentIds, wrapper, repo } = setup()
     const onDocs = vi.fn()


### PR DESCRIPTION
This is essentially the useDocuments counterpart of #318.