### PR TITLE
Update documentation of the wire protocol's `join` message

### DIFF
--- a/packages/automerge-repo-network-websocket/README.md
+++ b/packages/automerge-repo-network-websocket/README.md
@@ -27,12 +27,12 @@ Handshake is the following steps:
 
 - Once a connection is established the initiating peer sends a
   [join](#join) message with the `senderId` set to the initiating peers ID and
-  the `protocolVersion` set to "1"
+  a `supportedProtocolVersions` array containing "1"
 - The receiving peer waits until it receives a message from the initiating
   peer, if the initiating peer receives a message before sending the join message
   the initiating peer SHOULD terminate the connection.
 - When the receiving peer receives the join message
-  - if the `protocolVersion` is not "1" the receiving peer sends an
+  - if the `supportedProtocolVersions` does not contain "1" the receiving peer sends an
     [error](#error) message and terminates the connection
   - otherwise
     - store the `senderId` as the peer ID of the initiating peer

--- a/packages/automerge-repo-network-websocket/README.md
+++ b/packages/automerge-repo-network-websocket/README.md
@@ -119,7 +119,7 @@ Sent by the initiating peer in the [handshake](#handshake) phase.
 {
     type: "join",
     senderId: peer_id,
-    supportedProtocolVersions: protocol_version
+    supportedProtocolVersions: [protocol_version]
     ? metadata: peer_metadata,
 }
 ```


### PR DESCRIPTION
Reading the Automerge Repo's docs I noticed what I believe is a minor discrepancy between the documented protocol and the reality as codified by the implementation:

https://github.com/automerge/automerge-repo/blob/66b09d6f3662e16e0cd8e2cafef39ef5504104d6/packages/automerge-repo-network-websocket/src/messages.ts#L18

https://github.com/automerge/automerge-repo/blob/66b09d6f3662e16e0cd8e2cafef39ef5504104d6/packages/automerge-repo-network-websocket/src/BrowserWebSocketClientAdapter.ts#L223