### PR TITLE
Update useDocuments to return map keyed by AutomergeUrl

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocuments.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocuments.ts
@@ -5,108 +5,107 @@ import {
   DocHandleDeletePayload,
   DocumentId,
   isValidAutomergeUrl,
-  parseAutomergeUrl,
+  stringifyAutomergeUrl,
 } from "@automerge/automerge-repo/slim"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useRepo } from "./useRepo.js"
 
 /**
- * Maintains a map of document states, keyed by DocumentId. Useful for collections of related
+ * Maintains a map of document states, keyed by AutomergeUrl. Useful for collections of related
  * documents.
- * Accepts either URLs or document IDs in the input array, but all get converted to IDs
+ * Accepts either URLs or document IDs in the input array, but all get converted to URLs
  * for the output map.
  */
 export const useDocuments = <T>(idsOrUrls?: DocId[]) => {
   const repo = useRepo()
-  const ids = useMemo(
+  const urls = useMemo(
     () =>
       idsOrUrls?.map(idOrUrl => {
         if (isValidAutomergeUrl(idOrUrl)) {
-          const { documentId } = parseAutomergeUrl(idOrUrl)
-          return documentId
+          return idOrUrl as AutomergeUrl
         } else {
-          return idOrUrl as DocumentId
+          return stringifyAutomergeUrl(idOrUrl)
         }
       }) ?? [],
     [idsOrUrls]
   )
-  const prevIds = useRef<DocumentId[]>([])
+  const prevUrls = useRef<AutomergeUrl[]>([])
   const [documents, setDocuments] = useState(() => {
-    return ids.reduce((docs, id) => {
-      const handle = repo.find<T>(id)
+    return urls.reduce((docs, url) => {
+      const handle = repo.find<T>(url)
       const doc = handle.docSync()
       if (doc) {
-        docs[id] = doc
+        docs[url] = doc
       }
       return docs
-    }, {} as Record<DocumentId, T>)
+    }, {} as Record<AutomergeUrl, T>)
   })
 
   useEffect(() => {
     // These listeners will live for the lifetime of this useEffect
     // and be torn down when the useEffect is rerun.
-    const listeners = {} as Record<DocumentId, Listeners<T>>
-    const updateDocument = (id: DocId, doc?: T) => {
-      if (doc) setDocuments(docs => ({ ...docs, [id]: doc }))
+    const listeners = {} as Record<AutomergeUrl, Listeners<T>>
+    const updateDocument = (url: AutomergeUrl, doc?: T) => {
+      if (doc) setDocuments(docs => ({ ...docs, [url]: doc }))
     }
     const addListener = (handle: DocHandle<T>) => {
-      const id = handle.documentId
+      const url = stringifyAutomergeUrl(handle.documentId);
 
       // whenever a document changes, update our map
       const listenersForDoc: Listeners<T> = {
-        change: ({ doc }) => updateDocument(id, doc),
-        delete: () => removeDocument(id),
+        change: ({ doc }) => updateDocument(url, doc),
+        delete: () => removeDocument(url),
       }
       handle.on("change", listenersForDoc.change)
       handle.on("delete", listenersForDoc.delete)
 
       // store the listener so we can remove it later
-      listeners[id] = listenersForDoc
+      listeners[url] = listenersForDoc
     }
 
-    const removeDocument = (id: DocumentId) => {
+    const removeDocument = (url: AutomergeUrl) => {
       // remove the document from the document map
       setDocuments(docs => {
-        const { [id]: _removedDoc, ...remainingDocs } = docs
+        const { [url]: _removedDoc, ...remainingDocs } = docs
         return remainingDocs
       })
     }
 
     // Add a new document to our map
-    const addNewDocument = (id: DocumentId) => {
-      const handle = repo.find<T>(id)
+    const addNewDocument = (url: AutomergeUrl) => {
+      const handle = repo.find<T>(url)
       if (handle.docSync()) {
-        updateDocument(id, handle.docSync())
+        updateDocument(url, handle.docSync())
         addListener(handle)
       } else {
         // As each document loads, update our map
         handle
           .doc()
           .then(doc => {
-            updateDocument(id, doc)
+            updateDocument(url, doc)
             addListener(handle)
           })
           .catch(err => {
-            console.error(`Error loading document ${id} in useDocuments: `, err)
+            console.error(`Error loading document ${url} in useDocuments: `, err)
           })
       }
     }
 
     const teardown = () => {
-      Object.entries(listeners).forEach(([id, listeners]) => {
-        const handle = repo.find<T>(id as DocId)
+      Object.entries(listeners).forEach(([url, listeners]) => {
+        const handle = repo.find<T>(url as AutomergeUrl)
         handle.off("change", listeners.change)
         handle.off("delete", listeners.delete)
       })
     }
 
-    if (!ids) {
+    if (!urls) {
       return teardown
     }
 
-    for (const id of ids) {
-      const handle = repo.find<T>(id)
-      if (prevIds.current.includes(id)) {
+    for (const url of urls) {
+      const handle = repo.find<T>(url)
+      if (prevUrls.current.includes(url)) {
         // the document was already in our list before.
         // we only need to register new listeners.
         addListener(handle)
@@ -114,19 +113,19 @@ export const useDocuments = <T>(idsOrUrls?: DocId[]) => {
         // This is a new document that was not in our list before.
         // We need to update its state in the documents array and register
         // new listeners.
-        addNewDocument(id)
+        addNewDocument(url)
       }
     }
 
     // remove any documents that are no longer in the list
-    const removedIds = prevIds.current.filter(id => !ids.includes(id))
-    removedIds.forEach(removeDocument)
+    const removedUrls = prevUrls.current.filter(url => !urls.includes(url))
+    removedUrls.forEach(removeDocument)
 
-    // Update the ref so we remember the old IDs for next time
-    prevIds.current = ids
+    // Update the ref so we remember the old URLs for next time
+    prevUrls.current = urls
 
     return teardown
-  }, [ids, repo])
+  }, [urls, repo])
 
   return documents
 }

--- a/packages/automerge-repo-react-hooks/src/useDocuments.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocuments.ts
@@ -49,7 +49,7 @@ export const useDocuments = <T>(idsOrUrls?: DocId[]) => {
       if (doc) setDocuments(docs => ({ ...docs, [url]: doc }))
     }
     const addListener = (handle: DocHandle<T>) => {
-      const url = stringifyAutomergeUrl(handle.documentId);
+      const url = stringifyAutomergeUrl(handle.documentId)
 
       // whenever a document changes, update our map
       const listenersForDoc: Listeners<T> = {
@@ -86,7 +86,10 @@ export const useDocuments = <T>(idsOrUrls?: DocId[]) => {
             addListener(handle)
           })
           .catch(err => {
-            console.error(`Error loading document ${url} in useDocuments: `, err)
+            console.error(
+              `Error loading document ${url} in useDocuments: `,
+              err
+            )
           })
       }
     }

--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -1,6 +1,7 @@
 import {
   AutomergeUrl,
   DocumentId,
+  parseAutomergeUrl,
   PeerId,
   Repo,
   stringifyAutomergeUrl,
@@ -28,14 +29,14 @@ describe("useDocuments", () => {
 
     let documentValues: Record<string, any> = {}
 
-    const documentIds = range(10).map(i => {
+    const documentUrls = range(10).map(i => {
       const value = { foo: i }
       const handle = repo.create(value)
       documentValues[handle.documentId] = value
-      return handle.documentId
+      return stringifyAutomergeUrl(handle.documentId)
     })
 
-    return { repo, wrapper, documentIds, documentValues }
+    return { repo, wrapper, documentUrls, documentValues }
   }
 
   const Component = ({
@@ -50,32 +51,32 @@ describe("useDocuments", () => {
     return null
   }
 
-  it("returns a collection of documents, given a list of ids", async () => {
-    const { documentIds, wrapper } = setup()
+  it("returns a collection of documents, given a list of urls", async () => {
+    const { documentUrls, wrapper } = setup()
     const onDocs = vi.fn()
 
-    render(<Component idsOrUrls={documentIds} onDocs={onDocs} />, { wrapper })
+    render(<Component idsOrUrls={documentUrls} onDocs={onDocs} />, { wrapper })
     await waitFor(() =>
       expect(onDocs).toHaveBeenCalledWith(
-        Object.fromEntries(documentIds.map((id, i) => [id, { foo: i }]))
+        Object.fromEntries(documentUrls.map((url, i) => [url, { foo: i }]))
       )
     )
   })
 
-  it("returns a collection of loaded documents immediately, given a list of ids", async () => {
-    const { documentIds, wrapper } = setup()
+  it("returns a collection of loaded documents immediately, given a list of urls", async () => {
+    const { documentUrls, wrapper } = setup()
     const onDocs = vi.fn()
 
-    render(<Component idsOrUrls={documentIds} onDocs={onDocs} />, { wrapper })
+    render(<Component idsOrUrls={documentUrls} onDocs={onDocs} />, { wrapper })
 
     expect(onDocs).not.toHaveBeenCalledWith({})
     expect(onDocs).toHaveBeenCalledWith(
-      Object.fromEntries(documentIds.map((id, i) => [id, { foo: i }]))
+      Object.fromEntries(documentUrls.map((id, i) => [id, { foo: i }]))
     )
   })
 
   it("cleans up listeners properly", async () => {
-    const { documentIds, wrapper, repo } = setup()
+    const { documentUrls, wrapper, repo } = setup()
     const onDocs = vi.fn()
 
     // The goal here is to check that we're not leaking listeners.
@@ -84,14 +85,14 @@ describe("useDocuments", () => {
     const numMounts = 5 // arbitrary number here
     for (let i = 0; i < numMounts; i++) {
       const { unmount } = render(
-        <Component idsOrUrls={documentIds} onDocs={onDocs} />,
+        <Component idsOrUrls={documentUrls} onDocs={onDocs} />,
         { wrapper }
       )
       await waitFor(() => unmount())
     }
 
-    for (const id of documentIds) {
-      const handle = repo.find(id)
+    for (const url of documentUrls) {
+      const handle = repo.find(url)
 
       // You might expect we'd check that it's equal to 0 here.
       // but it turns out that automerge-repo registers an internal
@@ -104,109 +105,109 @@ describe("useDocuments", () => {
   })
 
   it("updates documents when they change", async () => {
-    const { repo, documentIds, wrapper } = setup()
+    const { repo, documentUrls, wrapper } = setup()
     const onDocs = vi.fn()
-
-    render(<Component idsOrUrls={documentIds} onDocs={onDocs} />, { wrapper })
-    await waitFor(() =>
-      expect(onDocs).toHaveBeenCalledWith(
-        Object.fromEntries(documentIds.map((id, i) => [id, { foo: i }]))
-      )
-    )
-
-    act(() => {
-      // multiply the value of foo in each document by 10
-      documentIds.forEach(id => {
-        const handle = repo.find(id)
-        handle.change(s => (s.foo *= 10))
-      })
-    })
-    await waitFor(() =>
-      expect(onDocs).toHaveBeenCalledWith(
-        Object.fromEntries(documentIds.map((id, i) => [id, { foo: i * 10 }]))
-      )
-    )
-  })
-
-  it("updates documents when they change, if URLs are passed in", async () => {
-    const { repo, documentIds, wrapper } = setup()
-    const onDocs = vi.fn()
-    const documentUrls = documentIds.map(id => stringifyAutomergeUrl(id))
 
     render(<Component idsOrUrls={documentUrls} onDocs={onDocs} />, { wrapper })
     await waitFor(() =>
       expect(onDocs).toHaveBeenCalledWith(
-        Object.fromEntries(documentIds.map((id, i) => [id, { foo: i }]))
+        Object.fromEntries(documentUrls.map((id, i) => [id, { foo: i }]))
       )
     )
 
     act(() => {
       // multiply the value of foo in each document by 10
-      documentIds.forEach(id => {
-        const handle = repo.find(id)
+      documentUrls.forEach(url => {
+        const handle = repo.find(url)
         handle.change(s => (s.foo *= 10))
       })
     })
     await waitFor(() =>
       expect(onDocs).toHaveBeenCalledWith(
-        Object.fromEntries(documentIds.map((id, i) => [id, { foo: i * 10 }]))
+        Object.fromEntries(documentUrls.map((id, i) => [id, { foo: i * 10 }]))
       )
     )
   })
 
-  it(`removes documents when they're removed from the list of ids`, async () => {
-    const { documentIds, wrapper } = setup()
+  it("updates documents when they change, if ids are passed in", async () => {
+    const { repo, documentUrls, wrapper } = setup()
+    const onDocs = vi.fn()
+    const documentIds = documentUrls.map(url => parseAutomergeUrl(url).documentId);
+
+    render(<Component idsOrUrls={documentIds} onDocs={onDocs} />, { wrapper })
+    await waitFor(() =>
+      expect(onDocs).toHaveBeenCalledWith(
+        Object.fromEntries(documentUrls.map((url, i) => [url, { foo: i }]))
+      )
+    )
+
+    act(() => {
+      // multiply the value of foo in each document by 10
+      documentUrls.forEach(url => {
+        const handle = repo.find(url)
+        handle.change(s => (s.foo *= 10))
+      })
+    })
+    await waitFor(() =>
+      expect(onDocs).toHaveBeenCalledWith(
+        Object.fromEntries(documentUrls.map((url, i) => [url, { foo: i * 10 }]))
+      )
+    )
+  })
+
+  it(`removes documents when they're removed from the list of URLs`, async () => {
+    const { documentUrls, wrapper } = setup()
     const onDocs = vi.fn()
 
     const { rerender } = render(
-      <Component idsOrUrls={documentIds} onDocs={onDocs} />,
+      <Component idsOrUrls={documentUrls} onDocs={onDocs} />,
       { wrapper }
     )
     await waitFor(() =>
       expect(onDocs).toHaveBeenCalledWith(
-        Object.fromEntries(documentIds.map((id, i) => [id, { foo: i }]))
+        Object.fromEntries(documentUrls.map((id, i) => [id, { foo: i }]))
       )
     )
 
     // remove the first document
-    rerender(<Component idsOrUrls={documentIds.slice(1)} onDocs={onDocs} />)
+    rerender(<Component idsOrUrls={documentUrls.slice(1)} onDocs={onDocs} />)
     // 👆 Note that this only works because documentIds.slice(1) is a different
     // object from documentIds. If we modified documentIds directly, the hook
     // wouldn't re-run.
     await waitFor(() =>
       expect(onDocs).toHaveBeenCalledWith(
         Object.fromEntries(
-          documentIds.map((id, i) => [id, { foo: i }]).slice(1)
+          documentUrls.map((id, i) => [id, { foo: i }]).slice(1)
         )
       )
     )
   })
 
   it(`keeps updating documents after the list has changed`, async () => {
-    const { documentIds, wrapper, repo } = setup()
+    const { documentUrls, wrapper, repo } = setup()
     const onDocs = vi.fn()
 
     const { rerender } = render(
-      <Component idsOrUrls={documentIds} onDocs={onDocs} />,
+      <Component idsOrUrls={documentUrls} onDocs={onDocs} />,
       { wrapper }
     )
     await waitFor(() =>
       expect(onDocs).toHaveBeenCalledWith(
-        Object.fromEntries(documentIds.map((id, i) => [id, { foo: i }]))
+        Object.fromEntries(documentUrls.map((url, i) => [url, { foo: i }]))
       )
     )
 
     // remove the first document
     act(() => {
-      rerender(<Component idsOrUrls={documentIds.slice(1)} onDocs={onDocs} />)
+      rerender(<Component idsOrUrls={documentUrls.slice(1)} onDocs={onDocs} />)
     })
-    // 👆 Note that this only works because documentIds.slice(1) is a different
-    // object from documentIds. If we modified documentIds directly, the hook
+    // 👆 Note that this only works because documentUrls.slice(1) is a different
+    // object from documentUrls. If we modified documentUrls directly, the hook
     // wouldn't re-run.
     await waitFor(() =>
       expect(onDocs).toHaveBeenCalledWith(
         Object.fromEntries(
-          documentIds.map((id, i) => [id, { foo: i }]).slice(1)
+          documentUrls.map((url, i) => [url, { foo: i }]).slice(1)
         )
       )
     )
@@ -215,8 +216,8 @@ describe("useDocuments", () => {
 
     act(() => {
       // multiply the value of foo in each document by 10
-      documentIds.slice(1).forEach(id => {
-        const handle = repo.find(id)
+      documentUrls.slice(1).forEach(url => {
+        const handle = repo.find(url)
         handle.change(s => (s.foo *= 10))
       })
     })
@@ -224,15 +225,15 @@ describe("useDocuments", () => {
     await waitFor(() =>
       expect(onDocs).toHaveBeenCalledWith(
         Object.fromEntries(
-          documentIds.map((id, i) => [id, { foo: i * 10 }]).slice(1)
+          documentUrls.map((url, i) => [url, { foo: i * 10 }]).slice(1)
         )
       )
     )
 
     act(() => {
       // multiply the value of foo in each document by 10
-      documentIds.slice(1).forEach(id => {
-        const handle = repo.find(id)
+      documentUrls.slice(1).forEach(url => {
+        const handle = repo.find(url)
         handle.change(s => (s.foo *= 10))
       })
     })
@@ -240,7 +241,7 @@ describe("useDocuments", () => {
     await waitFor(() => {
       expect(onDocs).toHaveBeenCalledWith(
         Object.fromEntries(
-          documentIds.map((id, i) => [id, { foo: i * 100 }]).slice(1)
+          documentUrls.map((url, i) => [url, { foo: i * 100 }]).slice(1)
         )
       )
     })

--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -132,7 +132,9 @@ describe("useDocuments", () => {
   it("updates documents when they change, if ids are passed in", async () => {
     const { repo, documentUrls, wrapper } = setup()
     const onDocs = vi.fn()
-    const documentIds = documentUrls.map(url => parseAutomergeUrl(url).documentId);
+    const documentIds = documentUrls.map(
+      url => parseAutomergeUrl(url).documentId
+    )
 
     render(<Component idsOrUrls={documentIds} onDocs={onDocs} />, { wrapper })
     await waitFor(() =>


### PR DESCRIPTION
The recommended mechanism seems to be to store Automerge URLs when referencing other documents, not just plain document ids, so it seems more natural to key the map returned from useDocuments by URL rather than by id.

See discussion in https://discord.com/channels/1200006940210757672/1202325266937159690/1277333966575374356