### PR TITLE
Add support for removing doc handle from handleCache

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -546,7 +546,17 @@ export class Repo extends EventEmitter<RepoEvents> {
     )
   }
 
+  /**
+   * Removes a DocHandle from the handleCache.
+   * @hidden this API is experimental and may change.
+   * @param documentId - documentId of the DocHandle to remove from handleCache, if present in cache.
+   * @returns Promise<void>
+   */
   async removeFromCache(documentId: DocumentId) {
+    if (!this.#handleCache[documentId]){
+      this.#log(`WARN: removeFromCache called but handle not found in handleCache for documentId: ${documentId}`)
+      return
+    }
     const handle = this.#getHandle({ documentId })
     const doc = await handle.doc([READY, UNLOADED, DELETED, UNAVAILABLE])
     if (doc) {

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -553,8 +553,10 @@ export class Repo extends EventEmitter<RepoEvents> {
    * @returns Promise<void>
    */
   async removeFromCache(documentId: DocumentId) {
-    if (!this.#handleCache[documentId]){
-      this.#log(`WARN: removeFromCache called but handle not found in handleCache for documentId: ${documentId}`)
+    if (!this.#handleCache[documentId]) {
+      this.#log(
+        `WARN: removeFromCache called but handle not found in handleCache for documentId: ${documentId}`
+      )
       return
     }
     const handle = this.#getHandle({ documentId })

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -486,6 +486,31 @@ describe("Repo", () => {
       const doc = await handle.doc()
       expect(doc).toEqual({})
     })
+
+    describe("handle cache", () => {
+      it("contains doc handle", async () => {
+        const { repo } = setup()
+        const handle = repo.create({ foo: "bar" })
+        await handle.doc()
+        assert(repo.handles[handle.documentId])
+      })
+
+      it("delete removes doc handle", async () => {
+        const { repo } = setup()
+        const handle = repo.create({ foo: "bar" })
+        await handle.doc()
+        await repo.delete(handle.documentId)
+        assert(repo.handles[handle.documentId] === undefined)
+      })
+
+      it("removeFromCache removes doc handle", async () => {
+        const { repo } = setup()
+        const handle = repo.create({ foo: "bar" })
+        await handle.doc()
+        await repo.removeFromCache(handle.documentId)
+        assert(repo.handles[handle.documentId] === undefined)
+      })
+    })
   })
 
   describe("flush behaviour", () => {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -510,6 +510,14 @@ describe("Repo", () => {
         await repo.removeFromCache(handle.documentId)
         assert(repo.handles[handle.documentId] === undefined)
       })
+
+      it("removeFromCache for documentId not found", async () => {
+        const { repo } = setup()
+        const badDocumentId = "badbadbad" as DocumentId
+        const handleCacheSize = Object.keys(repo.handles).length
+        await repo.removeFromCache(badDocumentId)
+        assert(Object.keys(repo.handles).length === handleCacheSize)
+      })
     })
   })
 


### PR DESCRIPTION
**Summary:**
Add support for removing doc handle from handleCache to free memory, without deleting document from storage.

**Issue:**
https://github.com/automerge/automerge-repo/issues/330

**Background:**
After creating enough documents in a repo, out of memory errors will cause a synch server to crash because memory isn't being freed. Repo holds references to each DocHandle in handleCache and each DocHandle holds a reference to the automerge doc.

**Next steps:**
Once `removeFromCache` is added, it can be called from the Repo and/or synch server to free memory usage (that code must determine that the doc handle is safe to be removed from cache at that time).
