### PR TITLE
Refactor the storage adapter tests to use a `beforeEach` hook

### DIFF
--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -1,4 +1,4 @@
-import { describe, expect, beforeEach, test } from "vitest"
+import { describe, expect, beforeEach, it as _it } from "vitest"
 
 import type { StorageAdapterInterface } from "../../storage/StorageAdapterInterface.js"
 
@@ -12,7 +12,7 @@ type AdapterTestContext = {
   adapter: StorageAdapterInterface
 }
 
-const it = test<AdapterTestContext>
+const it = _it<AdapterTestContext>
 
 export function runStorageAdapterTests(setup: SetupFn, title?: string): void {
   beforeEach<AdapterTestContext>(async ctx => {


### PR DESCRIPTION
To implement tests of a storage which use async APIs, I need the `teardown` function to be able to return a promise which gets awaited. I also took the liberty to refactor the tests a bit to use a `beforeEach` hook instead of calling `setup` and `teardown` in each of the tests. This ensures the `teardown` gets called even if the test fails. In the current state, this isn't the case since something throwing in the test could prevent the call to `teardown`.