### PR TITLE
Slightly improved tests for loadRange method

### DIFF
--- a/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
@@ -67,20 +67,16 @@ export function runStorageAdapterTests(setup: SetupFn, title?: string): void {
         await adapter.save(["AAAAA", "snapshot", "yyyyy"], PAYLOAD_B())
         await adapter.save(["AAAAA", "sync-state", "zzzzz"], PAYLOAD_C())
 
-        expect(await adapter.loadRange(["AAAAA"])).toStrictEqual(
-          expect.arrayContaining([
-            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A() },
-            { key: ["AAAAA", "snapshot", "yyyyy"], data: PAYLOAD_B() },
-            { key: ["AAAAA", "sync-state", "zzzzz"], data: PAYLOAD_C() },
-          ])
-        )
+        expect(await adapter.loadRange(["AAAAA"])).toStrictEqual([
+          { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A() },
+          { key: ["AAAAA", "snapshot", "yyyyy"], data: PAYLOAD_B() },
+          { key: ["AAAAA", "sync-state", "zzzzz"], data: PAYLOAD_C() },
+        ])
 
-        expect(await adapter.loadRange(["AAAAA", "sync-state"])).toStrictEqual(
-          expect.arrayContaining([
-            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A() },
-            { key: ["AAAAA", "sync-state", "zzzzz"], data: PAYLOAD_C() },
-          ])
-        )
+        expect(await adapter.loadRange(["AAAAA", "sync-state"])).toStrictEqual([
+          { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A() },
+          { key: ["AAAAA", "sync-state", "zzzzz"], data: PAYLOAD_C() },
+        ])
       })
 
       it("should only load values that match they key", async ({ adapter }) => {
@@ -88,16 +84,9 @@ export function runStorageAdapterTests(setup: SetupFn, title?: string): void {
         await adapter.save(["BBBBB", "sync-state", "zzzzz"], PAYLOAD_C())
 
         const actual = await adapter.loadRange(["AAAAA"])
-        expect(actual).toStrictEqual(
-          expect.arrayContaining([
-            { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A() },
-          ])
-        )
-        expect(actual).toStrictEqual(
-          expect.not.arrayContaining([
-            { key: ["BBBBB", "sync-state", "zzzzz"], data: PAYLOAD_C() },
-          ])
-        )
+        expect(actual).toStrictEqual([
+          { key: ["AAAAA", "sync-state", "xxxxx"], data: PAYLOAD_A() },
+        ])
       })
     })
 


### PR DESCRIPTION
This PR is more a question then a suggestion.

The question: should we care about an order in which `StorageAdapterInterface.loadRange` returns data?

When I utilized `expect.arrayContaining` in this commit https://github.com/bijela-gora/automerge-repo/commit/3238d7a6e2a7f8563aed17b554996c3c329894a8 to automerge-repo I'm sure I didn't consider that. Now, I'm not even sure why I used that asymmetric matcher. The `expect.arrayContaining` does not care about an order of elements inside arrays:
```javascript
describe('expect.arrayContaining', () => {
	it("doesn't care about order", () => {
		expect([0, 1, 2]).toEqual(expect.arrayContaining([2, 0]))
	})
})
```

I noticed that a day ago when I was trying to make a storage adapter based on `node:sqlite`. For some reasons `better-sqlite3` and `node:sqlite` for the same SQL statement returns results ordered differently. I tested that with latest version of better-sqlite3 and with latest Node.js because latest versions uses [the](https://github.com/WiseLibs/better-sqlite3/commit/8b584ef6a15caecf2b121a0891aa70d6e56f4f8f) [same](https://github.com/nodejs/node/commit/3caf29ea8869d4668193111ebdd390b63d7942dc) SQLite version