### PR TITLE
Add a denylist of automerge URLs to Repo constructor

### DIFF
--- a/packages/automerge-repo/src/synchronizer/Synchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/Synchronizer.ts
@@ -25,10 +25,15 @@ export interface SyncStatePayload {
   syncState: SyncState
 }
 
-export type DocSyncMetrics = {
-  type: "receive-sync-message"
-  documentId: DocumentId
-  durationMillis: number
-  numOps: number
-  numChanges: number
-}
+export type DocSyncMetrics =
+  | {
+      type: "receive-sync-message"
+      documentId: DocumentId
+      durationMillis: number
+      numOps: number
+      numChanges: number
+    }
+  | {
+      type: "doc-denied"
+      documentId: DocumentId
+    }


### PR DESCRIPTION
Problem: some documents can consume so much memory at runtime and require so long to load that they render a server unresponsive.

Solution: add a denylist argument to Repo which contains a list of documents that the repo will not attempt to load when receiving sync messages. This is a fairly hacky stop-gap solution, but it is _a_ solution.