### PR TITLE
Fix memoization of ids in useDocuments.ts

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocuments.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocuments.ts
@@ -28,7 +28,7 @@ export const useDocuments = <T>(idsOrUrls?: DocId[]) => {
           return idOrUrl as DocumentId
         }
       }) ?? [],
-    idsOrUrls
+    idsOrUrls ?? []
   )
   const prevIds = useRef<DocumentId[]>([])
   const [documents, setDocuments] = useState(() => {

--- a/packages/automerge-repo-react-hooks/src/useDocuments.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocuments.ts
@@ -28,7 +28,7 @@ export const useDocuments = <T>(idsOrUrls?: DocId[]) => {
           return idOrUrl as DocumentId
         }
       }) ?? [],
-    [idsOrUrls]
+    idsOrUrls
   )
   const prevIds = useRef<DocumentId[]>([])
   const [documents, setDocuments] = useState(() => {


### PR DESCRIPTION
Right now, useDocuments tries to memoize the list of ids/urls argument as it normalizes it to ids to avoid doing unnecessary work if the list is not changing. However, it does this by passing the ids as a member of the useMemo dependencies array. If callers are passing the array as a literal, this will create a new array on every render, and the memoization won't accomplish anything.

To avoid this, we could spread the array to add its members (the real dependencies) to our useMemo dependencies, but since there are no other dependencies, we can pass the ids array itself instead.