### PR TITLE
Export missing types from NetworkSubsystem

### DIFF
--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -78,6 +78,11 @@ export type {
 } from "./network/NetworkAdapterInterface.js"
 
 export type {
+  NetworkSubsystemEvents,
+  PeerPayload,
+} from "./network/NetworkSubsystem.js"
+
+export type {
   DocumentUnavailableMessage,
   EphemeralMessage,
   Message,


### PR DESCRIPTION
I bumped into a situation where I needed the `PeerPayload` type for the "peer" network subsystem event.