### PR TITLE
Let's make find synchronous again, why not?

### DIFF
--- a/packages/automerge-repo-react-hooks/src/helpers/DummyNetworkAdapter.ts
+++ b/packages/automerge-repo-react-hooks/src/helpers/DummyNetworkAdapter.ts
@@ -1,0 +1,67 @@
+import { Message, NetworkAdapter, PeerId } from "@automerge/automerge-repo/slim"
+
+export const pause = (t = 0) =>
+  new Promise<void>(resolve => setTimeout(() => resolve(), t))
+
+type SendMessageFn = (message: Message) => void
+
+export class DummyNetworkAdapter extends NetworkAdapter {
+  #sendMessage: SendMessageFn
+  #ready = false
+  #readyResolver: ((value: void) => void) | undefined
+  #readyPromise = new Promise(resolve => {
+    this.#readyResolver = resolve
+  })
+  isReady() {
+    return this.#ready
+  }
+  // @ts-expect-error ah whatever
+  whenReady() {
+    return this.#readyPromise
+  }
+  #forceReady() {
+    if (!this.#ready) {
+      this.#ready = true
+      this.#readyResolver?.()
+    }
+  }
+  // A public wrapper for use in tests!
+  forceReady() {
+    this.#forceReady()
+  }
+  constructor(
+    opts = { startReady: true, sendMessage: (_message: Message) => {} }
+  ) {
+    super()
+    if (opts.startReady) {
+      this.#forceReady()
+    }
+    this.#sendMessage = opts.sendMessage
+  }
+  connect(peerId: PeerId) {
+    this.peerId = peerId
+  }
+  disconnect() {}
+  peerCandidate(peerId: PeerId) {
+    this.emit("peer-candidate", { peerId, peerMetadata: {} })
+  }
+  send(message: Message) {
+    this.#sendMessage?.(message)
+  }
+  receive(message: Message) {
+    this.emit("message", message)
+  }
+  static createConnectedPair({ latency = 10 } = {}) {
+    const adapter1 = new DummyNetworkAdapter({
+      startReady: true,
+      sendMessage: (message: Message) =>
+        pause(latency).then(() => adapter2.receive(message)),
+    })
+    const adapter2 = new DummyNetworkAdapter({
+      startReady: true,
+      sendMessage: message =>
+        pause(latency).then(() => adapter1.receive(message)),
+    })
+    return [adapter1, adapter2]
+  }
+}


### PR DESCRIPTION
When we already have the document loaded, ideally we don't want to suspend. This patch is close to accomplishing that but has an unexplained exception leaking from abortable().