### PR TITLE
Don't use `/next` subpath export from `@automerge/automerge`

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -1,4 +1,4 @@
-import * as A from "@automerge/automerge/slim/next"
+import { next as A } from "@automerge/automerge/slim"
 import debug from "debug"
 import { EventEmitter } from "eventemitter3"
 import { assertEvent, assign, createActor, setup, waitFor } from "xstate"

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -43,6 +43,7 @@ export type { NetworkAdapterInterface } from "./network/NetworkAdapterInterface.
 export { isRepoMessage } from "./network/messages.js"
 export { StorageAdapter } from "./storage/StorageAdapter.js"
 export type { StorageAdapterInterface } from "./storage/StorageAdapterInterface.js"
+import { next as Automerge } from "@automerge/automerge/slim"
 
 /** @hidden **/
 export * as cbor from "./helpers/cbor.js"
@@ -101,46 +102,59 @@ export type {
 
 export * from "./types.js"
 
-// export commonly used data types
-export { Counter, RawString } from "@automerge/automerge/slim/next"
-
-// export some automerge API types
-export type {
-  Doc,
-  Heads,
-  Patch,
-  PatchCallback,
-  Prop,
-  ActorId,
-  Change,
-  ChangeFn,
-  Mark,
-  MarkSet,
-  MarkRange,
-  MarkValue,
-  Cursor,
-} from "@automerge/automerge/slim/next"
+// Automerge re-exports
+//
+// Note that we can't use export type { .. } from "@automerge/automerge" because we are
+// importing automerge like this:
+//
+// import { next as Automerge } from "@automerge/automerge"
+//
+// I.e. we are using the `next` export from Automerge. Not the module itself. This is
+// to maintain compatiblity with Automerge 3.0 and 2.0. In 2.0 we used to have a
+// subpath export at `/next` so the re-exports looked like this:
+//
+// export { type .. } from "@automerge/automerge/slim/next"
+//
+// However, we have now removed the subpath export (and deprecated next generally)
+// so we need to explicitly name each type we are re-exporting here.
+export const Counter = Automerge.Counter
+export const RawString = Automerge.RawString
+// In automerge 3.0 RawString is renamed to ImmutableString
+export const ImmutableString = Automerge.RawString
+export type Counter = Automerge.Counter
+export type Doc<T> = Automerge.Doc<T>
+export type Heads = Automerge.Heads
+export type Patch = Automerge.Patch
+export type PatchCallback<T> = Automerge.PatchCallback<T>
+export type Prop = Automerge.Prop
+export type ActorId = Automerge.ActorId
+export type Change = Automerge.Change
+export type ChangeFn<T> = Automerge.ChangeFn<T>
+export type Mark = Automerge.Mark
+export type MarkSet = Automerge.MarkSet
+export type MarkRange = Automerge.MarkRange
+export type MarkValue = Automerge.MarkValue
+export type Cursor = Automerge.Cursor
 
 // export a few utility functions that aren't in automerge-repo
 // NB that these should probably all just be available via the dochandle
-export {
-  getChanges,
-  getAllChanges,
-  applyChanges,
-  view,
-  getConflicts,
-} from "@automerge/automerge/slim/next"
+export const getChanges = Automerge.getChanges
+export const getAllChanges = Automerge.getAllChanges
+export const applyChanges = Automerge.applyChanges
+export const view = Automerge.view
+export const getConflicts = Automerge.getConflicts
 
 // export type-specific utility functions
 // these mostly can't be on the data-type in question because
 // JS strings can't have methods added to them
-export {
-  getCursor,
-  getCursorPosition,
-  splice,
-  updateText,
-  insertAt,
-  deleteAt,
-  mark,
-  unmark,
-} from "@automerge/automerge/slim/next"
+export const getCursor = Automerge.getCursor
+export const getCursorPosition = Automerge.getCursorPosition
+export const splice = Automerge.splice
+export const updateText = Automerge.updateText
+export const insertAt = Automerge.insertAt
+export const deleteAt = Automerge.deleteAt
+export const mark = Automerge.mark
+export const unmark = Automerge.unmark
+export const isRawString = Automerge.isRawString
+// In Automerge 3.0 raw string is renamed to immutable string
+export const isImmutableString = Automerge.isRawString

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -1,4 +1,4 @@
-import * as A from "@automerge/automerge/slim/next"
+import { next as A } from "@automerge/automerge/slim"
 import debug from "debug"
 import { headsAreSame } from "../helpers/headsAreSame.js"
 import { mergeArrays } from "../helpers/mergeArrays.js"

--- a/packages/automerge-repo/src/storage/keyHash.ts
+++ b/packages/automerge-repo/src/storage/keyHash.ts
@@ -1,4 +1,4 @@
-import * as A from "@automerge/automerge/slim/next"
+import { next as A } from "@automerge/automerge/slim"
 import * as sha256 from "fast-sha256"
 import { mergeArrays } from "../helpers/mergeArrays.js"
 

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -1,4 +1,4 @@
-import * as A from "@automerge/automerge/slim/next"
+import { next as A } from "@automerge/automerge/slim"
 import { decode } from "cbor-x"
 import debug from "debug"
 import {

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -1,4 +1,4 @@
-import * as A from "@automerge/automerge/next"
+import { next as A } from "@automerge/automerge"
 import assert from "assert"
 import { decode } from "cbor-x"
 import { describe, expect, it, vi } from "vitest"

--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -1,5 +1,5 @@
 import { NodeFSStorageAdapter } from "../../automerge-repo-storage-nodefs/src/index.js"
-import * as A from "@automerge/automerge/next"
+import { next as A } from "@automerge/automerge"
 import assert from "assert"
 import fs from "fs"
 import os from "os"


### PR DESCRIPTION
In the upcoming Automerge 3.0 there is no `/next` subpath export and the `next` interface is deprecated. We want to continue working with both Automerge 3.0 and Automerge 2.0, so we switch to using `next` like this:

import { next as Automerge } from "@automerge/automerge"

This will be backwards compatible with both versions of Automerge