### PR TITLE
Remove document from synchronizer when document is removed from repo

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -110,8 +110,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     this.sharePolicy = sharePolicy ?? this.sharePolicy
 
     this.on("delete-document", ({ documentId }) => {
-      // TODO Pass the delete on to the network
-      // synchronizer.removeDocument(documentId)
+      this.synchronizer.removeDocument(documentId)
 
       if (storageSubsystem) {
         storageSubsystem.removeDoc(documentId).catch(err => {
@@ -798,8 +797,7 @@ export class Repo extends EventEmitter<RepoEvents> {
         )
       }
       delete this.#handleCache[documentId]
-      // TODO: remove document from synchronizer when removeDocument is implemented
-      // this.synchronizer.removeDocument(documentId)
+      this.synchronizer.removeDocument(documentId)
     } else {
       this.#log(
         `WARN: removeFromCache called but doc undefined for documentId: ${documentId}`

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -138,10 +138,9 @@ export class CollectionSynchronizer extends Synchronizer {
     })
   }
 
-  // TODO: implement this
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   removeDocument(documentId: DocumentId) {
-    throw new Error("not implemented")
+    delete this.docSynchronizers[documentId];
+    delete this.#docSetUp[documentId];
   }
 
   /** Adds a peer and maybe starts synchronizing with them */

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -139,8 +139,12 @@ export class CollectionSynchronizer extends Synchronizer {
   }
 
   removeDocument(documentId: DocumentId) {
-    delete this.docSynchronizers[documentId];
-    delete this.#docSetUp[documentId];
+    const docSynchronizer = this.docSynchronizers[documentId]
+    if (docSynchronizer !== undefined) {
+      this.peers.forEach(peerId => void docSynchronizer.endSync(peerId))
+    }
+    delete this.docSynchronizers[documentId]
+    delete this.#docSetUp[documentId]
   }
 
   /** Adds a peer and maybe starts synchronizing with them */

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -75,4 +75,25 @@ describe("CollectionSynchronizer", () => {
 
       setTimeout(done)
     }))
+
+  it("removes document", () =>
+    new Promise<void>((done, reject) => {
+      const handle = repo.create()
+      synchronizer.addDocument(handle)
+      synchronizer.addPeer("peer1" as PeerId)
+      // starts synchronizing document to peer
+      synchronizer.once("message", event => {
+        const { targetId, documentId } = event as SyncMessage
+        assert(targetId === "peer1")
+        assert(documentId === handle.documentId)
+        done()
+      })
+      // no message should be sent after removing document
+      synchronizer.once("message", () => {
+        reject(new Error("Should not have sent a message"))
+      })
+      assert(synchronizer.docSynchronizers[handle.documentId] !== undefined)
+      synchronizer.removeDocument(handle.documentId)
+      assert(synchronizer.docSynchronizers[handle.documentId] === undefined)
+    }))
 })

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -519,6 +519,7 @@ describe("Repo", () => {
         const handle = repo.create({ foo: "bar" })
         await repo.delete(handle.documentId)
         assert(repo.handles[handle.documentId] === undefined)
+        assert(repo.synchronizer.docSynchronizers[handle.documentId] === undefined)
       })
 
       it("removeFromCache removes doc handle", async () => {
@@ -526,6 +527,7 @@ describe("Repo", () => {
         const handle = repo.create({ foo: "bar" })
         await repo.removeFromCache(handle.documentId)
         assert(repo.handles[handle.documentId] === undefined)
+        assert(repo.synchronizer.docSynchronizers[handle.documentId] === undefined)
       })
 
       it("removeFromCache for documentId not found", async () => {


### PR DESCRIPTION
Implement removal of a document when the document is removed from the repo.

This can happen in two cases:
-when the document is deleted
-when the document is removed from the handle cache

Specifically, this reference graph needs to be released in order to free up memory usage of the document:
-repo references synchronizer: CollectionSynchronizer
-synchronizer has record from documentId to docSynchronizer
-docSynchronizer has reference to DocHandle
