### PR TITLE
automerge-repo-react-hooks: avoid Suspense where possible for useDocuments

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocHandles.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocHandles.ts
@@ -15,13 +15,26 @@ export function useDocHandles<T>(
   { suspense = false }: UseDocHandlesParams = {}
 ): DocHandleMap<T> {
   const repo = useRepo()
-  const [handleMap, setHandleMap] = useState<DocHandleMap<T>>(() => new Map())
+  const [handleMap, setHandleMap] = useState<DocHandleMap<T>>(() => {
+    const map = new Map()
+
+    // Initialize the map with any handles that are ready
+    for (const id of ids) {
+      const progress = repo.findWithProgress<T>(id)
+      if (progress.state === "ready") {
+        map.set(id, progress.handle)
+      }
+    }
+
+    return map
+  })
 
   const pendingPromises: PromiseWrapper<DocHandle<T>>[] = []
   const nextHandleMap = new Map<AutomergeUrl, DocHandle<T> | undefined>()
 
   // Check if we need any new wrappers
   for (const id of ids) {
+    let handle = handleMap.get(id)
     let wrapper = wrapperCache.get(id)
     if (!wrapper) {
       try {
@@ -37,7 +50,7 @@ export function useDocHandles<T>(
     // Update handleMap with any available handles,
     // and collect any pending promises
     try {
-      const handle = wrapper.read() as DocHandle<T>
+      handle ??= wrapper.read() as DocHandle<T>
       nextHandleMap.set(id, handle)
     } catch (e) {
       if (e instanceof Promise) {

--- a/packages/automerge-repo-react-hooks/src/useDocHandles.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocHandles.ts
@@ -20,7 +20,13 @@ export function useDocHandles<T>(
 
     // Initialize the map with any handles that are ready
     for (const id of ids) {
-      const progress = repo.findWithProgress<T>(id)
+      let progress
+      try {
+        progress = repo.findWithProgress<T>(id)
+      } catch (e) {
+        continue
+      }
+
       if (progress.state === "ready") {
         map.set(id, progress.handle)
       }

--- a/packages/automerge-repo-react-hooks/src/useDocuments.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocuments.ts
@@ -19,7 +19,16 @@ export function useDocuments<T>(
   { suspense = true }: UseDocumentsOptions = {}
 ): [DocMap<T>, ChangeDocFn<T>] {
   const handleMap = useDocHandles<T>(ids, { suspense })
-  const [docMap, setDocMap] = useState<DocMap<T>>(() => new Map())
+  const [docMap, setDocMap] = useState<DocMap<T>>(() => {
+    const docs: DocMap<T> = new Map()
+    handleMap.forEach(handle => {
+      const url = handle?.url
+      if (url) {
+        docs.set(url, handle?.doc())
+      }
+    })
+    return docs
+  })
 
   useEffect(() => {
     const listeners = new Map<AutomergeUrl, () => void>()

--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -245,7 +245,9 @@ describe("useDocuments", () => {
     })
 
     it("should handle loading multiple documents asynchronously", async () => {
-      const { handleA, handleB, wrapper } = setup()
+      const { repoCreator, repoFinder, wrapper } = setupPairedRepos()
+      const handleA = repoCreator.create({ foo: "A" })
+      const handleB = repoCreator.create({ foo: "B" })
       const onState = vi.fn()
 
       const Wrapped = () => (
@@ -260,12 +262,15 @@ describe("useDocuments", () => {
       render(<Wrapped />, { wrapper })
 
       // Initial state should be empty
-      let [docs] = onState.mock.lastCall || []
+      let docs = onState.mock.lastCall?.[0]
       expect(docs.size).toBe(0)
 
       // Wait for documents to load
       await act(async () => {
-        await Promise.resolve()
+        await Promise.all([
+          repoFinder.find(handleA.url),
+          repoFinder.find(handleB.url),
+        ])
       })
 
       // Check loaded state

--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -411,7 +411,8 @@ describe("useDocuments", () => {
       render(<Wrapped />, { wrapper })
 
       // Initial state empty
-      let [docs] = onState.mock.lastCall || []
+      let docs = onState.mock.lastCall?.[0]
+      expect(docs).toBeDefined()
       expect(docs.size).toBe(0)
 
       // Should remain empty after attempted load
@@ -420,6 +421,7 @@ describe("useDocuments", () => {
       })
 
       docs = onState.mock.lastCall?.[0]
+      expect(docs).toBeDefined()
       expect(docs.size).toBe(0)
     })
   })

--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -296,7 +296,10 @@ describe("useDocuments", () => {
     })
 
     it("should handle document removal with pending loads", async () => {
-      const { handleA, handleB, wrapper } = setup()
+      const { repoCreator, repoFinder, wrapper } = setupPairedRepos()
+      const handleA = repoCreator.create({ foo: "A" })
+      const handleB = repoCreator.create({ foo: "B" })
+
       const onState = vi.fn()
 
       const Wrapped = ({ urls }: { urls: AutomergeUrl[] }) => (
@@ -311,7 +314,8 @@ describe("useDocuments", () => {
       )
 
       // Initial state should be empty
-      let [docs] = onState.mock.lastCall || []
+      let docs = onState.mock.lastCall?.[0]
+      expect(docs).toBeDefined()
       expect(docs.size).toBe(0)
 
       // Remove one document before load completes
@@ -319,7 +323,10 @@ describe("useDocuments", () => {
 
       // Wait for remaining document to load
       await act(async () => {
-        await Promise.resolve()
+        await Promise.all([
+          repoFinder.find(handleA.url),
+          repoFinder.find(handleB.url),
+        ])
       })
 
       // Should only have loaded the remaining document


### PR DESCRIPTION
Allow useDocuments and useDocHandles to immediately return
already-loaded documents without invoking Suspense (in their Suspense
variants).

We should avoid unnecessary Suspense since it can lead to clumsy UX
with flashing loaders.

See also #415.