### PR TITLE
Refactor automerge-repo-react-hooks test setup code

### DIFF
--- a/packages/automerge-repo-react-hooks/test/testSetup.ts
+++ b/packages/automerge-repo-react-hooks/test/testSetup.ts
@@ -1,7 +1,0 @@
-import "@testing-library/jest-dom"
-import { cleanup } from "@testing-library/react"
-import { afterEach } from "vitest"
-
-afterEach(() => {
-  cleanup()
-})

--- a/packages/automerge-repo-react-hooks/test/testSetup.tsx
+++ b/packages/automerge-repo-react-hooks/test/testSetup.tsx
@@ -1,0 +1,81 @@
+import React from "react"
+
+import { PeerId, Repo } from "@automerge/automerge-repo"
+import "@testing-library/jest-dom"
+import { cleanup } from "@testing-library/react"
+import { afterEach } from "vitest"
+import { RepoContext } from "../src/useRepo"
+import { DummyNetworkAdapter } from "../src/helpers/DummyNetworkAdapter"
+
+afterEach(() => {
+  cleanup()
+})
+
+export interface ExampleDoc {
+  foo: string
+  counter?: number
+  nested?: {
+    value: string
+  }
+}
+
+export function setup() {
+  const repo = new Repo({
+    peerId: "bob" as PeerId,
+  })
+
+  const handleA = repo.create<ExampleDoc>()
+  handleA.change(doc => (doc.foo = "A"))
+
+  const handleB = repo.create<ExampleDoc>()
+  handleB.change(doc => (doc.foo = "B"))
+
+  const handleC = repo.create<ExampleDoc>()
+  handleC.change(doc => (doc.foo = "C"))
+
+  const wrapper = ({ children }) => {
+    return <RepoContext.Provider value={repo}>{children}</RepoContext.Provider>
+  }
+
+  return {
+    repo,
+    handleA,
+    handleB,
+    handleC,
+    handles: [handleA, handleB, handleC],
+    urls: [handleA.url, handleB.url, handleC.url],
+    wrapper,
+  }
+}
+
+export function setupPairedRepos(latency = 10) {
+  // Create two connected repos with network delay
+  const [adapterCreator, adapterFinder] =
+    DummyNetworkAdapter.createConnectedPair({
+      latency,
+    })
+
+  const peerIdCreator = "peer-creator" as PeerId
+  const peerIdFinder = "peer-finder" as PeerId
+  const repoCreator = new Repo({
+    peerId: peerIdCreator,
+    network: [adapterCreator],
+  })
+  const repoFinder = new Repo({
+    peerId: peerIdFinder,
+    network: [adapterFinder],
+  })
+
+  // TODO: dummynetwork adapter should probably take care of this
+  // Initialize the network.
+  adapterCreator.peerCandidate(peerIdFinder)
+  adapterFinder.peerCandidate(peerIdCreator)
+
+  function Wrapper({ children }) {
+    return (
+      <RepoContext.Provider value={repoFinder}>{children}</RepoContext.Provider>
+    )
+  }
+
+  return { repoCreator, repoFinder, wrapper: Wrapper }
+}

--- a/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
@@ -2,10 +2,6 @@ import {
   AutomergeUrl,
   Doc,
   generateAutomergeUrl,
-  PeerId,
-  Repo,
-  NetworkAdapter,
-  Message,
 } from "@automerge/automerge-repo"
 import { render, screen, waitFor } from "@testing-library/react"
 import React, { Suspense } from "react"
@@ -13,74 +9,10 @@ import { describe, expect, it, vi } from "vitest"
 import "@testing-library/jest-dom"
 
 import { useDocument } from "../src/useDocument"
-import { RepoContext } from "../src/useRepo"
 import { ErrorBoundary } from "react-error-boundary"
-import { DummyNetworkAdapter, pause } from "../src/helpers/DummyNetworkAdapter"
-interface ExampleDoc {
-  foo: string
-}
+import { setup, setupPairedRepos, ExampleDoc } from "./testSetup"
 
 describe("useDocument", () => {
-  function setup() {
-    const repo = new Repo({
-      peerId: "bob" as PeerId,
-    })
-
-    const handleA = repo.create<ExampleDoc>()
-    handleA.change(doc => (doc.foo = "A"))
-
-    const handleB = repo.create<ExampleDoc>()
-    handleB.change(doc => (doc.foo = "B"))
-
-    const handleC = repo.create<ExampleDoc>()
-    handleC.change(doc => (doc.foo = "C"))
-
-    const wrapper = ({ children }) => {
-      return (
-        <RepoContext.Provider value={repo}>{children}</RepoContext.Provider>
-      )
-    }
-
-    return {
-      repo,
-      handleA,
-      handleB,
-      handleC,
-      wrapper,
-    }
-  }
-
-  function setupPairedRepos(latency = 10) {
-    // Create two connected repos with network delay
-    const [adapterCreator, adapterFinder] =
-      DummyNetworkAdapter.createConnectedPair({
-        latency,
-      })
-
-    const repoCreator = new Repo({
-      peerId: "peer-creator" as PeerId,
-      network: [adapterCreator],
-    })
-    const repoFinder = new Repo({
-      peerId: "peer-finder" as PeerId,
-      network: [adapterFinder],
-    })
-
-    // TODO: dummynetwork adapter should probably take care of this
-    // Initialize the network.
-    adapterCreator.peerCandidate(`peer-finder` as PeerId)
-    adapterFinder.peerCandidate(`peer-creator` as PeerId)
-
-    const wrapper = ({ children }) => {
-      return (
-        <RepoContext.Provider value={repoFinder}>
-          {children}
-        </RepoContext.Provider>
-      )
-    }
-
-    return { repoCreator, repoFinder, wrapper }
-  }
   const Component = ({
     url,
     onDoc,

--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -3,49 +3,10 @@ import { AutomergeUrl, Repo, PeerId } from "@automerge/automerge-repo"
 import { render, act, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { useDocuments } from "../src/useDocuments"
-import { RepoContext } from "../src/useRepo"
 import { ErrorBoundary } from "react-error-boundary"
-
-interface ExampleDoc {
-  foo: string
-  counter?: number
-  nested?: {
-    value: string
-  }
-}
-
-function getRepoWrapper(repo: Repo) {
-  return ({ children }) => (
-    <RepoContext.Provider value={repo}>{children}</RepoContext.Provider>
-  )
-}
+import { ExampleDoc, setup } from "./testSetup"
 
 describe("useDocuments", () => {
-  const repo = new Repo({
-    peerId: "bob" as PeerId,
-  })
-
-  function setup() {
-    const handleA = repo.create<ExampleDoc>()
-    handleA.change(doc => (doc.foo = "A"))
-
-    const handleB = repo.create<ExampleDoc>()
-    handleB.change(doc => (doc.foo = "B"))
-
-    const handleC = repo.create<ExampleDoc>()
-    handleC.change(doc => (doc.foo = "C"))
-
-    return {
-      repo,
-      handleA,
-      handleB,
-      handleC,
-      handles: [handleA, handleB, handleC],
-      urls: [handleA.url, handleB.url, handleC.url],
-      wrapper: getRepoWrapper(repo),
-    }
-  }
-
   const DocumentsComponent = ({
     urls,
     onState,
@@ -235,31 +196,6 @@ describe("useDocuments", () => {
   })
 
   describe("useDocuments with suspense: false", () => {
-    const repo = new Repo({
-      peerId: "bob" as PeerId,
-    })
-
-    function setup() {
-      const handleA = repo.create<ExampleDoc>()
-      handleA.change(doc => (doc.foo = "A"))
-
-      const handleB = repo.create<ExampleDoc>()
-      handleB.change(doc => (doc.foo = "B"))
-
-      const handleC = repo.create<ExampleDoc>()
-      handleC.change(doc => (doc.foo = "C"))
-
-      return {
-        repo,
-        handleA,
-        handleB,
-        handleC,
-        handles: [handleA, handleB, handleC],
-        urls: [handleA.url, handleB.url, handleC.url],
-        wrapper: getRepoWrapper(repo),
-      }
-    }
-
     const NonSuspendingDocumentsComponent = ({
       urls,
       onState,

--- a/packages/automerge-repo-react-hooks/vitest.config.ts
+++ b/packages/automerge-repo-react-hooks/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path"
 export default defineConfig({
   test: {
     globals: true,
-    setupFiles: [path.join(__dirname, "./test/testSetup.ts")],
+    setupFiles: [path.join(__dirname, "./test/testSetup.tsx")],
     environment: "jsdom",
     coverage: {
       provider: "v8",


### PR DESCRIPTION
In updating the tests for #429, I found that we have very similar
setup code in three hook test files. There are some benefits to
localized setup like that, but I can't imagine our tests for this
package will ever care very much about the actual document contents,
so instead of copying the paired repo setup code to yet another place,
I decided to try refactoring.

Thoughts?
