### PR TITLE
Export explicit RawString and ImmutableString types (fix #437)

### DIFF
--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -121,6 +121,12 @@ export const Counter = Automerge.Counter
 export const RawString = Automerge.RawString
 // In automerge 3.0 RawString is renamed to ImmutableString
 export const ImmutableString = Automerge.RawString
+
+// Export separate RawString and ImmutableString types,
+// whose symbols are only usable as values otherwise.
+export type RawString = InstanceType<typeof Automerge.RawString>
+export type ImmutableString = RawString
+
 export type Counter = Automerge.Counter
 export type Doc<T> = Automerge.Doc<T>
 export type Heads = Automerge.Heads


### PR DESCRIPTION
The `RawString` and `ImmutableString` symbols that are exported by `automerge-repo` only work as values since version 2, as reported in #437.

This PR fixes this bug by exporting separate types that have the same name and are defined as `InstanceType<typeof Automerge.RawString>`.