### PR TITLE
Replace getRemoteHeads with getSyncInfo

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -12,6 +12,7 @@ import { headsAreSame } from "./helpers/headsAreSame.js"
 import { withTimeout } from "./helpers/withTimeout.js"
 import type { AutomergeUrl, DocumentId, PeerId, UrlHeads } from "./types.js"
 import { StorageId } from "./storage/types.js"
+import { SyncInfo } from "./RemoteHeadsSubscriptions.js"
 
 /**
  * A DocHandle is a wrapper around a single Automerge document that lets us listen for changes and
@@ -42,8 +43,8 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
    * unavailable much sooner if all known peers respond that they don't have it.) */
   #timeoutDelay = 60_000
 
-  /** A dictionary mapping each peer to the last heads we know they have. */
-  #remoteHeads: Record<StorageId, UrlHeads> = {}
+  /** A dictionary mapping each peer to the last known heads we have. */
+  #syncInfoByStorageId: Record<StorageId, SyncInfo> = {}
 
   /** Cache for view handles, keyed by the stringified heads */
   #viewCache: Map<string, DocHandle<T>> = new Map()
@@ -482,14 +483,26 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
    * Called by the repo when a doc handle changes or we receive new remote heads.
    * @hidden
    */
-  setRemoteHeads(storageId: StorageId, heads: UrlHeads) {
-    this.#remoteHeads[storageId] = heads
-    this.emit("remote-heads", { storageId, heads })
+  setSyncInfo(storageId: StorageId, syncInfo: SyncInfo) {
+    this.#syncInfoByStorageId[storageId] = syncInfo
+    this.emit("remote-heads", {
+      storageId,
+      heads: syncInfo.lastHeads,
+      timestamp: syncInfo.lastSyncTimestamp,
+    })
   }
 
-  /** Returns the heads of the storageId. */
+  /** Returns the heads of the storageId.
+   *
+   * @deprecated Use getSyncInfo instead.
+   */
   getRemoteHeads(storageId: StorageId): UrlHeads | undefined {
-    return this.#remoteHeads[storageId]
+    return this.#syncInfoByStorageId[storageId]?.lastHeads
+  }
+
+  /** Returns the heads and the timestamp of the last update for the storageId. */
+  getSyncInfo(storageId: StorageId): SyncInfo | undefined {
+    return this.#syncInfoByStorageId[storageId]
   }
 
   /**
@@ -722,6 +735,7 @@ export interface DocHandleOutboundEphemeralMessagePayload<T> {
 export interface DocHandleRemoteHeadsPayload {
   storageId: StorageId
   heads: UrlHeads
+  timestamp: number
 }
 
 // STATE MACHINE TYPES & CONSTANTS

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -206,7 +206,7 @@ export class Repo extends EventEmitter<RepoEvents> {
         return
       }
 
-      const heads = handle.getRemoteHeads(storageId)
+      const heads = handle.getSyncInfo(storageId)?.lastHeads
       const haveHeadsChanged =
         message.syncState.theirHeads &&
         (!heads ||

--- a/packages/automerge-repo/test/RemoteHeadsSubscriptions.test.ts
+++ b/packages/automerge-repo/test/RemoteHeadsSubscriptions.test.ts
@@ -3,7 +3,7 @@ import assert from "assert"
 import { describe, it } from "vitest"
 import { generateAutomergeUrl, parseAutomergeUrl } from "../src/AutomergeUrl.js"
 import { RemoteHeadsSubscriptions } from "../src/RemoteHeadsSubscriptions.js"
-import { PeerId, StorageId } from "../src/index.js"
+import { PeerId, StorageId, UrlHeads } from "../src/index.js"
 import {
   RemoteHeadsChanged,
   RemoteSubscriptionControlMessage,
@@ -32,7 +32,7 @@ describe("RepoHeadsSubscriptions", () => {
     newHeads: {
       [storageB]: {
         heads: [],
-        timestamp: Date.now(),
+        timestamp: 1000,
       },
     },
   }
@@ -45,7 +45,7 @@ describe("RepoHeadsSubscriptions", () => {
     newHeads: {
       [storageB]: {
         heads: [],
-        timestamp: Date.now(),
+        timestamp: 2000,
       },
     },
   }
@@ -64,7 +64,7 @@ describe("RepoHeadsSubscriptions", () => {
     newHeads: {
       [storageB]: {
         heads: docBHeads,
-        timestamp: Date.now() + 1,
+        timestamp: 3000,
       },
     },
   }
@@ -153,7 +153,7 @@ describe("RepoHeadsSubscriptions", () => {
     remoteHeadsSubscriptions.handleImmediateRemoteHeadsChanged(
       docC,
       storageB,
-      []
+      [] as UrlHeads
     )
 
     // should forward remote-heads events
@@ -233,7 +233,7 @@ describe("RepoHeadsSubscriptions", () => {
     remoteHeadsSubscriptions.handleImmediateRemoteHeadsChanged(
       docC,
       storageB,
-      []
+      [] as UrlHeads
     )
 
     // expect peer c to be notified both changes
@@ -279,7 +279,7 @@ describe("RepoHeadsSubscriptions", () => {
     remoteHeadsSubscriptions.handleImmediateRemoteHeadsChanged(
       docC,
       storageB,
-      []
+      [] as UrlHeads
     )
 
     // expect peer c to be notified both changes
@@ -309,6 +309,7 @@ describe("RepoHeadsSubscriptions", () => {
     assert.strictEqual(messages[0].storageId, storageB)
     assert.strictEqual(messages[0].documentId, docB)
     assert.deepStrictEqual(messages[0].remoteHeads, docBHeads)
+    assert.strictEqual(messages[0].timestamp, 3000)
   })
 
   it("should remove subs of disconnected peers", async () => {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1267,9 +1267,10 @@ describe("Repo", () => {
       const nextRemoteHeadsPromise = new Promise<{
         storageId: StorageId
         heads: UrlHeads
+        timestamp: number
       }>(resolve => {
-        handle.on("remote-heads", ({ storageId, heads }) => {
-          resolve({ storageId, heads })
+        handle.on("remote-heads", ({ storageId, heads, timestamp }) => {
+          resolve({ storageId, heads, timestamp })
         })
       })
 
@@ -1289,10 +1290,10 @@ describe("Repo", () => {
       assert.deepStrictEqual(nextRemoteHeads.storageId, charliedStorageId)
       assert.deepStrictEqual(nextRemoteHeads.heads, charlieHandle.heads())
 
-      assert.deepStrictEqual(
-        handle.getRemoteHeads(charliedStorageId),
-        charlieHandle.heads()
-      )
+      const syncInfo = handle.getSyncInfo(charliedStorageId)
+
+      assert.deepStrictEqual(syncInfo?.lastHeads, charlieHandle.heads())
+      assert.strictEqual(syncInfo?.lastSyncTimestamp, nextRemoteHeads.timestamp)
 
       teardown()
     })

--- a/packages/automerge-repo/test/remoteHeads.test.ts
+++ b/packages/automerge-repo/test/remoteHeads.test.ts
@@ -9,6 +9,7 @@ import {
   DocHandleRemoteHeadsPayload,
   PeerId,
   Repo,
+  UrlHeads,
 } from "../src/index.js"
 import { DummyStorageAdapter } from "../src/helpers/DummyStorageAdapter.js"
 import { collectMessages } from "./helpers/collectMessages.js"
@@ -29,7 +30,10 @@ describe("DocHandle.remoteHeads", () => {
     const bobStorageId = await bobRepo.storageId()
 
     const remoteHeadsMessagePromise = eventPromise(handle, "remote-heads")
-    handle.setRemoteHeads(bobStorageId, [])
+    handle.setSyncInfo(bobStorageId, {
+      lastHeads: [] as UrlHeads,
+      lastSyncTimestamp: Date.now(),
+    })
 
     const remoteHeadsMessage = await remoteHeadsMessagePromise
 

--- a/packages/automerge-repo/test/remoteHeads.test.ts
+++ b/packages/automerge-repo/test/remoteHeads.test.ts
@@ -19,7 +19,7 @@ import { pause } from "../src/helpers/pause.js"
 describe("DocHandle.remoteHeads", () => {
   const TEST_ID = parseAutomergeUrl(generateAutomergeUrl()).documentId
 
-  it("should allow to listen for remote head changes and manually read remote heads", async () => {
+  it("should allow to listen for remote head changes and manually read sync info", async () => {
     const handle = new DocHandle<TestDoc>(TEST_ID, { isNew: true })
     const bobRepo = new Repo({
       peerId: "bob" as PeerId,
@@ -32,7 +32,7 @@ describe("DocHandle.remoteHeads", () => {
     const remoteHeadsMessagePromise = eventPromise(handle, "remote-heads")
     handle.setSyncInfo(bobStorageId, {
       lastHeads: [] as UrlHeads,
-      lastSyncTimestamp: Date.now(),
+      lastSyncTimestamp: 1000,
     })
 
     const remoteHeadsMessage = await remoteHeadsMessagePromise
@@ -41,7 +41,13 @@ describe("DocHandle.remoteHeads", () => {
     assert.deepStrictEqual(remoteHeadsMessage.heads, [])
 
     // read remote heads manually
-    assert.deepStrictEqual(handle.getRemoteHeads(bobStorageId), [])
+
+    const syncInfo = handle.getSyncInfo(bobStorageId)
+
+    assert.deepStrictEqual(syncInfo, {
+      lastHeads: [] as UrlHeads,
+      lastSyncTimestamp: 1000,
+    })
   })
 
   describe("multi hop sync", () => {


### PR DESCRIPTION
Currently, getRemoteHeads only exposes the last synced heads of a remote peer. It would be useful to also get the timestamp of the last sync. Internally, we already track that information, but haven't exposed it through the API.

This pull request adds `getSyncInfo` to the doc handle that returns both the last synced heads and the last synced timestamp as a replacement for `getRemoteHeads`. For now, I've marked `getRemoteHeads` as deprecated. I think we should delete it in a future release.