### PR TITLE
isReadOnly() -- test if a dochandle can be change()d

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -564,6 +564,20 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
   }
 
   /**
+   * Check if the document can be change()ed. Currently, documents can be
+   * edited unless we are viewing a particular point in time.
+   *
+   * @remarks It is technically possible to back-date changes using changeAt(),
+   *          but we block it for usability reasons when viewing a particular point in time.
+   *          To make changes in the past, use the primary document handle with no heads set.
+   *
+   * @returns boolean indicating whether changes are possible
+   */
+  isReadOnly() {
+    return !!this.#fixedHeads
+  }
+
+  /**
    * Merges another document into this document. Any peers we are sharing changes with will be
    * notified of the changes resulting from the merge.
    *

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -587,4 +587,57 @@ describe("DocHandle", () => {
     // Cached access should be significantly faster
     expect(timeForCachedAccesses).toBeLessThan(timeForFirstAccess / 10)
   })
+
+  describe("isReadOnly", () => {
+    it("should return false for a regular document handle", () => {
+      const handle = setup()
+      expect(handle.isReadOnly()).toBe(false)
+    })
+
+    it("should return false for a newly created document handle", () => {
+      const handle = new DocHandle<TestDoc>(TEST_ID)
+      expect(handle.isReadOnly()).toBe(false)
+    })
+
+    it("should return true for a view handle with fixed heads", () => {
+      const handle = setup()
+      handle.change(doc => {
+        doc.foo = "test"
+      })
+
+      const heads = handle.heads()
+      const viewHandle = handle.view(heads)
+
+      expect(viewHandle.isReadOnly()).toBe(true)
+    })
+
+    it("should return true for a handle constructed with fixed heads", () => {
+      const handle = setup()
+      handle.change(doc => {
+        doc.foo = "test"
+      })
+
+      const heads = handle.heads()
+      const fixedHeadsHandle = new DocHandle<TestDoc>(TEST_ID, { heads })
+      fixedHeadsHandle.update(() => A.clone(handle.doc()!))
+      fixedHeadsHandle.doneLoading()
+
+      expect(fixedHeadsHandle.isReadOnly()).toBe(true)
+    })
+
+    it("should return false after regular changes", () => {
+      const handle = setup()
+
+      // Initially not read-only
+      expect(handle.isReadOnly()).toBe(false)
+
+      // Make a change
+      handle.change(doc => {
+        doc.foo = "changed"
+      })
+
+      // Still not read-only
+      expect(handle.isReadOnly()).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
We currently only support one way of putting a docHandle into readOnly mode, which is to view at particular point in time in the past. This is occasionally requested functionality though, so in preparation for introduction of Keyhive ACLs and other similar work, I've taken the liberty of introducing a new test function here.