### PR TITLE
Remove MessageChannel network adapters on disconnect

### DIFF
--- a/packages/automerge-repo-network-messagechannel/src/index.ts
+++ b/packages/automerge-repo-network-messagechannel/src/index.ts
@@ -101,6 +101,7 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
           case "leave":
             if (this.#remotePeerId === senderId) {
               this.emit("peer-disconnected", { peerId: senderId })
+              this.emit("close")
             }
             break
           default:
@@ -167,6 +168,7 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
         senderId: this.peerId,
       })
       this.emit("peer-disconnected", { peerId: this.#remotePeerId })
+      this.emit("close")
     }
     this.messagePortRef.stop()
   }

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -102,6 +102,7 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
           delete this.#adaptersByPeer[peerId as PeerId]
         }
       })
+      this.adapters = this.adapters.filter(a => a !== networkAdapter)
     })
 
     this.peerMetadata


### PR DESCRIPTION
MessageChannel network adapters can never reconnect once they have been disconnected, so we remove them from the network subsystem.