### PR TITLE
automerge-repo-network-websocket: handle invalid cbor in the client

### DIFF
--- a/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
@@ -194,7 +194,13 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   receiveMessage(messageBytes: Uint8Array) {
-    const message: FromServerMessage = cbor.decode(new Uint8Array(messageBytes))
+    let message: FromServerMessage
+    try {
+      message = cbor.decode(new Uint8Array(messageBytes))
+    } catch (e) {
+      this.#log("error decoding message:", e)
+      return
+    }
 
     assert(this.socket)
     if (messageBytes.byteLength === 0)


### PR DESCRIPTION
Problem: If the server sends invalid CBOR then the client will crash and bring down the whole repo with it. 

Solution: catch the error in the client and log it, then rely on the normal reconnect logic to recover (in case the server is just temporarily misbehaving).