### PR TITLE
Log the message as well as the error when receive message throws

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -301,7 +301,7 @@ export class Repo extends EventEmitter<RepoEvents> {
       case "ephemeral":
       case "doc-unavailable":
         this.synchronizer.receiveMessage(message).catch(err => {
-          console.log("error receiving message", { err })
+          console.log("error receiving message", { err, message })
         })
     }
   }


### PR DESCRIPTION
When receive message throws an error we just log the error. This makes it hard to figure out what message caused this because the catch is called asynchronously.