### PR TITLE
allow react 19

### DIFF
--- a/packages/automerge-react/package.json
+++ b/packages/automerge-react/package.json
@@ -24,7 +24,7 @@
     "react": "^18.0.0"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/packages/automerge-repo-react-hooks/package.json
+++ b/packages/automerge-repo-react-hooks/package.json
@@ -32,8 +32,8 @@
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "watch": {
     "build": {


### PR DESCRIPTION
To avoid this warning:

```
 WARN  Issues with peer dependencies found

  └─┬ @automerge/automerge-repo-react-hooks 2.0.6
    ├── ✕ unmet peer react@^18.0.0: found 19.1.0
    └── ✕ unmet peer react-dom@^18.0.0: found 19.1.0
```