### PR TITLE
State of Dochandle should be "ready" when change event is triggered

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -235,7 +235,6 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
       // checkForChanges will then be triggered again by the state machine
       // This ensures that when change is triggered the state is set to ready
       if (!this.isReady()) {
-        console.log(this.state)
         this.#machine.send({ type: DOC_READY })
         return
       }

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -34,10 +34,6 @@ describe("DocHandle", () => {
     const handle = new DocHandle<TestDoc>(TEST_ID)
     assert.equal(handle.isReady(), false)
 
-    handle.on("change", ({ handle }) => {
-      console.log("inside change", handle.state)
-    })
-
     const states = []
 
     handle.on("change", ({ handle }) => {

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -506,6 +506,19 @@ describe("DocHandle", () => {
     assert(wasBar, "foo should have been bar as we changed at the old heads")
   })
 
+  it("should emit a change event when the document becomes unavailable", async () => {
+    const handle = setup()
+
+    const p = new Promise<void>(resolve =>
+      handle.once("change", () => resolve())
+    )
+
+    handle.unavailable()
+
+    await p
+    assert.equal(handle.isUnavailable(), true)
+  })
+
   describe("ephemeral messaging", () => {
     it("can broadcast a message for the network to send out", async () => {
       const handle = setup()


### PR DESCRIPTION
When you subscribe to changes on a doc handle the first time the document loads the state on the handle is still "loading" in  the change callback even though the document is already loaded.

```js
handle.on("change", () => {
   console.log(handle.state) // logs "loading" when initially loading instead of ready
})
```

Why is this happening? On each state transition we call `#checkForChanges` this function which has two responsibilities:

- checks if we need to emit a change event 
- transitions the state machine from "loading" to "ready" when the document was loaded for the first time

Right now when the document is loaded for the first time `#checkForChanges` emits a change event and then transitions the state machine from "loading" to "ready". That's why in the callback the state field on the handle is still loading. This pull request fixes this that we first transition into the ready state and then trigger a change event.