### PR TITLE
Prevent duplicate save listeners

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -279,13 +279,21 @@ export class Repo extends EventEmitter<RepoEvents> {
       }
       const throttledSaveFn = throttle(saveFn, this.saveDebounceRate)
       // Use a named function to make it easier to identify
-      const wrappedSaveFn = function wrappedSaveFn(payload: DocHandleEncodedChangePayload<any>) {
+      const wrappedSaveFn = function wrappedSaveFn(
+        payload: DocHandleEncodedChangePayload<any>
+      ) {
         throttledSaveFn(payload)
       }
 
       // Add save function as a listener if it's not already registered
       const existingListeners = handle.listeners("heads-changed")
-      if (!existingListeners.some(listener => listener.name === wrappedSaveFn.name && listener.toString() === wrappedSaveFn.toString())) {
+      if (
+        !existingListeners.some(
+          listener =>
+            listener.name === wrappedSaveFn.name &&
+            listener.toString() === wrappedSaveFn.toString()
+        )
+      ) {
         handle.on("heads-changed", wrappedSaveFn)
       }
     }

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -289,9 +289,7 @@ export class Repo extends EventEmitter<RepoEvents> {
       const existingListeners = handle.listeners("heads-changed")
       if (
         !existingListeners.some(
-          listener =>
-            listener.name === wrappedSaveFn.name &&
-            listener.toString() === wrappedSaveFn.toString()
+          listener => listener.name === wrappedSaveFn.name
         )
       ) {
         handle.on("heads-changed", wrappedSaveFn)

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -74,9 +74,11 @@ export class Repo extends EventEmitter<RepoEvents> {
   /** @hidden */
   storageSubsystem?: StorageSubsystem
 
-  /** The debounce rate is adjustable on the repo. */
   /** @hidden */
-  saveDebounceRate = 100
+  #saveDebounceRate: number
+
+  /** @hidden */
+  #saveFn: (payload: DocHandleEncodedChangePayload<any>) => void
 
   #handleCache: Record<DocumentId, DocHandle<any>> = {}
 
@@ -103,6 +105,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     isEphemeral = storage === undefined,
     enableRemoteHeadsGossiping = false,
     denylist = [],
+    saveDebounceRate = 100,
   }: RepoConfig = {}) {
     super()
     this.#remoteHeadsGossipingEnabled = enableRemoteHeadsGossiping
@@ -148,6 +151,18 @@ export class Repo extends EventEmitter<RepoEvents> {
     }
 
     this.storageSubsystem = storageSubsystem
+
+    this.#saveDebounceRate = saveDebounceRate
+
+    if (this.storageSubsystem) {
+      const saveFn = ({ handle, doc }: DocHandleEncodedChangePayload<any>) => {
+        void this.storageSubsystem!.saveDoc(handle.documentId, doc)
+      }
+      // Save no more often than saveDebounceRate.
+      this.#saveFn = throttle(saveFn, this.#saveDebounceRate)
+    } else {
+      this.#saveFn = () => {}
+    }
 
     // NETWORK
     // The network subsystem deals with sending and receiving messages to and from peers.
@@ -271,28 +286,12 @@ export class Repo extends EventEmitter<RepoEvents> {
   // The `document` event is fired by the DocCollection any time we create a new document or look
   // up a document by ID. We listen for it in order to wire up storage and network synchronization.
   #registerHandleWithSubsystems(handle: DocHandle<any>) {
-    const { storageSubsystem } = this
-    if (storageSubsystem) {
-      // Save when the document changes, but no more often than saveDebounceRate.
-      const saveFn = ({ handle, doc }: DocHandleEncodedChangePayload<any>) => {
-        void storageSubsystem.saveDoc(handle.documentId, doc)
-      }
-      const throttledSaveFn = throttle(saveFn, this.saveDebounceRate)
-      // Use a named function to make it easier to identify
-      const wrappedSaveFn = function wrappedSaveFn(
-        payload: DocHandleEncodedChangePayload<any>
-      ) {
-        throttledSaveFn(payload)
-      }
-
+    if (this.storageSubsystem) {
       // Add save function as a listener if it's not already registered
       const existingListeners = handle.listeners("heads-changed")
-      if (
-        !existingListeners.some(
-          listener => listener.name === wrappedSaveFn.name
-        )
-      ) {
-        handle.on("heads-changed", wrappedSaveFn)
+      if (!existingListeners.some(listener => listener === this.#saveFn)) {
+        // Save when the document changes
+        handle.on("heads-changed", this.#saveFn)
       }
     }
 
@@ -350,7 +349,7 @@ export class Repo extends EventEmitter<RepoEvents> {
             syncState
           )
         },
-        this.saveDebounceRate
+        this.#saveDebounceRate
       )
     }
 
@@ -877,6 +876,11 @@ export interface RepoConfig {
    * loading documents that are known to be too resource intensive.
    */
   denylist?: AutomergeUrl[]
+
+  /**
+   * The debounce rate in milliseconds for saving documents. Defaults to 100ms.
+   */
+  saveDebounceRate?: number
 }
 
 /** A function that determines whether we should share a document with a peer

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -51,8 +51,8 @@ describe("Repo", () => {
       const repo = new Repo({
         storage: storageAdapter,
         network: [networkAdapter],
+        saveDebounceRate: 1,
       })
-      repo.saveDebounceRate = 1
       return { repo, storageAdapter, networkAdapter }
     }
 
@@ -647,8 +647,13 @@ describe("Repo", () => {
       })
 
       it("respects saveDebounceRate when saving", async () => {
-        const { repo, storageAdapter } = setup()
-        repo.saveDebounceRate = 100
+        const storageAdapter = new DummyStorageAdapter()
+        const networkAdapter = new DummyNetworkAdapter()
+        const repo = new Repo({
+          storage: storageAdapter,
+          network: [networkAdapter],
+          saveDebounceRate: 100,
+        })
         const handle = repo.create<TestDoc>()
 
         for (let i = 0; i < 5; i++) {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1442,6 +1442,18 @@ describe("Repo", () => {
 
       teardown()
     })
+
+    it("does not add duplicate heads-changed listeners", async () => {
+      const { aliceRepo, bobRepo, teardown } = await setup()
+
+      const aliceHandle = aliceRepo.create<TestDoc>({ foo: "bar" })
+      await pause(10)
+
+      const bobHandle = await bobRepo.find<TestDoc>(aliceHandle.url)
+      assert.equal(bobHandle.listenerCount("heads-changed"), 1)
+
+      teardown()
+    })
   })
 
   describe("with peers (mesh network)", () => {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -613,7 +613,9 @@ describe("Repo", () => {
         const { repo, storageAdapter } = setup()
         const handle = repo.create<TestDoc>()
         await pause(10) // wait for debounced save to complete
-        assert(storageAdapter.keys().some(key => key.includes(handle.documentId)))
+        assert(
+          storageAdapter.keys().some(key => key.includes(handle.documentId))
+        )
       })
 
       it("registers document with synchronizer when finding an existing document", async () => {
@@ -650,7 +652,9 @@ describe("Repo", () => {
         const handle = repo.create<TestDoc>()
 
         for (let i = 0; i < 5; i++) {
-          handle.change(d => { d.foo = `bar${i}` })
+          handle.change(d => {
+            d.foo = `bar${i}`
+          })
         }
         await pause(10)
         assert(storageAdapter.keys().length < 5)


### PR DESCRIPTION
Problem:
https://github.com/automerge/automerge-repo/issues/456

Proposed solution:
In Repo.ts, since `#registerHandleWithSubsystems` can be called multiple times, check existing listeners on the handle before adding a listener for the save function.
