### PR TITLE
wip: add sedimentree

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -120,11 +120,41 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
           after: { [delay]: "unavailable" },
         },
         requesting: {
+          type: "parallel",
           on: {
-            DOC_UNAVAILABLE: "unavailable",
             DOC_READY: "ready",
           },
-          after: { [delay]: "unavailable" },
+          states: {
+            syncV1: {
+              initial: "requesting",
+              states: {
+                requesting: {
+                  on: {
+                    DOC_UNAVAILABLE_SYNC_V1: "unavailable",
+                  },
+                  after: { [delay]: "unavailable" },
+                },
+                unavailable: {
+                  type: "final",
+                },
+              },
+            },
+            sedimentree: {
+              initial: "requesting",
+              states: {
+                requesting: {
+                  on: {
+                    DOC_UNAVAILABLE_SEDIMENTREE: "unavailable",
+                  },
+                  after: { [delay]: "unavailable" },
+                },
+                unavailable: {
+                  type: "final",
+                },
+              },
+            },
+          },
+          onDone: "unavailable",
         },
         unavailable: {
           entry: "onUnavailable",
@@ -297,7 +327,14 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
 
   /** @hidden */
   get state() {
-    return this.#machine.getSnapshot().value
+    const current = this.#machine.getSnapshot().value
+    if (typeof current === "string") {
+      return current
+    } else {
+      return Object.keys(current)[0]
+    }
+    // this.#machine.getSnapshot().value
+    // return this.#machine.getSnapshot().value
   }
 
   /**
@@ -645,7 +682,11 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
    * @hidden
    */
   unavailable() {
-    this.#machine.send({ type: DOC_UNAVAILABLE })
+    this.#machine.send({ type: "DOC_UNAVAILABLE_SYNC_V1" })
+  }
+
+  unavailableSedimentree() {
+    this.#machine.send({ type: "DOC_UNAVAILABLE_SEDIMENTREE" })
   }
 
   /**
@@ -837,7 +878,8 @@ type DocHandleEvent<T> =
   | { type: typeof RELOAD }
   | { type: typeof DELETE }
   | { type: typeof TIMEOUT }
-  | { type: typeof DOC_UNAVAILABLE }
+  | { type: typeof DOC_UNAVAILABLE_SYNC_V1 }
+  | { type: typeof DOC_UNAVAILABLE_SEDIMENTREE }
 
 const BEGIN = "BEGIN"
 const REQUEST = "REQUEST"
@@ -847,4 +889,5 @@ const UNLOAD = "UNLOAD"
 const RELOAD = "RELOAD"
 const DELETE = "DELETE"
 const TIMEOUT = "TIMEOUT"
-const DOC_UNAVAILABLE = "DOC_UNAVAILABLE"
+const DOC_UNAVAILABLE_SYNC_V1 = "DOC_UNAVAILABLE_SYNC_V1"
+const DOC_UNAVAILABLE_SEDIMENTREE = "DOC_UNAVAILABLE_SEDIMENTREE"

--- a/packages/automerge-repo/src/sedimentree.ts
+++ b/packages/automerge-repo/src/sedimentree.ts
@@ -1,0 +1,107 @@
+import { NetworkAdapterInterface } from "./network/NetworkAdapterInterface.js"
+import { DocumentId } from "./types.js"
+import * as A from "@automerge/automerge"
+
+export interface Sedimentree {
+  // Called by the repo when the network should start work
+  start(adapters: NetworkAdapterInterface[]): void
+
+  // Called by the repo when the network should shut down
+  stop(): Promise<void>
+
+  // A promise which returns true when all the network adapters have said they
+  whenReady(): Promise<boolean>
+
+  find(documentId: DocumentId): Promise<Uint8Array[] | undefined>
+
+  // Called whenever the sedimentree network is aware of new changes for a document.
+  on(
+    event: "change",
+    documentId: DocumentId,
+    callback: (data: Uint8Array[]) => void
+  ): void
+  // Register a callback to provide bundles for the sedimentree
+  on(
+    event: "bundleRequired",
+    callback: (documentId: DocumentId, start: string, end: string) => Uint8Array
+  ): void
+
+  // Stop listening for changes to a particular document
+  off(
+    event: "change",
+    documentId: DocumentId,
+    callback: (data: Uint8Array[]) => void
+  ): void
+  off(
+    event: "bundleRequired",
+    callback: (documentId: DocumentId, start: string, end: string) => Uint8Array
+  ): void
+
+  // Notify the sedimentree that there are new commits (called whenever the document changes)
+  newCommit(documentId: DocumentId, hash: string, data: Uint8Array): void
+}
+
+export class DummySedimentree implements Sedimentree {
+  #docs: Map<DocumentId, A.Doc<unknown>> = new Map()
+  constructor(docs: Map<DocumentId, A.Doc<unknown>>) {
+    this.#docs = docs
+  }
+
+  start(adapters: NetworkAdapterInterface[]): void {}
+  async stop(): Promise<void> {}
+  async whenReady(): Promise<boolean> {
+    return true
+  }
+
+  find(documentId: DocumentId): Promise<Uint8Array[] | undefined> {
+    const doc = this.#docs.get(documentId)
+    if (doc) {
+      return Promise.resolve([A.save(doc)])
+    } else {
+      return Promise.resolve(undefined)
+    }
+  }
+
+  // Overload signatures
+  on(
+    event: "change",
+    documentId: DocumentId,
+    callback: (data: Uint8Array[]) => void
+  ): void
+  on(
+    event: "bundleRequired",
+    callback: (documentId: DocumentId, start: string, end: string) => Uint8Array
+  ): void
+  // Implementation signature
+  on(
+    event: "change" | "bundleRequired",
+    documentIdOrCallback:
+      | DocumentId
+      | ((documentId: DocumentId, start: string, end: string) => Uint8Array),
+    callback?: (data: Uint8Array[]) => void
+  ): void {}
+
+  // Overload signatures for off
+  off(
+    event: "change",
+    documentId: DocumentId,
+    callback: (data: Uint8Array[]) => void
+  ): void
+  off(
+    event: "bundleRequired",
+    callback: (documentId: DocumentId, start: string, end: string) => Uint8Array
+  ): void
+  // Implementation signature
+  off(
+    event: "change" | "bundleRequired",
+    documentIdOrCallback:
+      | DocumentId
+      | ((documentId: DocumentId, start: string, end: string) => Uint8Array),
+    callback?: (data: Uint8Array[]) => void
+  ): void {
+    // DummySedimentree doesn't actually store listeners, so this is a no-op
+    // In a real implementation, you would remove the listener here
+  }
+
+  newCommit(documentId: DocumentId, hash: string, data: Uint8Array): void {}
+}

--- a/packages/automerge-repo/test/sedimentree.test.ts
+++ b/packages/automerge-repo/test/sedimentree.test.ts
@@ -1,0 +1,21 @@
+import * as A from "@automerge/automerge"
+import { describe, expect, it } from "vitest"
+import assert from "assert"
+import { generateAutomergeUrl, parseAutomergeUrl } from "../src/AutomergeUrl.js"
+import { DummySedimentree } from "../src/sedimentree.js"
+import { Repo } from "../src/Repo.js"
+
+describe("Repo sedimentree integration", () => {
+  it("should find documents from sedimentree", async () => {
+    const url = generateAutomergeUrl()
+    const { documentId } = parseAutomergeUrl(url)
+    const doc = A.from({ foo: "bar" })
+    const repo = new Repo({
+      sedimentreeImplementation: new DummySedimentree(
+        new Map([[documentId, doc]])
+      ),
+    })
+    const handle = await repo.find(url)
+    assert.deepEqual(handle.doc().foo, "bar")
+  })
+})


### PR DESCRIPTION
This PR is an attempt to find a minimal way to add  a new sedimentree based method of synchronizing documents to automerge-repo. The overall strategy is to add a second network subsystem which speaks sedimentree rather than speaking the automerge sync protocol. We are planning to implement the actual sedimentree logic in a separate rust-compiled-to-wasm package, so this PR is mostly wiring up a stubbed out version to automerge-repo internals. Specifically:

* Add an `Sedimentree` interface describing the interface we expect a sedimentree based network subsystem to implement
* Add a new `sedimentreeImplementation` and `sedimentreeAdapters` argument to the `RepoConfig` constructor. The idea behind this is that whilst we are developing it is quicker to inject the implementation into Repo than to import it internally - we don't have to keep rebuilding automerge-repo that way. The `sedimentreeAdapters` are the network adapters which are intended for use with the new sedimentree subsystem. `Repo` passes these adpaters to `sedimentreeImplementation.start` on boot.
* Split the "unavailalable" xstate machine into two parallel states tracking unavailability from the existing network adadpter and from the sedimentree network adapter
* If a `sedimentreeImplementation` is passed then use it to request `DocHandle`s.