### PR TITLE
Fix document saves made within 100ms being discarded

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -18,7 +18,7 @@ import {
 } from "./DocHandle.js"
 import { RemoteHeadsSubscriptions } from "./RemoteHeadsSubscriptions.js"
 import { headsAreSame } from "./helpers/headsAreSame.js"
-import { throttle } from "./helpers/throttle.js"
+import { throttle, throttleByKey } from "./helpers/throttle.js"
 import {
   NetworkAdapterInterface,
   type PeerMetadata,
@@ -158,8 +158,10 @@ export class Repo extends EventEmitter<RepoEvents> {
       const saveFn = ({ handle, doc }: DocHandleEncodedChangePayload<any>) => {
         void this.storageSubsystem!.saveDoc(handle.documentId, doc)
       }
+      const keyFn = ({ handle }: DocHandleEncodedChangePayload<any>) => handle
+
       // Save no more often than saveDebounceRate.
-      this.#saveFn = throttle(saveFn, this.#saveDebounceRate)
+      this.#saveFn = throttleByKey(saveFn, keyFn, this.#saveDebounceRate)
     } else {
       this.#saveFn = () => {}
     }

--- a/packages/automerge-repo/src/helpers/throttle.ts
+++ b/packages/automerge-repo/src/helpers/throttle.ts
@@ -41,3 +41,44 @@ export const throttle = <F extends (...args: Parameters<F>) => ReturnType<F>>(
     }, wait)
   }
 }
+
+/**
+ * Same as {@link throttle()}, but throttles calls separately based on a
+ * (weakly-referenced) key.
+ *
+ * Given two distinct objects `a` and `b`, and
+ * `f = throttleByKey(fn, (v) => v.k, 100)`, then the following sequence of
+ * calls:
+ *
+ * - `f({ k: a, v: 1 })`
+ * - `f({ k: a, v: 2 })`
+ * - `f({ k: b, v: 3 })`
+ *
+ * Will result in `fn({ k: a, v: 2 })` and `fn({ k: b, v: 3 }) being called
+ * after 100ms. Contrast this with {@link throttle()}, which would only call
+ * `fn({ k: b, v: 3 })` after 100ms.
+ */
+export const throttleByKey = <Arg, K extends WeakKey, F extends (arg: Arg) => ReturnType<F>>(
+  fn: F,
+  key: (arg: Arg) => K,
+  delay: number
+) => {
+  const callTimeouts = new WeakMap<K, /*lastArg=*/Arg>()
+
+  return function (arg: Arg) {
+    const k = key(arg)
+
+    if (!callTimeouts.has(k)) {
+      // No timeout yet, set it up.
+      setTimeout(() => {
+        const lastArg = callTimeouts.get(k)
+        if (lastArg !== undefined) {
+          callTimeouts.delete(k)
+          fn(lastArg)
+        }
+      }, delay)
+    }
+
+    callTimeouts.set(k, arg)
+  }
+}


### PR DESCRIPTION
`saveFn()` would only be called with the last set of parameters given to it, which would discard documents saved within 100ms of each other, except for one.

It's fairly trivial to reproduce:

```js
const a = repo.create()
const b = repo.create()
const c = repo.create()
```

Only `a` will be saved.

Fixing this could be approached in multiple ways. The mapping from key to throttled function could be done in `Repo.ts`, but after shortly working on it it seems it would have made things more complex. The current approach is quite simple IMO.