### PR TITLE
Update publish-js GitHub Action to use pnpm v9

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
           run_install: false
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This may fix #481?

We install pnpm v8 in this step but specify v9 in package.json. I'm
not sure what actually gets used and whether the pnpm v8 lockfile is
using a lockfile v6 format (since that's what it gets reverted to). I
haven't figured out the pnpm lockfile format version history and
whether the numbering differs between the two like that.

Or alternately, if we are intentionally using v8 in this step for
whatever reason, we should probably avoid commiting the lockfile
changes. I can update the PR to do that instead if that makes more
sense.
