### PR TITLE
Avoid re-evaluating useDocHandles hook unnecessarily

### DIFF
--- a/packages/automerge-repo-react-hooks/src/helpers/useSet.ts
+++ b/packages/automerge-repo-react-hooks/src/helpers/useSet.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react"
+
+export function useSet<T>(items: T[]): Set<T> {
+  const [set, setSet] = useState<Set<T>>(() => {
+    return new Set<T>(items)
+  })
+  useEffect(() => {
+    const newSet = new Set(items)
+    if (identical(set, newSet)) {
+      return
+    }
+    setSet(newSet)
+  }, [set, items])
+  return set
+}
+
+function identical<T>(s1: Set<T>, s2: Set<T>) {
+  return s1.size === s2.size && Array.from(s1).every(v => s2.has(v))
+}

--- a/packages/automerge-repo-react-hooks/test/helpers/useSet.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/helpers/useSet.test.tsx
@@ -1,0 +1,82 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import "@testing-library/jest-dom"
+
+import { describe, expect, it, vi } from "vitest"
+import { useSet } from "../../src/helpers/useSet"
+
+describe("useSet", () => {
+  const Component = ({
+    args,
+    onSet,
+  }: {
+    args: number[]
+    onSet: (result: Set<number>) => void
+  }) => {
+    const result = useSet(args)
+    onSet(result)
+    return null
+  }
+
+  it("builds a Set from the provided arguments", () => {
+    const onSet = vi.fn<(result: Set<number>) => void>()
+
+    const source = [1, 2, 3]
+
+    render(<Component args={source} onSet={onSet} />)
+
+    const result = onSet.mock.lastCall?.at(0)
+    expect(result?.size).toBe(source.length)
+    source.forEach(entry => {
+      expect(result?.has(entry)).toBe(true)
+    })
+  })
+
+  it("collapses duplicates", () => {
+    const onSet = vi.fn<(result: Set<number>) => void>()
+
+    const source = [1, 2, 2, 3]
+
+    render(<Component args={source} onSet={onSet} />)
+
+    const result = onSet.mock.lastCall?.at(0)
+    expect(result?.size).toBe(3)
+    source.forEach(entry => {
+      expect(result?.has(entry)).toBe(true)
+    })
+  })
+
+  it("returns a new Set if the items change", () => {
+    const onSet1 = vi.fn<(result: Set<number>) => void>()
+    const source1 = [1, 2, 3]
+
+    const { rerender } = render(<Component args={source1} onSet={onSet1} />)
+    const result1 = onSet1.mock.lastCall?.at(0)
+
+    const onSet2 = vi.fn<(result: Set<number>) => void>()
+    const source2 = [2, 3, 4]
+    rerender(<Component args={source2} onSet={onSet2} />)
+    const result2 = onSet2.mock.lastCall?.at(0)
+
+    expect(result1).not.toBe(result2)
+    expect(result2?.size).toBe(source2.length)
+    source2.forEach(entry => {
+      expect(result2?.has(entry)).toBe(true)
+    })
+  })
+
+  it("returns the same Set (same object by reference) if the items did not change", () => {
+    const onSet1 = vi.fn<(result: Set<number>) => void>()
+    const source1 = [1, 2, 3]
+
+    const { rerender } = render(<Component args={source1} onSet={onSet1} />)
+    const result1 = onSet1.mock.lastCall?.at(0)
+
+    const onSet2 = vi.fn<(result: Set<number>) => void>()
+    const source2 = [1, 2, 3]
+    rerender(<Component args={source2} onSet={onSet2} />)
+    const result2 = onSet2.mock.lastCall?.at(0)
+
+    expect(result1).toBe(result2)
+  })
+})


### PR DESCRIPTION
We're currently updating the hook's handle map whenever the list of ids changes, causing it to trigger a re-render. This is intended, but we are passing the ids Array directly in as a useEffect dependency, meaning that any usage of the hook with a literal array, like

  useDocHandles([id1, id2, id3])

will create a new array on each render, re-triggering the useEffect hook, causing a setState and another render, indefinitely.

This code could use some refactoring (it's not obeying React's rules of hooks), but for now, work around the issue by adding a useSet hook that gives a stable reference for the useEffect dependency array as long as the contents of the id list passed to useDocHandles don't change.

Fixes #479.