### PR TITLE
Fix useDocHandle unnecessary re-renders

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocHandle.ts
@@ -65,7 +65,7 @@ export function useDocHandle<T>(
    * re-running this function until it succeeds, whereas the synchronous
    * form uses a setState to track the value. */
   useEffect(() => {
-    if (suspense || !wrapper) {
+    if (currentHandle || suspense || !wrapper) {
       return
     }
     wrapper.promise


### PR DESCRIPTION
With `suspense: false`, `useDocHandle` would thrash the state by calling `setHandle` even when the `currentHandle` was already available.

In some project, this lead to a dramatic performance degradation as many components re-rendered unnecessarily.

The rules of hooks force us to place hooks before early returns so we just need to short-circuit inside the `useEffect`, like we already do for suspense.

I've verified that the new test fails before the change (and passes after).