### PR TITLE
Add Watcher utility

### DIFF
--- a/packages/automerge-repo/src/Watcher.ts
+++ b/packages/automerge-repo/src/Watcher.ts
@@ -1,0 +1,112 @@
+import { DocHandle, DocHandleEvents } from "./DocHandle.js"
+import { Repo } from "./Repo.js"
+import { DocumentId } from "./types.js"
+
+type DocHandleEvent = keyof DocHandleEvents<unknown>
+
+type Watched<T> = Map<DocumentId, DocHandle<T>>
+
+type ChangeHandlers<T> = Partial<{
+  [K in keyof DocHandleEvents<T>]: (
+    ...args: [
+      watched: Map<DocumentId, DocHandle<T>>,
+      ...Parameters<DocHandleEvents<T>[K]>
+    ]
+  ) => Set<DocumentId> | undefined
+}>
+
+export class Watcher<T> {
+  #repo: Repo
+  #handlerWrappers: Partial<DocHandleEvents<T>>
+  #watched: Watched<T>
+
+  constructor(repo: Repo, handlers: ChangeHandlers<T>) {
+    this.#repo = repo
+    this.#watched = new Map()
+    this.#handlerWrappers = Object.entries(handlers).reduce(
+      (wrappers, [event, handler]) => {
+        wrappers[event as DocHandleEvent] = payload => {
+          try {
+            // TODO: better type
+            const newWatched = handler(this.#watched, payload as any)
+            if (!newWatched) {
+              return
+            }
+            this.watch(newWatched)
+          } catch (e) {
+            // TODO: handle error
+            throw e
+          }
+        }
+        return wrappers
+      },
+      {} as Partial<DocHandleEvents<T>>
+    )
+  }
+
+  watch(ids: Set<DocumentId>) {
+    const currentKeys = new Set(this.#watched.keys())
+    const outgoing = except(currentKeys, ids)
+    Array.from(outgoing).forEach(docId => {
+      this.#unwatchDoc(docId)
+    })
+
+    const incoming = except(ids, currentKeys)
+    Array.from(incoming).forEach(docId => {
+      this.#watchDoc(docId)
+    })
+  }
+
+  async #watchDoc(id: DocumentId) {
+    const handle = await this.#repo.find<T>(id)
+
+    Object.entries(this.#handlerWrappers).forEach(([event, handler]) => {
+      // TODO: better type
+      handle.on(event as DocHandleEvent, handler as any)
+    })
+    // fake a change event for the doc for the benefit of our handler
+    // TODO: should this just be a separate event type?
+    const changeHandler = this.#handlerWrappers['change'];
+    if (changeHandler) {
+      const doc = handle.doc();
+      changeHandler({
+        doc,
+        handle,
+        patches: [],
+        patchInfo: {
+          before: doc,
+          after: doc,
+          source: "emptyChange",
+        }
+      })
+    }
+
+    this.#watched.set(id, handle)
+  }
+
+  async #unwatchDoc(id: DocumentId) {
+    const handle = await this.#repo.find<T>(id)
+
+    Object.entries(this.#handlerWrappers).forEach(([event, handler]) => {
+      // TODO: better type
+      handle.off(event as DocHandleEvent, handler as any)
+    })
+    this.#watched.delete(id)
+  }
+}
+
+function except<T = unknown>(
+  s1: Readonly<Set<T>>,
+  s2: Readonly<Set<T>>
+): Set<T> {
+  const result = new Set<T>()
+
+  Array.from(s1).forEach(item => {
+    if (s2.has(item)) {
+      return
+    }
+    result.add(item)
+  })
+
+  return result
+}

--- a/packages/automerge-repo/test/Watcher.test.ts
+++ b/packages/automerge-repo/test/Watcher.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest"
+import { Repo } from "../src/Repo.js"
+import { DummyNetworkAdapter } from "../src/helpers/DummyNetworkAdapter.js"
+import { DummyStorageAdapter } from "../src/helpers/DummyStorageAdapter.js"
+import { DocumentId } from "../src/types.js"
+
+import { Watcher } from "../src/Watcher.js"
+import { Doc, generateAutomergeUrl } from "../src/index.js"
+import { parseAutomergeUrl } from "../src/AutomergeUrl.js"
+import { pause } from "../src/helpers/pause.js"
+
+describe("Watcher", () => {
+  describe("repo", () => {
+    const setup = ({ startReady = true } = {}) => {
+      const storageAdapter = new DummyStorageAdapter()
+      const networkAdapter = new DummyNetworkAdapter({ startReady })
+
+      const repo = new Repo({
+        storage: storageAdapter,
+        network: [networkAdapter],
+        saveDebounceRate: 1,
+      })
+      return { repo, storageAdapter, networkAdapter }
+    }
+
+    it("loads a document tree", async () => {
+      const { repo } = setup()
+
+      const tree = generateDirTree(repo)
+
+      let latestHandles: Set<DocumentId>;
+
+      const watcher = new Watcher<DirEntry>(repo, {
+        change: (handles, payload) => {
+          const newHandles = new Set(handles.keys())
+          const { handle, doc } = payload
+
+          if (doc.type === "leaf") {
+            return newHandles
+          }
+
+          newHandles.add(handle.documentId)
+
+          const entryIds = doc.contents
+
+          entryIds.forEach(docId => {
+            newHandles.add(docId)
+          })
+
+          latestHandles = newHandles;
+          return newHandles
+        },
+        delete: (handles, payload) => {
+          const newHandles = new Set(handles.keys())
+          const { handle } = payload
+          // TODO: what's up with the type here?
+          const doc = handle.doc()
+          if (doc.type === "leaf") {
+            return newHandles
+          }
+
+          const entryIds = doc.contents
+
+          entryIds.forEach(docId => {
+            // Each node manages an exclusive subset of the full tree contents,
+            // so we can be sure these documents do not appear anywhere else and
+            // can be deleted when this directory is deleted.
+            newHandles.delete(docId)
+          })
+
+          latestHandles = newHandles;
+          return newHandles
+        },
+      })
+
+      const { root, allDocs } = tree;
+
+      watcher.watch(new Set([root.documentId]))
+
+      await pause();
+
+      expect(latestHandles.size).toBe(allDocs.length);
+    })
+  })
+})
+
+function debug(repo: Repo, documentIds: DocumentId[]) {
+  documentIds.slice().sort().forEach(async (docId) => {
+    const doc = await repo.find(docId);
+    console.log(docId, JSON.stringify(doc.doc()))
+  })
+}
+
+function generateLeaf(repo: Repo) {
+  const { documentId } = parseAutomergeUrl(generateAutomergeUrl());
+  return repo.create({
+    type: "leaf",
+    contents: documentId,
+  });
+}
+
+function generateDir(repo: Repo, ...documents: DocumentId[]) {
+  return repo.create<DirEntry>({
+    type: "folder",
+    contents: documents
+  });
+}
+
+function generateDirTree(repo: Repo) {
+  const doc1 = generateLeaf(repo);
+  const dir1 = generateDir(repo, doc1.documentId);
+  const doc3 = generateLeaf(repo);
+  const doc4 = generateLeaf(repo);
+  const dir2 = generateDir(repo, doc3.documentId, doc4.documentId);
+  const doc5 = generateLeaf(repo);
+  const doc6 = generateLeaf(repo);
+  const dir3 = generateDir(repo, doc5.documentId, doc6.documentId, dir2.documentId);
+  const root = generateDir(repo, dir1.documentId, dir3.documentId);
+
+  const allDocs = [
+    doc1, dir1, doc3, doc4, dir2, doc5, doc6, dir3, root
+  ].map((handle) => handle.documentId);
+
+  return {
+    root,
+    allDocs,
+  }
+}
+
+type DirEntry = Doc<
+  | {
+      type: "folder"
+      contents: DocumentId[]
+    }
+  | {
+      type: "leaf"
+      contents: DocumentId
+    }
+>


### PR DESCRIPTION
This can be used to watch a tree or graph of documents.

Spike per discussion of some of these ideas with @pvh.

The ideas is this could serve as a building block for something `useDocumentTree` in React, or other similar APIs in other integrations.
