### PR TITLE
Update CI to use pnpm/action-setup@v4 consistently

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,13 +25,13 @@ jobs:
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - name: Install
         run: |
           pnpm install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,13 +34,13 @@ jobs:
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
           ref: ${{ github.ref }}
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - name: Install and Build
         run: |
           pnpm install 
@@ -65,13 +65,13 @@ jobs:
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - name: Install Dependencies
         id: deps
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,13 +25,13 @@ jobs:
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - name: Install and Build
         run: |
           pnpm install


### PR DESCRIPTION
In #482, I updated the CI release workflows to use
pnpm/action-setup@v4 and skip specifying the pnpm version (instead
relying on the package.json packageManager field). That workflow was a
problem as it committed the updated pnpm lock file, but these other
workflows should also be updated.
