### PR TITLE
fix: doc handle save fn stale doc reference

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -163,7 +163,7 @@ export class Repo extends EventEmitter<RepoEvents> {
       this.#saveFn = ({ handle, doc }: DocHandleEncodedChangePayload<any>) => {
         let fn = this.#saveFns[handle.documentId]
         if (!fn) {
-          fn = throttle(() => {
+        fn = throttle(({ doc }: DocHandleEncodedChangePayload<any>) => {
             void this.storageSubsystem!.saveDoc(handle.documentId, doc)
           }, this.#saveDebounceRate)
           this.#saveFns[handle.documentId] = fn


### PR DESCRIPTION
This fixes the issue where the document is only saved on the first call to the saveFn