### PR TITLE
Add ShareConfig

### DIFF
--- a/packages/automerge-repo/src/helpers/DummyNetworkAdapter.ts
+++ b/packages/automerge-repo/src/helpers/DummyNetworkAdapter.ts
@@ -4,6 +4,7 @@ import { Message, NetworkAdapter, PeerId } from "../../src/index.js"
 export class DummyNetworkAdapter extends NetworkAdapter {
   #sendMessage?: SendMessageFn
 
+  #connected = false
   #ready = false
   #readyResolver?: () => void
   #readyPromise: Promise<void> = new Promise<void>(resolve => {
@@ -39,20 +40,29 @@ export class DummyNetworkAdapter extends NetworkAdapter {
   }
 
   connect(peerId: PeerId) {
+    this.#connected = true
     this.peerId = peerId
   }
 
-  disconnect() {}
+  disconnect() {
+    this.#connected = false
+  }
 
   peerCandidate(peerId: PeerId) {
     this.emit("peer-candidate", { peerId, peerMetadata: {} })
   }
 
   override send(message: Message) {
+    if (!this.#connected) {
+      return
+    }
     this.#sendMessage?.(message)
   }
 
   receive(message: Message) {
+    if (!this.#connected) {
+      return
+    }
     this.emit("message", message)
   }
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -11,7 +11,7 @@ import {
   generateAutomergeUrl,
   stringifyAutomergeUrl,
 } from "../src/AutomergeUrl.js"
-import { Repo } from "../src/Repo.js"
+import { FindProgressWithMethods, Repo, ShareConfig } from "../src/Repo.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
 import {
@@ -33,6 +33,7 @@ import {
 import { getRandomItem } from "./helpers/getRandomItem.js"
 import { TestDoc } from "./types.js"
 import { StorageId, StorageKey } from "../src/storage/types.js"
+import { FindProgress } from "../src/FindProgress.js"
 
 describe("Repo", () => {
   describe("constructor", () => {
@@ -1707,6 +1708,174 @@ describe("Repo", () => {
 
       const openDocs = Object.keys(server.metrics().documents).length
       assert.deepEqual(openDocs, 0)
+    })
+  })
+
+  describe("the sharePolicy", () => {
+    async function connect(left: Repo, right: Repo) {
+      const [leftToRight, rightToLeft] =
+        DummyNetworkAdapter.createConnectedPair({ latency: 0 })
+      left.networkSubsystem.addNetworkAdapter(leftToRight)
+      right.networkSubsystem.addNetworkAdapter(rightToLeft)
+      leftToRight.peerCandidate(right.peerId)
+      rightToLeft.peerCandidate(left.peerId)
+      await Promise.all([
+        left.networkSubsystem.whenReady(),
+        right.networkSubsystem.whenReady(),
+      ])
+      await pause(10)
+    }
+
+    async function withTimeout<T>(
+      promise: Promise<T>,
+      timeout: number
+    ): Promise<T | undefined> {
+      const timeoutPromise = new Promise<T | undefined>(resolve => {
+        setTimeout(() => resolve(undefined), timeout)
+      })
+      return Promise.race([promise, timeoutPromise])
+    }
+
+    async function awaitState(
+      progress: FindProgress<unknown> | FindProgressWithMethods<unknown>,
+      state: string
+    ): Promise<void> {
+      if (progress.state == state) {
+        return
+      }
+      if (!("subscribe" in progress)) {
+        throw new Error(
+          `expected progress in state ${state} but was in final state ${progress.state}`
+        )
+      }
+      await new Promise(resolve => {
+        const unsubscribe = progress.subscribe(progress => {
+          if (progress.state === state) {
+            unsubscribe()
+            resolve(null)
+          }
+        })
+      })
+    }
+
+    // The parts of `RepoConfig` which are either the old sharePolicy API or the new shareConfig API
+    type EitherConfig = { sharePolicy?: SharePolicy; shareConfig?: ShareConfig }
+
+    /// Create two connected peers with the given share configurations
+    async function twoPeers({
+      alice: aliceConfig,
+      bob: bobConfig,
+    }: {
+      alice: EitherConfig
+      bob: EitherConfig
+    }): Promise<{ alice: Repo; bob: Repo }> {
+      const alice = new Repo({
+        peerId: "alice" as PeerId,
+        ...aliceConfig,
+      })
+      const bob = new Repo({
+        peerId: "bob" as PeerId,
+        ...bobConfig,
+      })
+      await connect(alice, bob)
+      return { alice, bob }
+    }
+
+    describe("the legacy API", () => {
+      it("should announce documents to peers for whom the sharePolicy returns true", async () => {
+        const { alice, bob } = await twoPeers({
+          alice: { sharePolicy: async () => true },
+          bob: { sharePolicy: async () => true },
+        })
+        const handle = alice.create({ foo: "bar" })
+
+        // Wait for the announcement to be synced
+        await pause(100)
+
+        // Disconnect and stop alice
+        await alice.shutdown()
+
+        // Bob should have the handle already because it was announced to him
+        const bobHandle = await bob.find(handle.url)
+      })
+
+      it("should not annouce documents to peers for whom the sharePolicy returns false", async () => {
+        const { alice, bob } = await twoPeers({
+          alice: { sharePolicy: async () => false },
+          bob: { sharePolicy: async () => true },
+        })
+        const handle = alice.create({ foo: "bar" })
+
+        // Disconnect and stop alice
+        await alice.shutdown()
+
+        // Bob should have the handle already because it was announced to him
+        const bobHandle = await withTimeout(bob.find(handle.url), 100)
+        assert.equal(bobHandle, null)
+      })
+
+      it("should respond to direct requests for document where the sharePolicy returns false", async () => {
+        const { alice, bob } = await twoPeers({
+          alice: { sharePolicy: async () => false },
+          bob: { sharePolicy: async () => true },
+        })
+        await connect(alice, bob)
+
+        const aliceHandle = alice.create({ foo: "bar" })
+        const bobHandle = await bob.find(aliceHandle.url)
+      })
+    })
+
+    it("should respond to direct requests for document where the announce policy returns false but the access policy returns true", async () => {
+      const { alice, bob } = await twoPeers({
+        alice: {
+          shareConfig: {
+            announce: async () => false,
+            access: async () => true,
+          },
+        },
+        bob: { sharePolicy: async () => true },
+      })
+
+      const aliceHandle = alice.create({ foo: "bar" })
+      const bobHandle = await bob.find(aliceHandle.url)
+    })
+
+    it("should not respond to direct requests for a document where the access policy returns false and the announce policy return trrrue", async () => {
+      const { alice, bob } = await twoPeers({
+        alice: {
+          shareConfig: {
+            announce: async () => true,
+            access: async () => false,
+          },
+        },
+        bob: { sharePolicy: async () => true },
+      })
+      await connect(alice, bob)
+
+      const aliceHandle = alice.create({ foo: "bar" })
+      withTimeout(
+        awaitState(bob.findWithProgress(aliceHandle.url), "unavailable"),
+        500
+      )
+    })
+
+    it("should not respond to direct requests for a document where the access policy and the announce policy return false", async () => {
+      const { alice, bob } = await twoPeers({
+        alice: {
+          shareConfig: {
+            announce: async () => false,
+            access: async () => false,
+          },
+        },
+        bob: { sharePolicy: async () => false },
+      })
+
+      const aliceHandle = alice.create({ foo: "bar" })
+      withTimeout(
+        awaitState(bob.findWithProgress(aliceHandle.url), "unavailable"),
+        500
+      )
     })
   })
 })


### PR DESCRIPTION
Problem: the `sharePolicy` field on `RepoConfig` allows configuring which peers we will announce documents to, but there is no way to stop a peer who knows a document ID from requesting it from us. We would like to be able to configure access policies which don't share even with peers who know the document ID.

Solution: add a new `shareConfig` field which has two fields `announce` is a function which has the same meaning as the existing `sharePolicy` field - it determines whether we should announce a document to a peer. The `access` field is a function which determines whether a peer should even have access to a document. If `access` returns false we respond to requests for the docuemnt with a "doc-unavailable" message.