### PR TITLE
Overly strict peer dependency in solid primitives

### DIFF
--- a/packages/automerge-repo-solid-primitives/package.json
+++ b/packages/automerge-repo-solid-primitives/package.json
@@ -24,7 +24,7 @@
     "vite-plugin-solid": "^2.11.0"
   },
   "peerDependencies": {
-    "@automerge/automerge": "3.0.0",
+    "@automerge/automerge": "^3.0.0",
     "solid-js": "^1.9.4"
   },
   "repository": {


### PR DESCRIPTION
As it stands, I get this warning when installing `automerge-repo-solid-primitives`:

```
 WARN  Issues with peer dependencies found
.
└─┬ @automerge/automerge-repo-solid-primitives 2.3.1
  └── ✕ unmet peer @automerge/automerge@3.0.0: found 3.1.1
```