### PR TITLE
Repo: Pass the initial heads of a document to the id factory

### DIFF
--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1,4 +1,4 @@
-import { next as A } from "@automerge/automerge"
+import { next as A, Heads } from "@automerge/automerge"
 import { MessageChannelNetworkAdapter } from "../../automerge-repo-network-messagechannel/src/index.js"
 import assert from "assert"
 import * as Uuid from "uuid"
@@ -2036,6 +2036,20 @@ describe("Repo.find() abort behavior", () => {
       })
       const handle = repo.create()
       expect(handle.documentId).toBe("9HUp4wuzRMx9MRvN4x")
+    })
+
+    it("passes the heads of the document to the callback", async () => {
+      const id = new Uint8Array("custom-id".split("").map(c => c.charCodeAt(0)))
+      let calledHeads: Heads | null = null
+      const repo = new Repo({
+        idFactory: (heads: Heads) => {
+          calledHeads = heads
+          return id
+        },
+      })
+      const handle = repo.create()
+      const actualHeads = A.getHeads(handle.doc())
+      assert.deepStrictEqual(actualHeads, calledHeads)
     })
 
     it("allows syncing documents with a custom ID", async () => {


### PR DESCRIPTION
Problem: the purpose of the idFactory callback which we are adding to `RepoConfig` is to allow keyhive to control the creation of a document ID, so that the document ID is the same as the keyhive document ID. At the moment the idFactory is called without any arguments, but the keyhive document ID requires the initial heads of the document in order to encode them into the initial delegation of the document creation.

Solution: pass the initial heads of the document to the idFactory. This is even more of a code smell than the original idFactory, but it is what we need for keyhive. This is all behind an @hidden flag because we think we'll probably want to change it anyway.