### PR TITLE
Add Repo.create2 to allow asynchronous id generation

### DIFF
--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -2034,7 +2034,7 @@ describe("Repo.find() abort behavior", () => {
       const repo = new Repo({
         idFactory: () => id,
       })
-      const handle = repo.create()
+      const handle = await repo.create2()
       expect(handle.documentId).toBe("9HUp4wuzRMx9MRvN4x")
     })
 
@@ -2047,7 +2047,7 @@ describe("Repo.find() abort behavior", () => {
           return id
         },
       })
-      const handle = repo.create()
+      const handle = await repo.create2()
       const actualHeads = A.getHeads(handle.doc())
       assert.deepStrictEqual(actualHeads, calledHeads)
     })
@@ -2066,7 +2066,7 @@ describe("Repo.find() abort behavior", () => {
 
       await pause(50)
 
-      const handle = alice.create({ foo: "bar" })
+      const handle = await alice.create2({ foo: "bar" })
       const bobHandle = await bob.find(handle.url)
       assert.deepStrictEqual(bobHandle.doc(), { foo: "bar" })
     })


### PR DESCRIPTION
Problem: in 722a48f9 we added an experimental constructor argument to Repo which allowed the user to provide a function used to generate new document IDs. The purpose of this function was so that keyhive can provide the IDs for documents, which in turn means that we don't have to carry around a mapping of keyhive IDs to document IDs in keyhive applications. Unfortunately it turns out that the keyhive ID generation is asynchronous, which means that we can't call it in Repo.create.

Solution: add a new method Repo.create2 which is asynchronous and which calls the id generator if present. This method is hidden and experimental. Long term I think we will need to do a major version change for Repo and make Repo.create asynchronous, but for now we can experiment with create2