### PR TITLE
add AbortError and ensure consistent abortion throws

### DIFF
--- a/packages/automerge-repo/src/helpers/abortable.ts
+++ b/packages/automerge-repo/src/helpers/abortable.ts
@@ -1,4 +1,22 @@
 /**
+ * An error thrown when an operation is aborted.
+ *
+ * @remarks
+ * This error is thrown when an operation is aborted. It is a subclass of DOMException
+ * with name "AbortError".
+ *
+ * @example
+ * ```typescript
+ * throw new AbortError()
+ * ```
+ */
+export class AbortError extends DOMException {
+  constructor(message?: string) {
+    super(message ?? "Operation aborted", "AbortError")
+  }
+}
+
+/**
  * Wraps a Promise and causes it to reject when the signal is aborted.
  *
  * @remarks
@@ -26,7 +44,6 @@
  * before the promise p settles, and settles as p settles otherwise
  * @throws {DOMException} With name "AbortError" if aborted before p settles
  */
-
 export function abortable<T>(
   p: Promise<T>,
   signal: AbortSignal | undefined
@@ -37,7 +54,7 @@ export function abortable<T>(
       "abort",
       () => {
         if (!settled) {
-          reject(new DOMException("Operation aborted", "AbortError"))
+          reject(new AbortError())
         }
       },
       { once: true }

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -34,6 +34,7 @@ import { getRandomItem } from "./helpers/getRandomItem.js"
 import { TestDoc } from "./types.js"
 import { StorageId, StorageKey } from "../src/storage/types.js"
 import { FindProgress } from "../src/FindProgress.js"
+import { AbortError } from "../src/helpers/abortable.js"
 
 describe("Repo", () => {
   describe("constructor", () => {
@@ -1993,7 +1994,7 @@ describe("Repo.find() abort behavior", () => {
 
     await expect(
       repo.find(generateAutomergeUrl(), { signal: controller.signal })
-    ).rejects.toThrow("Operation aborted")
+    ).rejects.toThrow(AbortError)
   })
 
   it("can abort while waiting for ready state", async () => {
@@ -2007,7 +2008,7 @@ describe("Repo.find() abort behavior", () => {
     const findPromise = repo.find(url, { signal: controller.signal })
     controller.abort()
 
-    await expect(findPromise).rejects.toThrow("Operation aborted")
+    await expect(findPromise).rejects.toThrow(AbortError)
     await expect(findPromise).rejects.not.toThrow("unavailable")
   })
 


### PR DESCRIPTION
Abortion error handling has been standardized for better consistency and user experience. Previously, the system threw two different error types: a ⁠DOMException when abortion was triggered from ⁠abortable, and a generic ⁠Error with the message "Operation aborted" when ⁠find() received an aborted signal. Now, all abortion scenarios consistently throw a single error type: ⁠AbortError, making error handling more predictable and easier to implement.