### PR TITLE
Allow undefined arguments to go into the useAwareness hooks

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useLocalAwareness.ts
+++ b/packages/automerge-repo-react-hooks/src/useLocalAwareness.ts
@@ -5,7 +5,7 @@ import { DocHandle } from "@automerge/automerge-repo/slim"
 
 export interface UseLocalAwarenessProps {
   /** The document handle to send ephemeral state on */
-  handle: DocHandle<unknown>
+  handle?: DocHandle<unknown>
   /** Our user ID **/
   userId: string
   /** The initial state object/primitive we should advertise */
@@ -43,13 +43,15 @@ export const useLocalAwareness = ({
         : stateOrUpdater
     setLocalState(state)
     // TODO: Send deltas instead of entire state
-    handle.broadcast([userId, state])
+    if (handle) {
+      handle.broadcast([userId, state])
+    }
   }
 
   useEffect(() => {
-    // Don't broadcast if userId isn't set: this avoids bogus broadcasts
-    // during the loading of a userId document.
-    if (!userId) {
+    // Don't broadcast if userId or handle isn't set: this avoids bogus broadcasts
+    // during the loading of a userId document or handle.
+    if (!userId || !handle) {
       return
     }
 
@@ -64,6 +66,10 @@ export const useLocalAwareness = ({
 
   useEffect(() => {
     // Send entire state to new peers
+    if (!handle || !userId) {
+      return
+    }
+
     let broadcastTimeoutId: ReturnType<typeof setTimeout>
     const newPeerEvents = peerEvents.on("new_peer", () => {
       broadcastTimeoutId = setTimeout(

--- a/packages/automerge-repo-react-hooks/test/useLocalAwareness.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useLocalAwareness.test.tsx
@@ -1,0 +1,275 @@
+import { DocHandle } from "@automerge/automerge-repo"
+import { render, waitFor } from "@testing-library/react"
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom"
+
+import { useLocalAwareness } from "../src/useLocalAwareness"
+import { setup, ExampleDoc } from "./testSetup"
+
+describe("useLocalAwareness", () => {
+  describe("with defined handle", () => {
+    const Component = ({
+      handle,
+      userId,
+      initialState,
+    }: {
+      handle: DocHandle<ExampleDoc>
+      userId: string
+      initialState: any
+    }) => {
+      const [state, setState] = useLocalAwareness({
+        handle,
+        userId,
+        initialState,
+      })
+      return (
+        <div>
+          <div data-testid="state">{JSON.stringify(state)}</div>
+          <button onClick={() => setState({ updated: true })}>Update</button>
+        </div>
+      )
+    }
+
+    it("should initialize with initial state", () => {
+      const { handleA, wrapper } = setup()
+      const initialState = { foo: "bar" }
+
+      const { getByTestId } = render(
+        <Component
+          handle={handleA}
+          userId="user1"
+          initialState={initialState}
+        />,
+        { wrapper }
+      )
+
+      expect(getByTestId("state")).toHaveTextContent(
+        JSON.stringify(initialState)
+      )
+    })
+
+    it("should broadcast state changes when handle is defined", async () => {
+      const { handleA, wrapper } = setup()
+      const broadcastSpy = vi.spyOn(handleA, "broadcast")
+
+      const { getByText, getByTestId } = render(
+        <Component
+          handle={handleA}
+          userId="user1"
+          initialState={{ initial: true }}
+        />,
+        { wrapper }
+      )
+
+      // Wait for initial heartbeat
+      await waitFor(() => {
+        expect(broadcastSpy).toHaveBeenCalled()
+      })
+
+      // Clear previous calls
+      broadcastSpy.mockClear()
+
+      // Click update button
+      React.act(() => {
+        getByText("Update").click()
+      })
+
+      // Should broadcast the update
+      await waitFor(() => {
+        expect(broadcastSpy).toHaveBeenCalledWith(["user1", { updated: true }])
+      })
+
+      expect(getByTestId("state")).toHaveTextContent(
+        JSON.stringify({ updated: true })
+      )
+    })
+
+    it("should send periodic heartbeats", async () => {
+      const { handleA, wrapper } = setup()
+      const broadcastSpy = vi.spyOn(handleA, "broadcast")
+      const initialState = { heartbeat: true }
+
+      render(
+        <Component
+          handle={handleA}
+          userId="user1"
+          initialState={initialState}
+        />,
+        { wrapper }
+      )
+
+      // Should send initial heartbeat
+      await waitFor(() => {
+        expect(broadcastSpy).toHaveBeenCalledWith(["user1", initialState])
+      })
+    })
+
+    it("should not broadcast if userId is not set", async () => {
+      const { handleA, wrapper } = setup()
+      const broadcastSpy = vi.spyOn(handleA, "broadcast")
+
+      render(
+        <Component handle={handleA} userId="" initialState={{ test: true }} />,
+        { wrapper }
+      )
+
+      // Wait a bit
+      await new Promise(resolve => setTimeout(resolve, 100))
+
+      // Should not have broadcast
+      expect(broadcastSpy).not.toHaveBeenCalled()
+    })
+
+    it("should cleanup on unmount", async () => {
+      const { handleA, wrapper } = setup()
+
+      const { unmount } = render(
+        <Component
+          handle={handleA}
+          userId="user1"
+          initialState={{ test: true }}
+        />,
+        { wrapper }
+      )
+
+      // Wait for initial heartbeat
+      await new Promise(resolve => setTimeout(resolve, 100))
+
+      // Unmount
+      unmount()
+
+      // No errors should occur
+      expect(true).toBe(true)
+    })
+  })
+
+  describe("with undefined handle", () => {
+    const Component = ({
+      handle,
+      userId,
+      initialState,
+    }: {
+      handle?: DocHandle<ExampleDoc>
+      userId: string
+      initialState: any
+    }) => {
+      const [state, setState] = useLocalAwareness({
+        handle,
+        userId,
+        initialState,
+      })
+      return (
+        <div>
+          <div data-testid="state">{JSON.stringify(state)}</div>
+          <button onClick={() => setState({ updated: true })}>Update</button>
+        </div>
+      )
+    }
+
+    it("should not crash when handle is undefined", () => {
+      const { wrapper } = setup()
+
+      expect(() => {
+        render(<Component userId="user1" initialState={{ test: true }} />, {
+          wrapper,
+        })
+      }).not.toThrow()
+    })
+
+    it("should still maintain local state when handle is undefined", () => {
+      const { wrapper } = setup()
+      const initialState = { foo: "bar" }
+
+      const { getByTestId } = render(
+        <Component userId="user1" initialState={initialState} />,
+        { wrapper }
+      )
+
+      expect(getByTestId("state")).toHaveTextContent(
+        JSON.stringify(initialState)
+      )
+    })
+
+    it("should update local state without broadcasting when handle is undefined", async () => {
+      const { wrapper } = setup()
+
+      const { getByText, getByTestId } = render(
+        <Component userId="user1" initialState={{ initial: true }} />,
+        { wrapper }
+      )
+
+      // Click update button
+      React.act(() => {
+        getByText("Update").click()
+      })
+
+      // State should update
+      await waitFor(() => {
+        expect(getByTestId("state")).toHaveTextContent(
+          JSON.stringify({ updated: true })
+        )
+      })
+    })
+
+    it("should handle transition from undefined to defined handle", async () => {
+      const { handleA, wrapper } = setup()
+      const broadcastSpy = vi.spyOn(handleA, "broadcast")
+
+      const { rerender, getByText } = render(
+        <Component userId="user1" initialState={{ test: true }} />,
+        { wrapper }
+      )
+
+      // Wait a bit with undefined handle
+      await new Promise(resolve => setTimeout(resolve, 100))
+
+      // Should not have broadcast yet
+      expect(broadcastSpy).not.toHaveBeenCalled()
+
+      // Now provide a handle
+      rerender(
+        <Component
+          handle={handleA}
+          userId="user1"
+          initialState={{ test: true }}
+        />
+      )
+
+      // Should start broadcasting
+      await waitFor(() => {
+        expect(broadcastSpy).toHaveBeenCalled()
+      })
+    })
+
+    it("should handle transition from defined to undefined handle", async () => {
+      const { handleA, wrapper } = setup()
+      const broadcastSpy = vi.spyOn(handleA, "broadcast")
+
+      const { rerender } = render(
+        <Component
+          handle={handleA}
+          userId="user1"
+          initialState={{ test: true }}
+        />,
+        { wrapper }
+      )
+
+      // Wait for initial broadcast
+      await waitFor(() => {
+        expect(broadcastSpy).toHaveBeenCalled()
+      })
+
+      broadcastSpy.mockClear()
+
+      // Now remove the handle
+      rerender(<Component userId="user1" initialState={{ test: true }} />)
+
+      // Wait a bit
+      await new Promise(resolve => setTimeout(resolve, 100))
+
+      // Should not broadcast anymore
+      expect(broadcastSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/automerge-repo-react-hooks/test/useRemoteAwareness.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useRemoteAwareness.test.tsx
@@ -1,0 +1,326 @@
+import { DocHandle } from "@automerge/automerge-repo"
+import { render, waitFor } from "@testing-library/react"
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom"
+
+import { useRemoteAwareness } from "../src/useRemoteAwareness"
+import { setup, ExampleDoc } from "./testSetup"
+
+describe("useRemoteAwareness", () => {
+  describe("with defined handle", () => {
+    const Component = ({
+      handle,
+      localUserId,
+    }: {
+      handle: DocHandle<ExampleDoc>
+      localUserId?: string
+    }) => {
+      const [peerStates, heartbeats] = useRemoteAwareness({
+        handle,
+        localUserId,
+      })
+      return (
+        <div>
+          <div data-testid="peer-states">{JSON.stringify(peerStates)}</div>
+          <div data-testid="heartbeats">{JSON.stringify(heartbeats)}</div>
+        </div>
+      )
+    }
+
+    it("should initialize with empty peer states", () => {
+      const { handleA, wrapper } = setup()
+
+      const { getByTestId } = render(
+        <Component handle={handleA} localUserId="local-user" />,
+        { wrapper }
+      )
+
+      expect(getByTestId("peer-states")).toHaveTextContent("{}")
+      expect(getByTestId("heartbeats")).toHaveTextContent("{}")
+    })
+
+    it("should receive and store remote peer states", async () => {
+      const { handleA, wrapper } = setup()
+
+      const { getByTestId } = render(
+        <Component handle={handleA} localUserId="local-user" />,
+        { wrapper }
+      )
+
+      // Simulate receiving a message from a remote peer
+      const mockEvent = {
+        handle: handleA,
+        message: ["remote-user", { status: "online" }],
+      }
+
+      // @ts-ignore - accessing private emit for testing
+      React.act(() => {
+        handleA.emit("ephemeral-message", mockEvent)
+      })
+
+      await waitFor(() => {
+        expect(getByTestId("peer-states")).toHaveTextContent(
+          JSON.stringify({ "remote-user": { status: "online" } })
+        )
+      })
+    })
+
+    it("should filter out messages from local user", async () => {
+      const { handleA, wrapper } = setup()
+
+      const { getByTestId } = render(
+        <Component handle={handleA} localUserId="local-user" />,
+        { wrapper }
+      )
+
+      // Simulate receiving a message from the local user (should be ignored)
+      const mockEvent = {
+        handle: handleA,
+        message: ["local-user", { status: "online" }],
+      }
+
+      // @ts-ignore - accessing private emit for testing
+      React.act(() => {
+        handleA.emit("ephemeral-message", mockEvent)
+      })
+
+      // Wait a bit
+      await new Promise(resolve => setTimeout(resolve, 100))
+
+      // Should still be empty
+      expect(getByTestId("peer-states")).toHaveTextContent("{}")
+    })
+
+    it("should update heartbeat timestamps when receiving messages", async () => {
+      const { handleA, wrapper } = setup()
+      const mockGetTime = vi.fn(() => 1000)
+
+      const ComponentWithTime = () => {
+        const [peerStates, heartbeats] = useRemoteAwareness({
+          handle: handleA,
+          localUserId: "local-user",
+          getTime: mockGetTime,
+        })
+        return (
+          <div>
+            <div data-testid="heartbeats">{JSON.stringify(heartbeats)}</div>
+          </div>
+        )
+      }
+
+      const { getByTestId } = render(<ComponentWithTime />, { wrapper })
+
+      // Simulate receiving a message
+      const mockEvent = {
+        handle: handleA,
+        message: ["remote-user", { status: "online" }],
+      }
+
+      // @ts-ignore - accessing private emit for testing
+      React.act(() => {
+        handleA.emit("ephemeral-message", mockEvent)
+      })
+
+      await waitFor(() => {
+        expect(getByTestId("heartbeats")).toHaveTextContent(
+          JSON.stringify({ "remote-user": 1000 })
+        )
+      })
+    })
+
+    it("should prune offline peers after timeout", async () => {
+      const { handleA, wrapper } = setup()
+      let currentTime = 1000
+      const mockGetTime = vi.fn(() => currentTime)
+
+      const ComponentWithTime = () => {
+        const [peerStates] = useRemoteAwareness({
+          handle: handleA,
+          localUserId: "local-user",
+          offlineTimeout: 100, // Short timeout for testing
+          getTime: mockGetTime,
+        })
+        return (
+          <div>
+            <div data-testid="peer-states">{JSON.stringify(peerStates)}</div>
+          </div>
+        )
+      }
+
+      const { getByTestId } = render(<ComponentWithTime />, { wrapper })
+
+      // Simulate receiving a message
+      const mockEvent = {
+        handle: handleA,
+        message: ["remote-user", { status: "online" }],
+      }
+
+      // @ts-ignore - accessing private emit for testing
+      React.act(() => {
+        handleA.emit("ephemeral-message", mockEvent)
+      })
+
+      // Should have the peer
+      await waitFor(() => {
+        expect(getByTestId("peer-states")).toHaveTextContent(
+          JSON.stringify({ "remote-user": { status: "online" } })
+        )
+      })
+
+      // Advance time past the offline timeout
+      currentTime = 1200
+
+      // Wait for the pruning interval to run (it runs every 100ms)
+      await new Promise(resolve => setTimeout(resolve, 150))
+
+      // Should now be pruned
+      expect(getByTestId("peer-states")).toHaveTextContent("{}")
+    })
+
+    it("should cleanup listeners on unmount", async () => {
+      const { handleA, wrapper } = setup()
+      const removeListenerSpy = vi.spyOn(handleA, "removeListener")
+
+      const { unmount } = render(
+        <Component handle={handleA} localUserId="local-user" />,
+        { wrapper }
+      )
+
+      // Unmount
+      unmount()
+
+      // Should have removed listener
+      expect(removeListenerSpy).toHaveBeenCalledWith(
+        "ephemeral-message",
+        expect.any(Function)
+      )
+    })
+  })
+
+  describe("with undefined handle", () => {
+    const Component = ({
+      handle,
+      localUserId,
+    }: {
+      handle?: DocHandle<ExampleDoc>
+      localUserId?: string
+    }) => {
+      const [peerStates, heartbeats] = useRemoteAwareness({
+        handle,
+        localUserId,
+      })
+      return (
+        <div>
+          <div data-testid="peer-states">{JSON.stringify(peerStates)}</div>
+          <div data-testid="heartbeats">{JSON.stringify(heartbeats)}</div>
+        </div>
+      )
+    }
+
+    it("should not crash when handle is undefined", () => {
+      const { wrapper } = setup()
+
+      expect(() => {
+        render(<Component localUserId="local-user" />, { wrapper })
+      }).not.toThrow()
+    })
+
+    it("should return empty peer states when handle is undefined", () => {
+      const { wrapper } = setup()
+
+      const { getByTestId } = render(<Component localUserId="local-user" />, {
+        wrapper,
+      })
+
+      expect(getByTestId("peer-states")).toHaveTextContent("{}")
+      expect(getByTestId("heartbeats")).toHaveTextContent("{}")
+    })
+
+    it("should handle transition from undefined to defined handle", async () => {
+      const { handleA, wrapper } = setup()
+
+      const { rerender, getByTestId } = render(
+        <Component localUserId="local-user" />,
+        { wrapper }
+      )
+
+      // Should have empty states
+      expect(getByTestId("peer-states")).toHaveTextContent("{}")
+
+      // Now provide a handle
+      rerender(<Component handle={handleA} localUserId="local-user" />)
+
+      // Simulate receiving a message
+      const mockEvent = {
+        handle: handleA,
+        message: ["remote-user", { status: "online" }],
+      }
+
+      // @ts-ignore - accessing private emit for testing
+      React.act(() => {
+        handleA.emit("ephemeral-message", mockEvent)
+      })
+
+      // Should now receive and display the peer state
+      await waitFor(() => {
+        expect(getByTestId("peer-states")).toHaveTextContent(
+          JSON.stringify({ "remote-user": { status: "online" } })
+        )
+      })
+    })
+
+    it("should handle transition from defined to undefined handle", async () => {
+      const { handleA, wrapper } = setup()
+
+      const { rerender, getByTestId } = render(
+        <Component handle={handleA} localUserId="local-user" />,
+        { wrapper }
+      )
+
+      // Simulate receiving a message
+      const mockEvent = {
+        handle: handleA,
+        message: ["remote-user", { status: "online" }],
+      }
+
+      // @ts-ignore - accessing private emit for testing
+      React.act(() => {
+        handleA.emit("ephemeral-message", mockEvent)
+      })
+
+      // Should have the peer
+      await waitFor(() => {
+        expect(getByTestId("peer-states")).toHaveTextContent(
+          JSON.stringify({ "remote-user": { status: "online" } })
+        )
+      })
+
+      // Now remove the handle
+      rerender(<Component localUserId="local-user" />)
+
+      // The peer states should remain (they don't get cleared automatically)
+      // but new messages won't be received
+      expect(getByTestId("peer-states")).toHaveTextContent(
+        JSON.stringify({ "remote-user": { status: "online" } })
+      )
+    })
+
+    it("should not attempt to add listeners when handle is undefined", async () => {
+      const { wrapper } = setup()
+
+      // This should not throw any errors
+      const { unmount } = render(<Component localUserId="local-user" />, {
+        wrapper,
+      })
+
+      // Wait a bit
+      await new Promise(resolve => setTimeout(resolve, 100))
+
+      // Unmount should also not throw
+      unmount()
+
+      expect(true).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
This is leftover debt from changing find to a promise-based API; it's now possible for the useHandle hook to return undefined, and so the hooks need to guard against receiving a missing value.
