### PR TITLE
Add more metrics

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -172,6 +172,12 @@ export class Repo extends EventEmitter<RepoEvents> {
       storageSubsystem.on("document-loaded", event =>
         this.emit("doc-metrics", { type: "doc-loaded", ...event })
       )
+      storageSubsystem.on("doc-compacted", event =>
+        this.emit("doc-metrics", { type: "doc-compacted", ...event })
+      )
+      storageSubsystem.on("doc-saved", event =>
+        this.emit("doc-metrics", { type: "doc-saved", ...event })
+      )
     }
 
     this.storageSubsystem = storageSubsystem
@@ -1088,6 +1094,17 @@ export interface DeleteDocumentPayload {
 
 export type DocMetrics =
   | DocSyncMetrics
+  | {
+      type: "doc-compacted"
+      documentId: DocumentId
+      durationMillis: number
+    }
+  | {
+      type: "doc-saved"
+      documentId: DocumentId
+      durationMillis: number
+      sinceHeads: Array<string>
+    }
   | {
       type: "doc-loaded"
       documentId: DocumentId

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -191,7 +191,15 @@ export class DocSynchronizer extends Synchronizer {
     this.#log(`sendSyncMessage ->${peerId}`)
 
     this.#withSyncState(peerId, syncState => {
+      const start = performance.now()
       const [newSyncState, message] = A.generateSyncMessage(doc, syncState)
+      const end = performance.now()
+      this.emit("metrics", {
+        type: "generate-sync-message",
+        documentId: this.#handle.documentId,
+        durationMillis: end - start,
+      })
+
       if (message) {
         this.#setSyncState(peerId, newSyncState)
         const isNew = A.getHeads(doc).length === 0

--- a/packages/automerge-repo/src/synchronizer/Synchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/Synchronizer.ts
@@ -34,6 +34,11 @@ export type DocSyncMetrics =
       numChanges: number
     }
   | {
+      type: "generate-sync-message"
+      documentId: DocumentId
+      durationMillis: number
+    }
+  | {
       type: "doc-denied"
       documentId: DocumentId
     }


### PR DESCRIPTION
Since Automerge 3.0 generateSyncMessage, saveSince, and save have become much more CPU intensive. In order to be able to monitor the effect of this change on running sync servers add some extra DocMetrics events for tracking these things. Specifically:

"doc-saved": fired whenever saveSince is called
"doc-compacted": fired whenever save is called
"generate-sync-message": fired whenever generateSyncMessage is called