### PR TITLE
Fix formatting issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,20 @@ This is a monorepo containing the following packages:
 #### Storage adapters
 
 - [automerge-repo-storage-indexeddb](/packages/automerge-repo-storage-indexeddb/): A storage
-  adapter to persist data in a browser
+  adapter to persist data in a browser.
 - [automerge-repo-storage-nodefs](/packages/automerge-repo-storage-nodefs/): A storage adapter to
-  write changes to the filesystem
+  write changes to the filesystem.
 
 #### Network adapters
 
 - [automerge-repo-network-websocket](/packages/automerge-repo-network-websocket/): Network adapters
-  for both sides of a client/server configuration over websocket
+  for both sides of a client/server configuration over websocket.
 - [automerge-repo-network-messagechannel](/packages/automerge-repo-network-messagechannel/): A
   network adapter that uses the [MessageChannel
-  API](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel) to communicate between tabs
+  API](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel) to communicate between tabs.
 - [automerge-repo-network-broadcastchannel](/packages/automerge-repo-network-broadcastchannel/):
   Likely only useful for experimentation, but allows simple (inefficient) tab-to-tab data
-  synchronization
+  synchronization.
 
 Please note that a reference sync-server peer which demonstrates the use of
 [automerge-repo-network-websocket](/packages/automerge-repo-network-websocket/)


### PR DESCRIPTION
Added missing periods to Storage adapters and Network adapters sections for consistent punctuation throughout the documentation.