### PR TITLE
turn off minification (and on maps) in solid and react

### DIFF
--- a/packages/automerge-repo-react-hooks/vite.config.ts
+++ b/packages/automerge-repo-react-hooks/vite.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
     process.env.VISUALIZE && visualizer(),
   ],
   build: {
+    minify: false,
+    sourcemap: true,
     lib: {
       entry: resolve(__dirname, "src/index.ts"),
       formats: ["es"],

--- a/packages/automerge-repo-solid-primitives/vite.config.ts
+++ b/packages/automerge-repo-solid-primitives/vite.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
     process.env.VISUALIZE && visualizer(),
   ],
   build: {
+    minify: false,
+    sourcemap: true,
     lib: {
       entry: resolve(__dirname, "src/index.ts"),
       formats: ["es"],


### PR DESCRIPTION
the rest of the packages aren't minified before publish, but these ones are because that's the default for vite.

so now they aren't minified too.