### PR TITLE
Add usePresence for solid primitives

### DIFF
--- a/packages/automerge-repo-solid-primitives/readme.md
+++ b/packages/automerge-repo-solid-primitives/readme.md
@@ -127,3 +127,9 @@ useRepo(): Repo
 ```ts
 const repo = useRepo()
 ```
+
+### `usePresence`
+
+This [hook](./src/usePresence.ts) allows temporary state to be shared, such as cursor positions or peer online/offline status.
+
+Ephemeral messages are replicated between peers, but not saved to the Automerge doc, and are used for temporary updates that will be discarded.

--- a/packages/automerge-repo-solid-primitives/src/usePresence.ts
+++ b/packages/automerge-repo-solid-primitives/src/usePresence.ts
@@ -23,6 +23,8 @@ export type UsePresenceResult<State extends PresenceState> = {
     channel: Channel,
     value: State[Channel]
   ) => void
+  start: () => void
+  stop: () => void
 }
 
 export function usePresence<State extends PresenceState>({
@@ -74,9 +76,23 @@ export function usePresence<State extends PresenceState>({
     setLocalState(() => updated)
   }
 
+  const start = () => {
+    presence().start({
+      initialState: presence().getLocalState(),
+      heartbeatMs,
+      peerTtlMs,
+    })
+  }
+
+  const stop = () => {
+    presence().stop()
+  }
+
   return {
     localState,
     peerStates,
     update,
+    start,
+    stop,
   }
 }

--- a/packages/automerge-repo-solid-primitives/src/usePresence.ts
+++ b/packages/automerge-repo-solid-primitives/src/usePresence.ts
@@ -7,7 +7,7 @@ import {
   type PresenceState,
   type UserId,
 } from "@automerge/automerge-repo/slim"
-import { onCleanup, onMount } from "solid-js"
+import { onCleanup } from "solid-js"
 import { createStore, reconcile, type Store } from "solid-js/store"
 
 export type UsePresenceConfig<State extends PresenceState> =
@@ -59,14 +59,11 @@ export function usePresence<State extends PresenceState>({
     )
   }
 
-  onMount(() => {
-    const presenceHandle = presence
-    presenceHandle.start({
-      initialState: firstInitialState,
-      ...currentTiming,
-    })
-    setupPresenceHandlers()
+  presence.start({
+    initialState: firstInitialState,
+    ...currentTiming,
   })
+  setupPresenceHandlers()
 
   onCleanup(() => {
     presence.stop()

--- a/packages/automerge-repo-solid-primitives/src/usePresence.ts
+++ b/packages/automerge-repo-solid-primitives/src/usePresence.ts
@@ -1,0 +1,82 @@
+import {
+  type DeviceId,
+  type DocHandle,
+  PeerStateView,
+  Presence,
+  type PresenceConfig,
+  type PresenceState,
+  type UserId,
+} from "@automerge/automerge-repo/slim"
+import { type Accessor, createSignal, onCleanup, onMount } from "solid-js"
+
+export type UsePresenceConfig<State extends PresenceState> =
+  PresenceConfig<State> & {
+    handle: DocHandle<unknown>
+    userId?: UserId
+    deviceId?: DeviceId
+  }
+
+export type UsePresenceResult<State extends PresenceState> = {
+  peerStates: Accessor<PeerStateView<State>>
+  localState: Accessor<State> | undefined
+  update: <Channel extends keyof State>(
+    channel: Channel,
+    value: State[Channel]
+  ) => void
+}
+
+export function usePresence<State extends PresenceState>({
+  handle,
+  userId,
+  deviceId,
+  initialState,
+  heartbeatMs,
+  peerTtlMs,
+}: UsePresenceConfig<State>): UsePresenceResult<State> {
+  const [localState, setLocalState] = createSignal<State>(initialState)
+  const [peerStates, setPeerStates] = createSignal(new PeerStateView<State>({}))
+  const [presence] = createSignal(
+    new Presence<State>({ handle, userId, deviceId })
+  )
+
+  onMount(() => {
+    const presenceHandle = presence()
+    presenceHandle.start({
+      initialState,
+      heartbeatMs,
+      peerTtlMs,
+    })
+
+    presenceHandle.on("heartbeat", () =>
+      setPeerStates(presenceHandle.getPeerStates())
+    )
+    presenceHandle.on("snapshot", () =>
+      setPeerStates(presenceHandle.getPeerStates())
+    )
+    presenceHandle.on("update", () =>
+      setPeerStates(presenceHandle.getPeerStates())
+    )
+    presenceHandle.on("goodbye", () =>
+      setPeerStates(presenceHandle.getPeerStates())
+    )
+  })
+
+  onCleanup(() => {
+    presence().stop()
+  })
+
+  const update = <Channel extends keyof State>(
+    channel: Channel,
+    msg: State[Channel]
+  ) => {
+    presence().broadcast(channel, msg)
+    const updated = presence().getLocalState()
+    setLocalState(() => updated)
+  }
+
+  return {
+    localState,
+    peerStates,
+    update,
+  }
+}

--- a/packages/automerge-repo-solid-primitives/src/usePresence.ts
+++ b/packages/automerge-repo-solid-primitives/src/usePresence.ts
@@ -23,7 +23,7 @@ export type UsePresenceResult<State extends PresenceState> = {
     channel: Channel,
     value: State[Channel]
   ) => void
-  start: () => void
+  start: (config?: Partial<PresenceConfig<State>>) => void
   stop: () => void
 }
 
@@ -40,6 +40,7 @@ export function usePresence<State extends PresenceState>({
   const [presence] = createSignal(
     new Presence<State>({ handle, userId, deviceId })
   )
+  const firstInitialState = initialState
 
   onMount(() => {
     const presenceHandle = presence()
@@ -76,11 +77,12 @@ export function usePresence<State extends PresenceState>({
     setLocalState(() => updated)
   }
 
-  const start = () => {
+  const start = (config?: Partial<PresenceConfig<State>>) => {
+    const initialState = config?.initialState ?? presence().getLocalState()
     presence().start({
-      initialState: presence().getLocalState(),
-      heartbeatMs,
-      peerTtlMs,
+      ...firstInitialState,
+      ...config,
+      initialState,
     })
   }
 

--- a/packages/automerge-repo-solid-primitives/src/usePresence.ts
+++ b/packages/automerge-repo-solid-primitives/src/usePresence.ts
@@ -1,11 +1,9 @@
 import {
-  type DeviceId,
   type DocHandle,
   PeerStateView,
   Presence,
   type PresenceConfig,
   type PresenceState,
-  type UserId,
 } from "@automerge/automerge-repo/slim"
 import { onCleanup } from "solid-js"
 import { createStore, reconcile, type Store } from "solid-js/store"
@@ -13,8 +11,6 @@ import { createStore, reconcile, type Store } from "solid-js/store"
 export type UsePresenceConfig<State extends PresenceState> =
   PresenceConfig<State> & {
     handle: DocHandle<unknown>
-    userId?: UserId
-    deviceId?: DeviceId
   }
 
 export type UsePresenceResult<State extends PresenceState> = {
@@ -30,15 +26,13 @@ export type UsePresenceResult<State extends PresenceState> = {
 
 export function usePresence<State extends PresenceState>({
   handle,
-  userId,
-  deviceId,
   initialState,
   heartbeatMs,
   peerTtlMs,
 }: UsePresenceConfig<State>): UsePresenceResult<State> {
   const [localState, setLocalState] = createStore<State>(initialState)
   const [peerStates, setPeerStates] = createStore(new PeerStateView<State>({}))
-  const presence = new Presence<State>({ handle, userId, deviceId })
+  const presence = new Presence<State>({ handle })
   const firstInitialState = initialState
   let currentTiming = { heartbeatMs, peerTtlMs }
 

--- a/packages/automerge-repo-solid-primitives/test/usePresence.test.tsx
+++ b/packages/automerge-repo-solid-primitives/test/usePresence.test.tsx
@@ -1,0 +1,55 @@
+import { Repo } from "@automerge/automerge-repo"
+import { render } from "@solidjs/testing-library"
+import { describe, expect, it, vi } from "vitest"
+import { usePresence } from "../src/usePresence.js"
+import { PRESENCE_MESSAGE_MARKER } from "../../automerge-repo/dist/presence/constants.js"
+import { PresenceMessage } from "../../automerge-repo/dist/presence/types.js"
+
+const isPresenceMessage = (msg: unknown): msg is PresenceMessage =>
+  typeof msg === "object" && msg !== null && PRESENCE_MESSAGE_MARKER in msg
+
+describe("usePresence", () => {
+  it("changes heartbeat frequency after stop/start", async () => {
+    vi.useFakeTimers()
+
+    const repo = new Repo()
+    const handle = repo.create({})
+
+    let api: ReturnType<typeof usePresence>
+    const Component = () => {
+      api = usePresence({
+        handle,
+        userId: "alice",
+        initialState: {},
+        heartbeatMs: 50,
+      })
+      return null
+    }
+
+    render(() => <Component />)
+
+    await Promise.resolve() // allow onMount
+
+    const broadcastSpy = vi.spyOn(handle, "broadcast")
+    const heartbeatCount = () =>
+      broadcastSpy.mock.calls.filter(([msg]) => {
+        if (!isPresenceMessage(msg)) return false
+        return msg[PRESENCE_MESSAGE_MARKER].type === "heartbeat"
+      }).length
+
+    vi.advanceTimersByTime(220)
+    const slowCount = heartbeatCount()
+    expect(slowCount).toBeGreaterThan(0)
+
+    api!.stop()
+    vi.advanceTimersByTime(220)
+    expect(heartbeatCount()).toBe(slowCount)
+
+    api!.start({ heartbeatMs: 10 })
+    vi.advanceTimersByTime(220)
+    const fastCount = heartbeatCount() - slowCount
+    expect(fastCount).toBeGreaterThan(slowCount)
+
+    vi.useRealTimers()
+  })
+})

--- a/packages/automerge-repo-solid-primitives/test/usePresence.test.tsx
+++ b/packages/automerge-repo-solid-primitives/test/usePresence.test.tsx
@@ -1,54 +1,149 @@
 import { Repo } from "@automerge/automerge-repo"
 import { render } from "@solidjs/testing-library"
 import { describe, expect, it, vi } from "vitest"
-import { usePresence } from "../src/usePresence.js"
-import { PRESENCE_MESSAGE_MARKER } from "../../automerge-repo/dist/presence/constants.js"
-import { PresenceMessage } from "../../automerge-repo/dist/presence/types.js"
+import { usePresence, type UsePresenceResult } from "../src/usePresence.js"
 
-const isPresenceMessage = (msg: unknown): msg is PresenceMessage =>
-  typeof msg === "object" && msg !== null && PRESENCE_MESSAGE_MARKER in msg
+type PresenceState = { status?: string }
+
+type PresenceEnvelope = { __presence: { type: string } }
+
+const isPresenceEnvelope = (msg: unknown): msg is PresenceEnvelope =>
+  typeof msg === "object" && msg !== null && "__presence" in msg
+
+const countHeartbeats = (calls: unknown[][]) =>
+  calls.filter(([msg]) => {
+    if (!isPresenceEnvelope(msg)) return false
+    return msg.__presence.type === "heartbeat"
+  }).length
+
+const PresenceComponent = (props: {
+  handle: ReturnType<Repo["create"]>
+  userId: string
+  initialState: PresenceState
+  heartbeatMs?: number
+  onReady?: (api: UsePresenceResult<PresenceState>) => void
+}) => {
+  const presence = usePresence<PresenceState>({
+    handle: props.handle,
+    userId: props.userId,
+    initialState: props.initialState,
+    heartbeatMs: props.heartbeatMs,
+  })
+
+  props.onReady?.(presence)
+
+  return null
+}
 
 describe("usePresence", () => {
-  it("changes heartbeat frequency after stop/start", async () => {
+  it("switches heartbeat interval via stop/start", async () => {
     vi.useFakeTimers()
 
     const repo = new Repo()
     const handle = repo.create({})
 
-    let api: ReturnType<typeof usePresence>
-    const Component = () => {
-      api = usePresence({
-        handle,
-        userId: "alice",
-        initialState: {},
-        heartbeatMs: 50,
-      })
-      return null
-    }
+    let api: UsePresenceResult<PresenceState> | undefined
+    render(() => (
+      <PresenceComponent
+        handle={handle}
+        userId="user1"
+        initialState={{ status: "ready" }}
+        heartbeatMs={50}
+        onReady={value => {
+          api = value
+        }}
+      />
+    ))
 
-    render(() => <Component />)
+    await Promise.resolve()
 
-    await Promise.resolve() // allow onMount
+    expect(api).toBeDefined()
 
     const broadcastSpy = vi.spyOn(handle, "broadcast")
-    const heartbeatCount = () =>
-      broadcastSpy.mock.calls.filter(([msg]) => {
-        if (!isPresenceMessage(msg)) return false
-        return msg[PRESENCE_MESSAGE_MARKER].type === "heartbeat"
-      }).length
 
     vi.advanceTimersByTime(220)
-    const slowCount = heartbeatCount()
+    const slowCount = countHeartbeats(broadcastSpy.mock.calls)
     expect(slowCount).toBeGreaterThan(0)
 
-    api!.stop()
+    api?.stop()
     vi.advanceTimersByTime(220)
-    expect(heartbeatCount()).toBe(slowCount)
+    expect(countHeartbeats(broadcastSpy.mock.calls)).toBe(slowCount)
 
-    api!.start({ heartbeatMs: 10 })
+    api?.start({ heartbeatMs: 10 })
     vi.advanceTimersByTime(220)
-    const fastCount = heartbeatCount() - slowCount
+    const fastCount = countHeartbeats(broadcastSpy.mock.calls) - slowCount
     expect(fastCount).toBeGreaterThan(slowCount)
+
+    vi.useRealTimers()
+  })
+
+  it("keeps heartbeat interval on restart without config", async () => {
+    vi.useFakeTimers()
+
+    const repo = new Repo()
+    const handle = repo.create({})
+
+    let api: UsePresenceResult<PresenceState> | undefined
+    render(() => (
+      <PresenceComponent
+        handle={handle}
+        userId="user1"
+        initialState={{ status: "ready" }}
+        heartbeatMs={15}
+        onReady={value => {
+          api = value
+        }}
+      />
+    ))
+
+    await Promise.resolve()
+
+    expect(api).toBeDefined()
+
+    const broadcastSpy = vi.spyOn(handle, "broadcast")
+
+    vi.advanceTimersByTime(220)
+    const initialCount = countHeartbeats(broadcastSpy.mock.calls)
+    expect(initialCount).toBeGreaterThan(0)
+
+    api?.stop()
+    vi.advanceTimersByTime(220)
+    const stoppedCount = countHeartbeats(broadcastSpy.mock.calls)
+    expect(stoppedCount).toBe(initialCount)
+
+    api?.start()
+    vi.advanceTimersByTime(220)
+    const resumedCount = countHeartbeats(broadcastSpy.mock.calls) - stoppedCount
+    expect(resumedCount).toBeGreaterThan(0)
+    expect(resumedCount).toBeGreaterThanOrEqual(initialCount - 2)
+    expect(resumedCount).toBeLessThanOrEqual(initialCount + 2)
+
+    vi.useRealTimers()
+  })
+
+  it("uses heartbeatMs from props", async () => {
+    vi.useFakeTimers()
+
+    const repo = new Repo()
+    const handle = repo.create({})
+
+    render(() => (
+      <PresenceComponent
+        handle={handle}
+        userId="user1"
+        initialState={{ status: "ready" }}
+        heartbeatMs={20}
+      />
+    ))
+
+    await Promise.resolve()
+
+    const broadcastSpy = vi.spyOn(handle, "broadcast")
+
+    vi.advanceTimersByTime(100)
+    const count = countHeartbeats(broadcastSpy.mock.calls)
+    expect(count).toBeGreaterThanOrEqual(5 - 2)
+    expect(count).toBeLessThanOrEqual(5 + 2)
 
     vi.useRealTimers()
   })


### PR DESCRIPTION
- Adds a usePresence hook to the solid-primitives package (mimics the one present in the react-hooks package)
- Exposes start/stop methods from the underlying Presence instance