### PR TITLE
Subductionjs pushwork fixes

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -736,14 +736,15 @@ export class Repo extends EventEmitter<RepoEvents> {
   }
 
   async shutdown() {
-    // Stop all inbound data — no new changes can arrive
+    // Quiesce Subduction first — stops reconnect loops, flushes pending
+    // saves, awaits storage writes, disconnects transports, frees Wasm
+    await this.#subductionSource?.shutdown()
+
+    // Stop traditional sync network connections
     this.networkSubsystem.disconnect()
 
-    // Flush all Automerge document storage (bypasses throttle, saves directly)
+    // Flush final Automerge document state to storage
     await this.flush()
-
-    // Flush Subduction pending saves, await in-flight writes, then clear timers
-    await this.#subductionSource?.shutdown()
   }
 
   metrics(): { documents: { [key: string]: any } } {

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -736,8 +736,14 @@ export class Repo extends EventEmitter<RepoEvents> {
   }
 
   async shutdown() {
-    this.#subductionSource?.shutdown()
+    // Stop all inbound data — no new changes can arrive
     this.networkSubsystem.disconnect()
+
+    // Flush all Automerge document storage (bypasses throttle, saves directly)
+    await this.flush()
+
+    // Flush Subduction pending saves, await in-flight writes, then clear timers
+    await this.#subductionSource?.shutdown()
   }
 
   metrics(): { documents: { [key: string]: any } } {

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -39,6 +39,7 @@ export {
   decodeHeads,
 } from "./AutomergeUrl.js"
 export { Repo } from "./Repo.js"
+export { initSubduction } from "./initSubduction.js"
 export { Presence } from "./presence/Presence.js"
 export { PeerStateView } from "./presence/PeerStateView.js"
 export type {

--- a/packages/automerge-repo/src/initSubduction.ts
+++ b/packages/automerge-repo/src/initSubduction.ts
@@ -1,17 +1,20 @@
-let initialized = false
+let initPromise: Promise<void> | null = null
 
 /**
- * Initialize the Subduction Wasm module. Must be called before
- * constructing a Repo. Safe to call multiple times (idempotent).
+ * Initialize the Subduction Wasm module ahead of time. This can be
+ * called before constructing a Repo when an application wants to
+ * eagerly load the Wasm module. Safe to call multiple times
+ * (idempotent, concurrent calls share the same import).
  *
  * This performs a dynamic import of `@automerge/automerge-subduction`
  * (the non-`/slim` entry), which auto-initializes the Wasm module as
  * a side effect. The `/slim` entry used internally by the Repo shares
- * the same module-scoped Wasm instance, so it sees the initialized
- * module without needing its own init step.
+ * the same module-scoped Wasm instance, so this pre-initialization is
+ * visible there as well.
  */
 export async function initSubduction(): Promise<void> {
-  if (initialized) return
-  await import("@automerge/automerge-subduction")
-  initialized = true
+  if (!initPromise) {
+    initPromise = import("@automerge/automerge-subduction").then(() => {})
+  }
+  return initPromise
 }

--- a/packages/automerge-repo/src/initSubduction.ts
+++ b/packages/automerge-repo/src/initSubduction.ts
@@ -1,0 +1,17 @@
+let initialized = false
+
+/**
+ * Initialize the Subduction Wasm module. Must be called before
+ * constructing a Repo. Safe to call multiple times (idempotent).
+ *
+ * This performs a dynamic import of `@automerge/automerge-subduction`
+ * (the non-`/slim` entry), which auto-initializes the Wasm module as
+ * a side effect. The `/slim` entry used internally by the Repo shares
+ * the same module-scoped Wasm instance, so it sees the initialized
+ * module without needing its own init step.
+ */
+export async function initSubduction(): Promise<void> {
+  if (initialized) return
+  await import("@automerge/automerge-subduction")
+  initialized = true
+}

--- a/packages/automerge-repo/src/initSubduction.ts
+++ b/packages/automerge-repo/src/initSubduction.ts
@@ -14,7 +14,12 @@ let initPromise: Promise<void> | null = null
  */
 export async function initSubduction(): Promise<void> {
   if (!initPromise) {
-    initPromise = import("@automerge/automerge-subduction").then(() => {})
+    initPromise = import("@automerge/automerge-subduction")
+      .then(() => {})
+      .catch(error => {
+        initPromise = null
+        throw error
+      })
   }
   return initPromise
 }

--- a/packages/automerge-repo/src/subduction/AdapterConnections.ts
+++ b/packages/automerge-repo/src/subduction/AdapterConnections.ts
@@ -11,6 +11,7 @@ export class AdapterConnections implements ConnectionManager {
   #onChangeCallback: (() => void) | null = null
   #pendingTransports = 0
   #generation = 0
+  #isShutdown = false
 
   constructor(subduction: Promise<Subduction>, localPeerId: PeerId) {
     this.#subduction = subduction
@@ -34,6 +35,11 @@ export class AdapterConnections implements ConnectionManager {
     this.#onChangeCallback = callback
   }
 
+  shutdown(): void {
+    this.#isShutdown = true
+    this.#onChangeCallback = null
+  }
+
   // ── Adapter management ──────────────────────────────────────────────
 
   addAdapter(
@@ -43,6 +49,7 @@ export class AdapterConnections implements ConnectionManager {
   ) {
     this.#adapters.push(adapter)
     adapter.on("peer-candidate", ({ peerId }) => {
+      if (this.#isShutdown) return
       // Increment synchronously so isConnecting() returns true
       // before the async handshake begins.
       this.#pendingTransports++

--- a/packages/automerge-repo/src/subduction/ConnectionManager.ts
+++ b/packages/automerge-repo/src/subduction/ConnectionManager.ts
@@ -28,4 +28,10 @@ export interface ConnectionManager {
    * use this to schedule a recompute.
    */
   onChange(callback: () => void): void
+
+  /**
+   * Stop managing connections. Breaks reconnect loops and prevents new
+   * transports from being established.
+   */
+  shutdown(): void
 }

--- a/packages/automerge-repo/src/subduction/SubductionConnections.ts
+++ b/packages/automerge-repo/src/subduction/SubductionConnections.ts
@@ -44,24 +44,24 @@ export class SubductionConnections implements ConnectionManager {
 
     while (true) {
       this.#setConnectionState(url, "connecting")
-      console.log(`[subduction] connecting to ${url}...`)
+      this.#log(`connecting to ${url}...`)
 
       try {
         const transport = await WebSocketTransport.connect(url)
         const subduction = await this.#subduction
         await subduction.connectTransport(transport, serviceName)
         this.#setConnectionState(url, "running")
-        console.log(`[subduction] connected to ${url}`)
+        this.#log(`connected to ${url}`)
         backoff = RECONNECT_BASE_MS
 
         await transport.closed()
-        console.log(`[subduction] disconnected from ${url}`)
+        this.#log(`disconnected from ${url}`)
       } catch (e) {
         console.warn(`[subduction] connection to ${url} failed:`, e)
       }
 
       this.#setConnectionState(url, "awaiting-reconnect")
-      console.log(`[subduction] reconnecting to ${url} in ${backoff}ms`)
+      this.#log(`reconnecting to ${url} in ${backoff}ms`)
       await new Promise(r => setTimeout(r, backoff))
       backoff = Math.min(backoff * 2, RECONNECT_MAX_MS)
     }

--- a/packages/automerge-repo/src/subduction/SubductionConnections.ts
+++ b/packages/automerge-repo/src/subduction/SubductionConnections.ts
@@ -15,7 +15,7 @@ export class SubductionConnections implements ConnectionManager {
   #onChangeCallback: (() => void) | null = null
   #generation = 0
   #isShutdown = false
-  #reconnectTimers = new Set<ReturnType<typeof setTimeout>>()
+  #pendingSleeps = new Map<ReturnType<typeof setTimeout>, () => void>()
 
   constructor(subduction: Promise<Subduction>) {
     this.#subduction = subduction
@@ -74,10 +74,10 @@ export class SubductionConnections implements ConnectionManager {
       this.#log(`reconnecting to ${url} in ${backoff}ms`)
       await new Promise<void>(r => {
         const timer = setTimeout(() => {
-          this.#reconnectTimers.delete(timer)
+          this.#pendingSleeps.delete(timer)
           r()
         }, backoff)
-        this.#reconnectTimers.add(timer)
+        this.#pendingSleeps.set(timer, r)
       })
       backoff = Math.min(backoff * 2, RECONNECT_MAX_MS)
     }
@@ -85,10 +85,11 @@ export class SubductionConnections implements ConnectionManager {
 
   shutdown(): void {
     this.#isShutdown = true
-    for (const timer of this.#reconnectTimers) {
+    for (const [timer, resolve] of this.#pendingSleeps) {
       clearTimeout(timer)
+      resolve()
     }
-    this.#reconnectTimers.clear()
+    this.#pendingSleeps.clear()
   }
 
   #setConnectionState(url: string, state: ConnectionState) {

--- a/packages/automerge-repo/src/subduction/SubductionConnections.ts
+++ b/packages/automerge-repo/src/subduction/SubductionConnections.ts
@@ -15,7 +15,7 @@ export class SubductionConnections implements ConnectionManager {
   #onChangeCallback: (() => void) | null = null
   #generation = 0
   #isShutdown = false
-  #reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  #reconnectTimers = new Set<ReturnType<typeof setTimeout>>()
 
   constructor(subduction: Promise<Subduction>) {
     this.#subduction = subduction
@@ -73,10 +73,11 @@ export class SubductionConnections implements ConnectionManager {
       this.#setConnectionState(url, "awaiting-reconnect")
       this.#log(`reconnecting to ${url} in ${backoff}ms`)
       await new Promise<void>(r => {
-        this.#reconnectTimer = setTimeout(() => {
-          this.#reconnectTimer = null
+        const timer = setTimeout(() => {
+          this.#reconnectTimers.delete(timer)
           r()
         }, backoff)
+        this.#reconnectTimers.add(timer)
       })
       backoff = Math.min(backoff * 2, RECONNECT_MAX_MS)
     }
@@ -84,10 +85,10 @@ export class SubductionConnections implements ConnectionManager {
 
   shutdown(): void {
     this.#isShutdown = true
-    if (this.#reconnectTimer !== null) {
-      clearTimeout(this.#reconnectTimer)
-      this.#reconnectTimer = null
+    for (const timer of this.#reconnectTimers) {
+      clearTimeout(timer)
     }
+    this.#reconnectTimers.clear()
   }
 
   #setConnectionState(url: string, state: ConnectionState) {

--- a/packages/automerge-repo/src/subduction/SubductionConnections.ts
+++ b/packages/automerge-repo/src/subduction/SubductionConnections.ts
@@ -15,6 +15,7 @@ export class SubductionConnections implements ConnectionManager {
   #onChangeCallback: (() => void) | null = null
   #generation = 0
   #isShutdown = false
+  #reconnectTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(subduction: Promise<Subduction>) {
     this.#subduction = subduction
@@ -49,6 +50,12 @@ export class SubductionConnections implements ConnectionManager {
 
       try {
         const transport = await WebSocketTransport.connect(url)
+
+        if (this.#isShutdown) {
+          transport.disconnect()
+          break
+        }
+
         const subduction = await this.#subduction
         await subduction.connectTransport(transport, serviceName)
         this.#setConnectionState(url, "running")
@@ -61,15 +68,26 @@ export class SubductionConnections implements ConnectionManager {
         console.warn(`[subduction] connection to ${url} failed:`, e)
       }
 
+      if (this.#isShutdown) break
+
       this.#setConnectionState(url, "awaiting-reconnect")
       this.#log(`reconnecting to ${url} in ${backoff}ms`)
-      await new Promise(r => setTimeout(r, backoff))
+      await new Promise<void>(r => {
+        this.#reconnectTimer = setTimeout(() => {
+          this.#reconnectTimer = null
+          r()
+        }, backoff)
+      })
       backoff = Math.min(backoff * 2, RECONNECT_MAX_MS)
     }
   }
 
   shutdown(): void {
     this.#isShutdown = true
+    if (this.#reconnectTimer !== null) {
+      clearTimeout(this.#reconnectTimer)
+      this.#reconnectTimer = null
+    }
   }
 
   #setConnectionState(url: string, state: ConnectionState) {

--- a/packages/automerge-repo/src/subduction/SubductionConnections.ts
+++ b/packages/automerge-repo/src/subduction/SubductionConnections.ts
@@ -14,6 +14,7 @@ export class SubductionConnections implements ConnectionManager {
   #subduction: Promise<Subduction>
   #onChangeCallback: (() => void) | null = null
   #generation = 0
+  #isShutdown = false
 
   constructor(subduction: Promise<Subduction>) {
     this.#subduction = subduction
@@ -42,7 +43,7 @@ export class SubductionConnections implements ConnectionManager {
     const serviceName = new URL(url).host
     let backoff = RECONNECT_BASE_MS
 
-    while (true) {
+    while (!this.#isShutdown) {
       this.#setConnectionState(url, "connecting")
       this.#log(`connecting to ${url}...`)
 
@@ -65,6 +66,10 @@ export class SubductionConnections implements ConnectionManager {
       await new Promise(r => setTimeout(r, backoff))
       backoff = Math.min(backoff * 2, RECONNECT_MAX_MS)
     }
+  }
+
+  shutdown(): void {
+    this.#isShutdown = true
   }
 
   #setConnectionState(url: string, state: ConnectionState) {

--- a/packages/automerge-repo/src/subduction/SyncScheduler.ts
+++ b/packages/automerge-repo/src/subduction/SyncScheduler.ts
@@ -77,6 +77,7 @@ export class SyncScheduler {
   #healTimers = new Map<string, ReturnType<typeof setTimeout>>()
   #healBackoff = new Map<string, number>()
   #healAttempts = new Map<string, number>()
+  #isShutdown = false
 
   // ── Periodic sync state ───────────────────────────────────────────
   #periodicSyncTimer: ReturnType<typeof setInterval> | null = null
@@ -111,6 +112,7 @@ export class SyncScheduler {
   // onHealExhausted callback.
 
   scheduleHealSync(sedimentreeId: SedimentreeId): void {
+    if (this.#isShutdown) return
     const key = sedimentreeId.toString()
     const attempts = this.#healAttempts.get(key) ?? 0
 
@@ -318,6 +320,7 @@ export class SyncScheduler {
   // ── Shutdown ────────────────────────────────────────────────────────
 
   shutdown(): void {
+    this.#isShutdown = true
     if (this.#periodicSyncTimer !== null) {
       clearInterval(this.#periodicSyncTimer)
       this.#periodicSyncTimer = null

--- a/packages/automerge-repo/src/subduction/SyncScheduler.ts
+++ b/packages/automerge-repo/src/subduction/SyncScheduler.ts
@@ -197,7 +197,7 @@ export class SyncScheduler {
   // ── Periodic background sync ────────────────────────────────────────
 
   async #runPeriodicSync(): Promise<void> {
-    if (this.#periodicSyncInProgress) return
+    if (this.#isShutdown || this.#periodicSyncInProgress) return
     this.#periodicSyncInProgress = true
 
     try {
@@ -264,7 +264,7 @@ export class SyncScheduler {
   }
 
   async #runBatchSync(): Promise<void> {
-    if (this.#batchSyncInProgress) return
+    if (this.#isShutdown || this.#batchSyncInProgress) return
     this.#batchSyncInProgress = true
     this.#log("starting batch sync (all open handles)")
 

--- a/packages/automerge-repo/src/subduction/SyncScheduler.ts
+++ b/packages/automerge-repo/src/subduction/SyncScheduler.ts
@@ -131,8 +131,8 @@ export class SyncScheduler {
 
     const delay = this.#healBackoff.get(key) ?? HEAL_INITIAL_DELAY_MS
 
-    console.log(
-      `[subduction] scheduling heal for ${key.slice(0, 8)} in ${delay}ms ` +
+    this.#log(
+      `scheduling heal for ${key.slice(0, 8)} in ${delay}ms ` +
         `(attempt ${attempts + 1}/${HEAL_MAX_ATTEMPTS})`
     )
 
@@ -205,8 +205,8 @@ export class SyncScheduler {
       const healingCount = sedimentreeIds.filter(id =>
         this.#healTimers.has(id.toString())
       ).length
-      console.log(
-        `[subduction] periodic sync: ${sedimentreeIds.length} entries, ` +
+      this.#log(
+        `periodic sync: ${sedimentreeIds.length} entries, ` +
           `${healingCount} healing (skipped)`
       )
 

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -662,7 +662,21 @@ export class SubductionSource implements DocumentSource {
 
   // ── Shutdown ────────────────────────────────────────────────────────
 
-  shutdown() {
+  async shutdown() {
+    // Flush all pending throttled saves so they start executing
+    for (const entry of this.#entries.values()) {
+      entry.flushSave.flush()
+    }
+
+    // Wait for all in-flight #save() calls to complete
+    await Promise.all(
+      Array.from(this.#entries.values()).map(e => e.saveSettled)
+    )
+
+    // Wait for SubductionStorageBridge writes to land on disk
+    await this.#storage.awaitSettled()
+
+    // Clear all timers (periodic sync, batch sync, heal retries)
     this.#scheduler.shutdown()
   }
 

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -184,9 +184,9 @@ export class SubductionSource implements DocumentSource {
         onEphemeral
       ).then(s => {
         this.#log(
-          `hydrate complete in ${(
-            performance.now() - hydrateStart
-          ).toFixed(0)}ms`
+          `hydrate complete in ${(performance.now() - hydrateStart).toFixed(
+            0
+          )}ms`
         )
         return s
       })
@@ -663,21 +663,35 @@ export class SubductionSource implements DocumentSource {
   // ── Shutdown ────────────────────────────────────────────────────────
 
   async shutdown() {
-    // Flush all pending throttled saves so they start executing
+    // 1. Stop reconnect loops and prevent new transports
+    for (const mgr of this.#connectionManagers) {
+      mgr.shutdown()
+    }
+
+    // 2. Stop scheduled sync timers (no new sync rounds will be triggered)
+    this.#scheduler.shutdown()
+
+    // 3. Flush all pending throttled saves so they start executing
     for (const entry of this.#entries.values()) {
       entry.flushSave.flush()
     }
 
-    // Wait for all in-flight #save() calls to complete
+    // 4. Wait for all in-flight #save() calls to complete
     await Promise.all(
       Array.from(this.#entries.values()).map(e => e.saveSettled)
     )
 
-    // Wait for SubductionStorageBridge writes to land on disk
+    // 5. Wait for SubductionStorageBridge writes to land on disk
     await this.#storage.awaitSettled()
 
-    // Clear all timers (periodic sync, batch sync, heal retries)
-    this.#scheduler.shutdown()
+    // 6. Disconnect all Wasm-side transports gracefully, then free
+    try {
+      const subduction = await this.#subduction
+      await subduction.disconnectAll()
+      subduction.free()
+    } catch (e) {
+      this.#log("error during subduction teardown: %O", e)
+    }
   }
 
   // ── Ephemeral messaging ──────────────────────────────────────────────

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -170,7 +170,7 @@ export class SubductionSource implements DocumentSource {
     if (websocketEndpoints.length > 0) {
       // Full hydration: load persisted sedimentrees from storage so
       // fingerprint-based sync can resume where it left off.
-      console.log("[subduction] starting hydrate...")
+      this.#log("starting hydrate...")
       const hydrateStart = performance.now()
       this.#subduction = Subduction.hydrate(
         signer,
@@ -183,8 +183,8 @@ export class SubductionSource implements DocumentSource {
         onRemoteHeads,
         onEphemeral
       ).then(s => {
-        console.log(
-          `[subduction] hydrate complete in ${(
+        this.#log(
+          `hydrate complete in ${(
             performance.now() - hydrateStart
           ).toFixed(0)}ms`
         )
@@ -194,7 +194,7 @@ export class SubductionSource implements DocumentSource {
       // No endpoints — skip hydration to avoid hundreds of IndexedDB
       // transactions that would compete with the service worker's real
       // hydration on the same database.
-      console.log("[subduction] no endpoints, skipping hydrate")
+      this.#log("no endpoints, skipping hydrate")
       this.#subduction = Promise.resolve(
         new Subduction(
           signer,
@@ -428,7 +428,7 @@ export class SubductionSource implements DocumentSource {
       entry.flushSave.flush()
       await entry.saveSettled
 
-      console.log(`[subduction] doSync ${sid} (state=${entry.syncState})`)
+      this.#log(`doSync ${sid} (state=${entry.syncState})`)
       const peerResultMap = await subduction.syncWithAllPeers(
         sedimentreeId,
         true
@@ -471,15 +471,15 @@ export class SubductionSource implements DocumentSource {
       // If new commits were saved or a new connection was established
       // while this sync was in flight, re-sync immediately.
       if (entry.needsResync || entry.lastSyncResult === null) {
-        console.log(
-          `[subduction] doSync ${sid} finally: re-sync needed ` +
+        this.#log(
+          `doSync ${sid} finally: re-sync needed ` +
             `(needsResync=${entry.needsResync}, lastSyncResult=${entry.lastSyncResult})`
         )
         entry.needsResync = false
         entry.lastSyncResult = null
       } else {
-        console.log(
-          `[subduction] doSync ${sid} finally: no re-sync ` +
+        this.#log(
+          `doSync ${sid} finally: no re-sync ` +
             `(needsResync=${entry.needsResync}, lastSyncResult=${entry.lastSyncResult})`
         )
       }
@@ -504,8 +504,8 @@ export class SubductionSource implements DocumentSource {
     const totalBytes = allBlobs
       ? allBlobs.reduce((n, b) => n + b.byteLength, 0)
       : 0
-    console.log(
-      `[subduction] loadBlobsIntoHandle ${sid}: ${
+    this.#log(
+      `loadBlobsIntoHandle ${sid}: ${
         allBlobs?.length ?? 0
       } blob(s), ${totalBytes} bytes, heads=${entry.handle.heads().length}`
     )
@@ -590,8 +590,8 @@ export class SubductionSource implements DocumentSource {
         doc,
         Array.from(previousHeads)
       ).length
-      console.log(
-        `[subduction] #save ${sid}: ${changeCount} change(s), ` +
+      this.#log(
+        `#save ${sid}: ${changeCount} change(s), ` +
           `state=${entry.syncState}, syncInFlight=${entry.syncInFlight}`
       )
       await this.#saveNewCommits(entry, doc, subduction, previousHeads)
@@ -603,8 +603,8 @@ export class SubductionSource implements DocumentSource {
     // flag for re-sync when it completes (otherwise the in-flight sync
     // would overwrite lastSyncResult and the new commits would be lost).
     if (entry.syncInFlight) {
-      console.log(
-        `[subduction] #save ${entry.sedimentreeId
+      this.#log(
+        `#save ${entry.sedimentreeId
           .toString()
           .slice(0, 8)}: setting needsResync=true (sync in flight)`
       )

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -685,12 +685,17 @@ export class SubductionSource implements DocumentSource {
     await this.#storage.awaitSettled()
 
     // 6. Disconnect all Wasm-side transports gracefully, then free
+    const subduction = await this.#subduction
     try {
-      const subduction = await this.#subduction
       await subduction.disconnectAll()
-      subduction.free()
     } catch (e) {
-      this.#log("error during subduction teardown: %O", e)
+      this.#log("error disconnecting subduction transports: %O", e)
+    } finally {
+      try {
+        subduction.free()
+      } catch (e) {
+        this.#log("error freeing subduction resources: %O", e)
+      }
     }
   }
 

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -684,8 +684,16 @@ export class SubductionSource implements DocumentSource {
     // 5. Wait for SubductionStorageBridge writes to land on disk
     await this.#storage.awaitSettled()
 
-    // 6. Disconnect all Wasm-side transports gracefully, then free
-    const subduction = await this.#subduction
+    // 6. Disconnect all Wasm-side transports gracefully, then free.
+    //    If hydration failed, this.#subduction is a rejected promise —
+    //    treat that as a no-op (nothing to disconnect or free).
+    let subduction: Subduction | null = null
+    try {
+      subduction = await this.#subduction
+    } catch (e) {
+      this.#log("subduction never initialized, skipping teardown: %O", e)
+      return
+    }
     try {
       await subduction.disconnectAll()
     } catch (e) {

--- a/packages/automerge-repo/test/subduction/Topology.test.ts
+++ b/packages/automerge-repo/test/subduction/Topology.test.ts
@@ -633,9 +633,20 @@ describe("Tab → Worker → Server topology", () => {
       return doc !== undefined && doc.items.length === 1
     }, 5000)
 
-    // Now Bob should be able to find the sub-document and get its data
-    // WITHOUT needing another round-trip / another edit from Alice.
-    const bobSub = await pair2.tab.find<ItemDoc>(bobList.doc()!.items[0])
+    const subUrl = bobList.doc()!.items[0]
+
+    // Wait for the sub-document data to arrive on Bob's worker via
+    // subduction. We poll findWithProgress rather than calling find()
+    // (which rejects on unavailable) because the worker may need
+    // several sync rounds before the sub-doc arrives.
+    await waitForCondition(() => {
+      const state = pair2.worker.findWithProgress<ItemDoc>(subUrl).peek()
+      return state.state === "ready" && state.handle.doc()?.title !== undefined
+    }, 5000)
+
+    // Now Bob's tab can find the sub-document via MessageChannel sync
+    // with the worker — the worker already has the data.
+    const bobSub = await pair2.tab.find<ItemDoc>(subUrl)
     await bobSub.whenReady()
     expect(bobSub.doc()!.title).toBe("First item")
   }, 15_000)


### PR DESCRIPTION
Shutdown cleanly & switch logs to `this.#log`. We'll likely need to configure logs downstream but it was VERBOSE in TPW and pushwork before