### PR TITLE
Retry failed syncs on SubductionSource on shareConfigChanged()

### DIFF
--- a/packages/automerge-repo/src/DocumentSource.ts
+++ b/packages/automerge-repo/src/DocumentSource.ts
@@ -21,4 +21,6 @@ export interface DocumentSource {
 
   /** Called when a document is removed from the repo. */
   detach(documentId: DocumentId): void
+
+  shareConfigChanged(): void
 }

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -753,6 +753,7 @@ export class Repo extends EventEmitter<RepoEvents> {
 
   shareConfigChanged() {
     this.synchronizer.reevaluateDocumentShare()
+    this.#subductionSource?.retryFailedSyncs()
   }
 }
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -752,8 +752,9 @@ export class Repo extends EventEmitter<RepoEvents> {
   }
 
   shareConfigChanged() {
-    this.synchronizer.reevaluateDocumentShare()
-    this.#subductionSource?.retryFailedSyncs()
+    for (const source of this.#sources) {
+      source.shareConfigChanged()
+    }
   }
 }
 

--- a/packages/automerge-repo/src/StorageSource.ts
+++ b/packages/automerge-repo/src/StorageSource.ts
@@ -54,6 +54,8 @@ export class StorageSource implements DocumentSource {
     delete this.#saveFns[documentId]
   }
 
+  shareConfigChanged(): void {}
+
   #makeSaveFn(
     documentId: DocumentId
   ): (payload: DocHandleEncodedChangePayload<any>) => void {

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -344,6 +344,17 @@ export class SubductionSource implements DocumentSource {
 
   detach(documentId: DocumentId): void {}
 
+  /** Reset entries stuck in "all-failed" so they sync again. */
+  retryFailedSyncs(): void {
+    for (const entry of this.#entries.values()) {
+      if (entry.lastSyncResult === "all-failed" && !entry.syncInFlight) {
+        entry.lastSyncResult = null
+        this.#scheduler.resetHealState(entry.sedimentreeId.toString())
+      }
+    }
+    this.#recompute()
+  }
+
   // ── Central recompute ───────────────────────────────────────────────
 
   #recompute() {

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -344,8 +344,7 @@ export class SubductionSource implements DocumentSource {
 
   detach(documentId: DocumentId): void {}
 
-  /** Reset entries stuck in "all-failed" so they sync again. */
-  retryFailedSyncs(): void {
+  shareConfigChanged(): void {
     for (const entry of this.#entries.values()) {
       if (entry.lastSyncResult === "all-failed" && !entry.syncInFlight) {
         entry.lastSyncResult = null

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -189,7 +189,7 @@ export class CollectionSynchronizer
 
   // SHARE POLICY
 
-  reevaluateDocumentShare(): void {
+  shareConfigChanged(): void {
     for (const docSync of Object.values(this.#docSynchronizers)) {
       docSync.reevaluateSharePolicy()
     }

--- a/packages/automerge-repo/test/subduction/AdapterTopology.test.ts
+++ b/packages/automerge-repo/test/subduction/AdapterTopology.test.ts
@@ -24,6 +24,7 @@ import { generateAutomergeUrl } from "../../src/AutomergeUrl.js"
 import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
 import { type PeerId } from "../../src/types.js"
 import { pause } from "../../src/helpers/pause.js"
+import type { Policy } from "@automerge/automerge-subduction"
 
 // ── Test helpers ──────────────────────────────────────────────────────
 
@@ -32,12 +33,18 @@ import { pause } from "../../src/helpers/pause.js"
  * Each restart creates a fresh Repo and WebSocketServer. The underlying
  * storage and signer can optionally be preserved across restarts.
  */
+interface TestServerOptions {
+  subductionPolicy?: Policy
+  periodicSyncInterval?: number
+}
+
 class TestServer {
   #port: number
   #wss: WebSocketServer | null = null
   #serverAdapter: WebSocketServerAdapter | null = null
   #storage: DummyStorageAdapter | null = null
   #repo: Repo | null = null
+  #opts: TestServerOptions
 
   get url() {
     return `ws://localhost:${this.#port}`
@@ -47,11 +54,12 @@ class TestServer {
     return this.#repo!
   }
 
-  private constructor(port: number) {
+  private constructor(port: number, opts: TestServerOptions = {}) {
     this.#port = port
+    this.#opts = opts
   }
 
-  static async start(): Promise<TestServer> {
+  static async start(opts?: TestServerOptions): Promise<TestServer> {
     // Grab an ephemeral port
     const tmp = new WebSocketServer({ port: 0 })
     await new Promise<void>(r => tmp.on("listening", r))
@@ -59,7 +67,7 @@ class TestServer {
     if (typeof addr === "string") throw new Error("unexpected address type")
     const port = addr.port
     await new Promise<void>((r, e) => tmp.close(err => (err ? e(err) : r())))
-    const server = new TestServer(port)
+    const server = new TestServer(port, opts)
     await server.restart()
     return server
   }
@@ -88,6 +96,8 @@ class TestServer {
         { adapter: this.#serverAdapter, serviceName, role: "accept" },
       ],
       sharePolicy: async () => true,
+      subductionPolicy: this.#opts.subductionPolicy,
+      periodicSyncInterval: this.#opts.periodicSyncInterval,
     })
   }
 
@@ -154,8 +164,8 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
     cleanups.length = 0
   })
 
-  async function startServer() {
-    const server = await TestServer.start()
+  async function startServer(opts?: TestServerOptions) {
+    const server = await TestServer.start(opts)
     cleanups.push(() => server.close())
     return server
   }
@@ -387,5 +397,62 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
     const aliceDocB = await alice.repo.find<{ from: string }>(docB.url)
     await aliceDocB.whenReady()
     expect(aliceDocB.doc()!.from).toBe("bob")
+  }, 10_000)
+
+  // ── Policy verdict change from deny to allow ──────────────────────────────────────
+
+  it("client gets doc after server policy changes from deny to allow", async () => {
+    // Mutable policy: deny fetch for everyone initially, then allow
+    let allowFetch = false
+    const policy: Policy = {
+      async authorizeConnect() {},
+      async authorizeFetch(_peerId, _sedimentreeId) {
+        if (!allowFetch) throw new Error("fetch denied")
+      },
+      async authorizePut() {},
+      async filterAuthorizedFetch(_peerId, ids) {
+        return allowFetch ? ids : []
+      },
+    }
+
+    const server = await startServer({
+      subductionPolicy: policy,
+      // Short periodic sync so the server pushes to Bob quickly
+      // after the policy changes.
+      periodicSyncInterval: 500,
+    })
+
+    const alice = startClient("alice", server.url)
+    const bob = startClient("bob", server.url)
+    await pause(500)
+
+    // Alice pushes a doc (put is allowed).
+    const aliceHandle = alice.repo.create<{ value: string }>()
+    aliceHandle.change(d => {
+      d.value = "access granted"
+    })
+
+    // Let Alice's push reach the server's WASM storage
+    await pause(1000)
+
+    // Bob requests the doc.
+    const progress = bob.repo.findWithProgress<{ value: string }>(
+      aliceHandle.url
+    )
+    await pause(1000)
+    expect(progress.peek().state).not.toBe("ready")
+
+    // Policy changes: Bob is now allowed.
+    allowFetch = true
+
+    // Tell the client the share config changed.
+    bob.repo.shareConfigChanged()
+
+    await waitForCondition(() => {
+      const s = progress.peek()
+      return s.state === "ready" && s.handle.doc()?.value === "access granted"
+    }, 5000)
+
+    expect(progress.peek().state).toBe("ready")
   }, 10_000)
 })


### PR DESCRIPTION
This PR adds `retryFailedSyncs()` to `SubductionSource`, which resets all "all-failed" entries to null and clears their heal state, triggering an immediate re-sync on the next `#recompute`. `Repo.shareConfigChanged()` now calls it, so subduction policy updates (e.g., because of a new keyhive delegation) lead to successful syncing.