### PR TITLE
Fix import cycles introduced in v2.5.2

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -58,7 +58,7 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
   #refCache: Map<string, WeakRef<Ref<any>>> = new Map()
 
   /** Factory for creating Ref instances, injected by Repo to avoid circular imports */
-  #refConstructor?: <TDoc, TPath extends readonly PathInput[]>(
+  #refConstructor: <TDoc, TPath extends readonly PathInput[]>(
     handle: DocHandle<TDoc>,
     path: [...TPath]
   ) => Ref<any>
@@ -66,13 +66,15 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
   /** @hidden */
   constructor(
     public documentId: DocumentId,
+    refConstructor: <TDoc, TPath extends readonly PathInput[]>(
+      handle: DocHandle<TDoc>,
+      path: [...TPath]
+    ) => Ref<any>,
     options: DocHandleOptions<T> = {}
   ) {
     super()
 
-    if ("refConstructor" in options && options.refConstructor) {
-      this.#refConstructor = options.refConstructor
-    }
+    this.#refConstructor = refConstructor
 
     if ("timeoutDelay" in options && options.timeoutDelay) {
       this.#timeoutDelay = options.timeoutDelay
@@ -455,10 +457,9 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
     }
 
     // Create a new handle with the same documentId but fixed heads
-    const handle = new DocHandle<T>(this.documentId, {
+    const handle = new DocHandle<T>(this.documentId, this.#refConstructor, {
       heads,
       timeoutDelay: this.#timeoutDelay,
-      refConstructor: this.#refConstructor,
     })
     handle.update(() => A.clone(this.#doc))
     handle.doneLoading()
@@ -766,12 +767,6 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
       return existingRef as Ref<InferRefType<T, TPath>>
     }
 
-    if (!this.#refConstructor) {
-      throw new Error(
-        "Refs are not available on this DocHandle (no refConstructor option provided)"
-      )
-    }
-
     // Create new ref and cache it
     const newRef = this.#refConstructor<T, TPath>(this, segments as [...TPath])
     this.#refCache.set(cacheKey, new WeakRef(newRef))
@@ -806,13 +801,7 @@ export type SyncInfo = {
 }
 
 /** @hidden */
-export type DocHandleOptions<T> = {
-  /** @hidden Factory for creating Ref instances — injected by Repo to avoid circular imports */
-  refConstructor?: <TDoc, TPath extends readonly PathInput[]>(
-    handle: DocHandle<TDoc>,
-    path: [...TPath]
-  ) => Ref<any>
-} & (
+export type DocHandleOptions<T> =
   | // NEW DOCUMENTS
   {
       /** If we know this is a new document (because we're creating it) this should be set to true. */
@@ -830,7 +819,6 @@ export type DocHandleOptions<T> = {
       /** The number of milliseconds before we mark this document as unavailable if we don't have it and nobody shares it with us. */
       timeoutDelay?: number
     }
-)
 
 // EXTERNAL EVENTS
 

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -17,7 +17,6 @@ import {
   AbortOptions,
   isAbortErrorLike,
 } from "./helpers/abortable.js"
-import { RefImpl } from "./refs/ref.js"
 import type { PathInput, InferRefType, Ref } from "./refs/types.js"
 
 /**
@@ -58,12 +57,22 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
   /** Cache for ref instances, keyed by serialized path */
   #refCache: Map<string, WeakRef<Ref<any>>> = new Map()
 
+  /** Factory for creating Ref instances, injected by Repo to avoid circular imports */
+  #refConstructor?: <TDoc, TPath extends readonly PathInput[]>(
+    handle: DocHandle<TDoc>,
+    path: [...TPath]
+  ) => Ref<any>
+
   /** @hidden */
   constructor(
     public documentId: DocumentId,
     options: DocHandleOptions<T> = {}
   ) {
     super()
+
+    if ("refConstructor" in options && options.refConstructor) {
+      this.#refConstructor = options.refConstructor
+    }
 
     if ("timeoutDelay" in options && options.timeoutDelay) {
       this.#timeoutDelay = options.timeoutDelay
@@ -449,6 +458,7 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
     const handle = new DocHandle<T>(this.documentId, {
       heads,
       timeoutDelay: this.#timeoutDelay,
+      refConstructor: this.#refConstructor,
     })
     handle.update(() => A.clone(this.#doc))
     handle.doneLoading()
@@ -756,8 +766,14 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
       return existingRef as Ref<InferRefType<T, TPath>>
     }
 
+    if (!this.#refConstructor) {
+      throw new Error(
+        "Refs are not available on this DocHandle (no refConstructor option provided)"
+      )
+    }
+
     // Create new ref and cache it
-    const newRef = new RefImpl<T, TPath>(this, segments as [...TPath])
+    const newRef = this.#refConstructor<T, TPath>(this, segments as [...TPath])
     this.#refCache.set(cacheKey, new WeakRef(newRef))
 
     return newRef as Ref<InferRefType<T, TPath>>
@@ -790,16 +806,21 @@ export type SyncInfo = {
 }
 
 /** @hidden */
-export type DocHandleOptions<T> =
-  // NEW DOCUMENTS
-  | {
+export type DocHandleOptions<T> = {
+  /** @hidden Factory for creating Ref instances — injected by Repo to avoid circular imports */
+  refConstructor?: <TDoc, TPath extends readonly PathInput[]>(
+    handle: DocHandle<TDoc>,
+    path: [...TPath]
+  ) => Ref<any>
+} & (
+  | // NEW DOCUMENTS
+  {
       /** If we know this is a new document (because we're creating it) this should be set to true. */
       isNew: true
 
       /** The initial value of the document. */
       initialValue?: T
-    }
-  // EXISTING DOCUMENTS
+    } // EXISTING DOCUMENTS
   | {
       isNew?: false
 
@@ -809,6 +830,7 @@ export type DocHandleOptions<T> =
       /** The number of milliseconds before we mark this document as unavailable if we don't have it and nobody shares it with us. */
       timeoutDelay?: number
     }
+)
 
 // EXTERNAL EVENTS
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -43,6 +43,7 @@ import type {
 } from "./types.js"
 import { abortable, AbortOptions, AbortError } from "./helpers/abortable.js"
 import { FindProgress } from "./FindProgress.js"
+import { RefImpl } from "./refs/ref.js"
 
 export type FindProgressWithMethods<T> = FindProgress<T> & {
   untilReady: (allowableStates: string[]) => Promise<DocHandle<T>>
@@ -408,7 +409,9 @@ export class Repo extends EventEmitter<RepoEvents> {
 
     // If not, create a new handle, cache it, and return it
     if (!documentId) throw new Error(`Invalid documentId ${documentId}`)
-    const handle = new DocHandle<T>(documentId)
+    const handle = new DocHandle<T>(documentId, {
+      refConstructor: (handle, path) => new RefImpl(handle, path),
+    })
     this.#handleCache[documentId] = handle
     return handle
   }

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -409,9 +409,10 @@ export class Repo extends EventEmitter<RepoEvents> {
 
     // If not, create a new handle, cache it, and return it
     if (!documentId) throw new Error(`Invalid documentId ${documentId}`)
-    const handle = new DocHandle<T>(documentId, {
-      refConstructor: (handle, path) => new RefImpl(handle, path),
-    })
+    const handle = new DocHandle<T>(
+      documentId,
+      (handle, path) => new RefImpl(handle, path)
+    )
     this.#handleCache[documentId] = handle
     return handle
   }

--- a/packages/automerge-repo/src/presence/Presence.ts
+++ b/packages/automerge-repo/src/presence/Presence.ts
@@ -1,6 +1,9 @@
 import { EventEmitter } from "eventemitter3"
 
-import { DocHandle, DocHandleEphemeralMessagePayload } from "../DocHandle.js"
+import type {
+  DocHandle,
+  DocHandleEphemeralMessagePayload,
+} from "../DocHandle.js"
 import {
   PresenceConfig,
   PresenceEvents,

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -11,13 +11,21 @@ import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
 import { DocHandle, DocHandleChangePayload } from "../src/index.js"
 import { TestDoc } from "./types.js"
+import { RefImpl } from "../src/refs/ref.js"
 
 describe("DocHandle", () => {
   const TEST_ID = parseAutomergeUrl(generateAutomergeUrl()).documentId
   const setup = (options?) => {
-    const handle = new DocHandle<TestDoc>(TEST_ID, options)
-    handle.update(() => A.init())
-    handle.doneLoading()
+    const { quick, ...rest } = options ?? {}
+    const handle = new DocHandle<TestDoc>(
+      TEST_ID,
+      (handle, path) => new RefImpl(handle, path),
+      rest
+    )
+    if (!quick) {
+      handle.update(() => A.init())
+      handle.doneLoading()
+    }
     return handle
   }
 
@@ -26,12 +34,12 @@ describe("DocHandle", () => {
   }
 
   it("should take the UUID passed into it", () => {
-    const handle = new DocHandle(TEST_ID)
+    const handle = setup({ quick: true })
     assert.equal(handle.documentId, TEST_ID)
   })
 
   it("should become ready when a document is loaded", async () => {
-    const handle = new DocHandle<TestDoc>(TEST_ID)
+    const handle = setup({ quick: true })
     assert.equal(handle.isReady(), false)
 
     // simulate loading from storage
@@ -43,7 +51,7 @@ describe("DocHandle", () => {
   })
 
   it("should allow sync access to the doc", async () => {
-    const handle = new DocHandle<TestDoc>(TEST_ID)
+    const handle = setup({ quick: true })
     assert.equal(handle.isReady(), false)
 
     // simulate loading from storage
@@ -55,12 +63,12 @@ describe("DocHandle", () => {
   })
 
   it("should throw an exception if we access the doc before ready", async () => {
-    const handle = new DocHandle<TestDoc>(TEST_ID)
+    const handle = setup({ quick: true })
     assert.throws(() => handle.doc())
   })
 
   it("should not return a doc until ready", async () => {
-    const handle = new DocHandle<TestDoc>(TEST_ID)
+    const handle = setup({ quick: true })
     assert.equal(handle.isReady(), false)
 
     // simulate loading from storage
@@ -92,7 +100,7 @@ describe("DocHandle", () => {
   })
 
   it("should throw an if the heads aren't loaded", async () => {
-    const handle = new DocHandle<TestDoc>(TEST_ID)
+    const handle = setup({ quick: true })
     assert.equal(handle.isReady(), false)
     expect(() => handle.heads()).toThrow("DocHandle is not ready")
   })
@@ -126,7 +134,7 @@ describe("DocHandle", () => {
     handle.change(d => (d.foo = "one"))
 
     const history = handle.history()
-    const viewHandle = new DocHandle<TestDoc>(TEST_ID, { heads: history[0] })
+    const viewHandle = setup({ quick: true, heads: history[0] })
     viewHandle.update(() => A.clone(handle.doc()!))
     viewHandle.doneLoading()
 
@@ -256,7 +264,7 @@ describe("DocHandle", () => {
     vi.useFakeTimers()
     const timerCount = vi.getTimerCount()
 
-    const handle = new DocHandle<TestDoc>(TEST_ID)
+    const handle = setup({ quick: true })
     assert.equal(handle.isReady(), false)
 
     assert(vi.getTimerCount() > timerCount)
@@ -270,7 +278,7 @@ describe("DocHandle", () => {
   })
 
   it("should block changes until ready()", async () => {
-    const handle = new DocHandle<TestDoc>(TEST_ID)
+    const handle = setup({ quick: true })
 
     // can't make changes in LOADING state
     assert.equal(handle.isReady(), false)
@@ -288,7 +296,7 @@ describe("DocHandle", () => {
   })
 
   it("should not be ready while requesting from the network", async () => {
-    const handle = new DocHandle<TestDoc>(TEST_ID)
+    const handle = setup({ quick: true })
 
     // we don't have it in storage, so we request it from the network
     handle.request()
@@ -301,7 +309,7 @@ describe("DocHandle", () => {
   })
 
   it("should become ready if the document is updated by the network", async () => {
-    const handle = new DocHandle<TestDoc>(TEST_ID)
+    const handle = setup({ quick: true })
 
     // we don't have it in storage, so we request it from the network
     handle.request()
@@ -422,14 +430,14 @@ describe("DocHandle", () => {
 
   it("should be undefined if loading the document times out", async () => {
     // set docHandle time out after 5 ms
-    const handle = new DocHandle<TestDoc>(TEST_ID, { timeoutDelay: 5 })
+    const handle = setup({ quick: true, timeoutDelay: 5 })
 
     expect(() => handle.doc()).toThrowError("DocHandle is not ready")
   })
 
   it("should not time out if the document is loaded in time", async () => {
     // set docHandle time out after 5 ms
-    const handle = new DocHandle<TestDoc>(TEST_ID, { timeoutDelay: 5 })
+    const handle = setup({ quick: true, timeoutDelay: 5 })
 
     // simulate loading from storage before the timeout expires
     handle.update(doc => docFromMockStorage(doc))
@@ -441,7 +449,7 @@ describe("DocHandle", () => {
 
   it("should throw an exception if loading from the network times out", async () => {
     // set docHandle time out after 5 ms
-    const handle = new DocHandle<TestDoc>(TEST_ID, { timeoutDelay: 5 })
+    const handle = setup({ quick: true, timeoutDelay: 5 })
 
     // simulate requesting from the network
     handle.request()
@@ -595,7 +603,7 @@ describe("DocHandle", () => {
     })
 
     it("should return false for a newly created document handle", () => {
-      const handle = new DocHandle<TestDoc>(TEST_ID)
+      const handle = setup({ quick: true })
       expect(handle.isReadOnly()).toBe(false)
     })
 
@@ -618,7 +626,7 @@ describe("DocHandle", () => {
       })
 
       const heads = handle.heads()
-      const fixedHeadsHandle = new DocHandle<TestDoc>(TEST_ID, { heads })
+      const fixedHeadsHandle = setup({ quick: true, heads })
       fixedHeadsHandle.update(() => A.clone(handle.doc()!))
       fixedHeadsHandle.doneLoading()
 


### PR DESCRIPTION
The import cycles trip up esm.sh's module rewriter and lead it to
generate a broken stub for @automerge/vanillajs/slim?bundle-deps.

Add the ref constructor as an injected dependency (and clean up some
other minor issues) to avoid the circular imports.
