### PR TITLE
SDN: Remove both periodic sync mechanisms

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -107,8 +107,6 @@ export class Repo extends EventEmitter<RepoEvents> {
     subductionPolicy,
     subductionWebsocketEndpoints,
     subductionAdapters,
-    periodicSyncInterval,
-    batchSyncInterval,
   }: RepoConfig = {}) {
     super()
     this.#peerId = peerId
@@ -196,8 +194,6 @@ export class Repo extends EventEmitter<RepoEvents> {
       onHealExhausted: documentId => {
         this.emit("heal-exhausted", { documentId })
       },
-      periodicSyncInterval,
-      batchSyncInterval,
     })
     this.#subductionSource = subductionSource
     this.#sources.push(subductionSource)
@@ -833,20 +829,6 @@ export interface RepoConfig {
      *  handshake for peers on this adapter. Defaults to "connect". */
     role?: "connect" | "accept"
   }[]
-
-  /**
-   * Interval in ms for per-document periodic sync via Subduction. Each open
-   * document is synced individually (skipping those in heal-backoff).
-   * Set to 0 to disable. Default: 10_000 (10s).
-   */
-  periodicSyncInterval?: number
-
-  /**
-   * Interval in ms for a full batch sync across all open documents via
-   * Subduction. On success, all heal state is reset.
-   * Set to 0 to disable. Default: 300_000 (5 min).
-   */
-  batchSyncInterval?: number
 }
 
 /** A function that determines whether we should share a document with a peer

--- a/packages/automerge-repo/src/subduction/SyncScheduler.ts
+++ b/packages/automerge-repo/src/subduction/SyncScheduler.ts
@@ -16,14 +16,8 @@ export interface SyncSchedulerOptions {
   log: debug.Debugger
 
   /**
-   * Returns the SedimentreeIds of all currently-attached documents.
-   * Called on each periodic/batch tick to discover the working set.
-   */
-  getActiveSedimentreeIds: () => SedimentreeId[]
-
-  /**
-   * Called when a periodic or heal sync receives new data from peers.
-   * The source should load the blobs into the document handle.
+   * Called when a heal sync receives new data from peers. The source
+   * should load the blobs into the document handle.
    */
   onSyncDataReceived: (
     sedimentreeId: SedimentreeId,
@@ -31,42 +25,28 @@ export interface SyncSchedulerOptions {
   ) => Promise<void>
 
   onHealExhausted?: OnHealExhausted
-
-  /**
-   * Interval in ms for per-document periodic sync. Each open document is
-   * synced individually (skipping those already in heal-backoff).
-   * Set to 0 to disable. Default: 30_000 (30s).
-   */
-  periodicSyncInterval: number
-
-  /**
-   * Interval in ms for a full batch sync across all sedimentrees.
-   * On success, all heal state is reset.
-   * Set to 0 to disable. Default: 300_000 (5 min).
-   */
-  batchSyncInterval: number
 }
 
 /**
- * Manages background periodic sync timers and self-healing retry logic.
+ * Manages self-healing retry logic for failed syncs.
  *
- * Two background timers run independently:
+ * When a caller observes a failed `syncWithAllPeers` for a sedimentree,
+ * it invokes {@link scheduleHealSync} to schedule an exponential-backoff
+ * retry (2 s → 60 s cap, up to {@link HEAL_MAX_ATTEMPTS}). Each retry
+ * calls `syncWithAllPeers`; if it recovers new commits/fragments, the
+ * caller's {@link SyncSchedulerOptions.onSyncDataReceived} hook is
+ * invoked so the handle can be updated. Successful retries clear the
+ * heal state via {@link resetHealState}. After exhausting retries the
+ * application is notified via {@link OnHealExhausted}.
  *
- *   **periodicSync** — syncs each open document individually, skipping
- *       those already in heal-backoff.
- *
- *   **batchSync** — syncs every open document in one sweep. On full
- *       success, resets all heal state.
- *
- * When a sync fails for a sedimentree, exponential-backoff retries are
- * scheduled (2 s → 60 s cap, up to {@link HEAL_MAX_ATTEMPTS}). After
- * exhausting retries the application is notified via
- * {@link OnHealExhausted}.
+ * This is entirely event-driven: no background polling runs. All sync
+ * attempts are triggered by real events (initial attach, reconnect,
+ * local change, share-config change) in {@link SubductionSource} or by
+ * heal retries scheduled here after a real failure.
  */
 export class SyncScheduler {
   #subduction: Promise<Subduction>
   #log: debug.Debugger
-  #getActiveSedimentreeIds: () => SedimentreeId[]
   #onSyncDataReceived: (
     sedimentreeId: SedimentreeId,
     subduction: Subduction
@@ -79,29 +59,11 @@ export class SyncScheduler {
   #healAttempts = new Map<string, number>()
   #isShutdown = false
 
-  // ── Periodic sync state ───────────────────────────────────────────
-  #periodicSyncTimer: ReturnType<typeof setInterval> | null = null
-  #batchSyncTimer: ReturnType<typeof setInterval> | null = null
-  #periodicSyncInProgress = false
-  #batchSyncInProgress = false
-
   constructor(options: SyncSchedulerOptions) {
     this.#subduction = options.subduction
     this.#log = options.log
-    this.#getActiveSedimentreeIds = options.getActiveSedimentreeIds
     this.#onSyncDataReceived = options.onSyncDataReceived
     this.#onHealExhausted = options.onHealExhausted
-
-    if (options.periodicSyncInterval > 0) {
-      this.#periodicSyncTimer = setInterval(() => {
-        void this.#runPeriodicSync()
-      }, options.periodicSyncInterval)
-    }
-    if (options.batchSyncInterval > 0) {
-      this.#batchSyncTimer = setInterval(() => {
-        void this.#runBatchSync()
-      }, options.batchSyncInterval)
-    }
   }
 
   // ── Self-healing sync ────────────────────────────────────────────────
@@ -163,6 +125,24 @@ export class SyncScheduler {
         r => !r.success || (r.transportErrors?.length ?? 0) > 0
       )
 
+      // If new data was received during the heal, load it into the handle
+      // immediately — otherwise the recovered commits/fragments would sit
+      // in subduction storage until some other event surfaced them.
+      const dataReceived = results.some(r => {
+        const s = r.stats
+        return s && (s.commitsReceived > 0 || s.fragmentsReceived > 0)
+      })
+      if (dataReceived) {
+        try {
+          await this.#onSyncDataReceived(sedimentreeId, subduction)
+        } catch (e) {
+          this.#log(
+            `onSyncDataReceived threw during heal for ${key.slice(0, 8)}: %O`,
+            e
+          )
+        }
+      }
+
       if (anyFailed || results.length === 0) {
         const currentDelay = this.#healBackoff.get(key) ?? HEAL_INITIAL_DELAY_MS
         const nextDelay = Math.min(currentDelay * 2, HEAL_MAX_DELAY_MS)
@@ -194,141 +174,10 @@ export class SyncScheduler {
     return this.#healTimers.has(sedimentreeId.toString())
   }
 
-  // ── Periodic background sync ────────────────────────────────────────
-
-  async #runPeriodicSync(): Promise<void> {
-    if (this.#isShutdown || this.#periodicSyncInProgress) return
-    this.#periodicSyncInProgress = true
-
-    try {
-      const subduction = await this.#subduction
-      const sedimentreeIds = this.#getActiveSedimentreeIds()
-
-      const healingCount = sedimentreeIds.filter(id =>
-        this.#healTimers.has(id.toString())
-      ).length
-      this.#log(
-        `periodic sync: ${sedimentreeIds.length} entries, ` +
-          `${healingCount} healing (skipped)`
-      )
-
-      const tasks: Array<Promise<void>> = []
-      for (const sedimentreeId of sedimentreeIds) {
-        const key = sedimentreeId.toString()
-        // Skip sedimentrees already in heal-backoff
-        if (this.#healTimers.has(key)) continue
-
-        tasks.push(
-          (async () => {
-            try {
-              const peerResultMap = await subduction.syncWithAllPeers(
-                sedimentreeId,
-                true
-              )
-
-              const results = peerResultMap.entries()
-              if (results.length === 0) return
-
-              // If data was received, update the handle immediately
-              const dataReceived = results.some(r => {
-                const s = r.stats
-                return s && (s.commitsReceived > 0 || s.fragmentsReceived > 0)
-              })
-              if (dataReceived) {
-                await this.#onSyncDataReceived(sedimentreeId, subduction)
-              }
-
-              const anyFailed = results.some(
-                r => !r.success || (r.transportErrors?.length ?? 0) > 0
-              )
-
-              if (anyFailed) {
-                this.scheduleHealSync(sedimentreeId)
-              } else {
-                this.resetHealState(key)
-              }
-            } catch (e) {
-              console.warn(
-                `[subduction] periodic sync failed for ${key.slice(0, 8)}:`,
-                e
-              )
-            }
-          })()
-        )
-      }
-
-      await Promise.allSettled(tasks)
-    } finally {
-      this.#periodicSyncInProgress = false
-    }
-  }
-
-  async #runBatchSync(): Promise<void> {
-    if (this.#isShutdown || this.#batchSyncInProgress) return
-    this.#batchSyncInProgress = true
-    this.#log("starting batch sync (all open handles)")
-
-    try {
-      const subduction = await this.#subduction
-      const sedimentreeIds = this.#getActiveSedimentreeIds()
-      let anyFailed = false
-
-      const tasks: Array<Promise<void>> = []
-      for (const sedimentreeId of sedimentreeIds) {
-        const key = sedimentreeId.toString()
-        tasks.push(
-          (async () => {
-            try {
-              const peerResultMap = await subduction.syncWithAllPeers(
-                sedimentreeId,
-                true
-              )
-
-              const results = peerResultMap.entries()
-              if (results.length === 0) return
-
-              const entryFailed = results.some(
-                r => !r.success || (r.transportErrors?.length ?? 0) > 0
-              )
-              if (entryFailed) anyFailed = true
-            } catch (e) {
-              anyFailed = true
-              this.#log(`batch sync failed for ${key.slice(0, 8)}: %O`, e)
-            }
-          })()
-        )
-      }
-
-      await Promise.allSettled(tasks)
-
-      if (!anyFailed) {
-        this.#log("batch sync succeeded — resetting all heal state")
-        for (const timer of this.#healTimers.values()) {
-          clearTimeout(timer)
-        }
-        this.#healTimers.clear()
-        this.#healBackoff.clear()
-        this.#healAttempts.clear()
-      } else {
-        this.#log("batch sync completed with errors")
-      }
-    } finally {
-      this.#batchSyncInProgress = false
-    }
-  }
-
   // ── Shutdown ────────────────────────────────────────────────────────
 
   shutdown(): void {
     this.#isShutdown = true
-    if (this.#periodicSyncTimer !== null) {
-      clearInterval(this.#periodicSyncTimer)
-      this.#periodicSyncTimer = null
-    }
-    if (this.#batchSyncTimer !== null) {
-      clearInterval(this.#batchSyncTimer)
-      this.#batchSyncTimer = null
-    }
     for (const timer of this.#healTimers.values()) {
       clearTimeout(timer)
     }

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -99,20 +99,6 @@ export interface SubductionSourceOptions {
   onHealExhausted?: (documentId: DocumentId) => void
 
   policy?: Policy
-
-  /**
-   * Interval in ms for per-document periodic sync. Each open document is
-   * synced individually (skipping those already in heal-backoff).
-   * Set to 0 to disable. Default: 30_000 (30s).
-   */
-  periodicSyncInterval?: number
-
-  /**
-   * Interval in ms for a full batch sync across all sedimentrees.
-   * On success, all heal state is reset.
-   * Set to 0 to disable. Default: 300_000 (5 min).
-   */
-  batchSyncInterval?: number
 }
 
 export class SubductionSource implements DocumentSource {
@@ -134,8 +120,6 @@ export class SubductionSource implements DocumentSource {
     onEphemeral,
     onHealExhausted,
     policy,
-    periodicSyncInterval = 30_000,
-    batchSyncInterval = 300_000,
   }: SubductionSourceOptions) {
     // Default to "warn" so the Rust side is quiet. When the debug npm module
     // has subduction namespaces enabled (via localStorage.debug), open the
@@ -234,8 +218,6 @@ export class SubductionSource implements DocumentSource {
     this.#scheduler = new SyncScheduler({
       subduction: this.#subduction,
       log: this.#log,
-      getActiveSedimentreeIds: () =>
-        Array.from(this.#entries.values()).map(e => e.sedimentreeId),
       onSyncDataReceived: async (sedimentreeId, subduction) => {
         const entry = this.#entries.get(sedimentreeId.toString())
         if (entry) {
@@ -243,8 +225,6 @@ export class SubductionSource implements DocumentSource {
         }
       },
       onHealExhausted,
-      periodicSyncInterval,
-      batchSyncInterval,
     })
   }
 
@@ -458,7 +438,7 @@ export class SubductionSource implements DocumentSource {
 
       // If new data was received, immediately load it into the handle.
       // This makes sync reactive — the handle updates as soon as data
-      // arrives, without waiting for periodic timers or state transitions.
+      // arrives, without waiting for further state transitions.
       if (dataReceived) {
         await this.#loadBlobsIntoHandle(entry, subduction)
       }
@@ -503,7 +483,7 @@ export class SubductionSource implements DocumentSource {
    * the query so it can transition to "ready".
    *
    * This is called reactively after any `syncWithAllPeers` that received
-   * data, making handle updates immediate rather than timer-driven.
+   * data, making handle updates immediate.
    */
   async #loadBlobsIntoHandle(
     entry: SedimentreeEntry,
@@ -561,7 +541,8 @@ export class SubductionSource implements DocumentSource {
         e
       )
       // Transition to running anyway so live pushes aren't permanently blocked.
-      // The periodic sync will retry loading data.
+      // A subsequent heal retry or connection-state change will retry loading
+      // data.
       entry.syncState = "running"
       entry.lastSyncResult = null
     } finally {
@@ -678,7 +659,7 @@ export class SubductionSource implements DocumentSource {
       mgr.shutdown()
     }
 
-    // 2. Stop scheduled sync timers (no new sync rounds will be triggered)
+    // 2. Stop any pending heal-retry timers and prevent new schedules
     this.#scheduler.shutdown()
 
     // 3. Flush all pending throttled saves so they start executing

--- a/packages/automerge-repo/test/subduction/AdapterTopology.test.ts
+++ b/packages/automerge-repo/test/subduction/AdapterTopology.test.ts
@@ -35,7 +35,6 @@ import type { Policy } from "@automerge/automerge-subduction"
  */
 interface TestServerOptions {
   subductionPolicy?: Policy
-  periodicSyncInterval?: number
 }
 
 class TestServer {
@@ -97,7 +96,6 @@ class TestServer {
       ],
       sharePolicy: async () => true,
       subductionPolicy: this.#opts.subductionPolicy,
-      periodicSyncInterval: this.#opts.periodicSyncInterval,
     })
   }
 
@@ -417,9 +415,6 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
 
     const server = await startServer({
       subductionPolicy: policy,
-      // Short periodic sync so the server pushes to Bob quickly
-      // after the policy changes.
-      periodicSyncInterval: 500,
     })
 
     const alice = startClient("alice", server.url)


### PR DESCRIPTION
Remove periodicSyncInterval and batchSyncInterval. I'm unclear why there's two of these mechanisms — if I had to guess it would be messy code pre-refactor or an LLM port in the refactor. I'm like 98% sure that they were doing the same thing just on separate timers, but please correct me if I'm wrong.

I have _left in_ "heal sync on failure with exponential backoff" since that is legitimately useful.