### PR TITLE
Read-atomic/crash-atomic NodeFS & Subduction bridge

### DIFF
--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -216,11 +216,21 @@ const atomicWrite = async (
   } finally {
     await fh.close()
     if (!wroteTmp) {
-      // Best-effort cleanup if writeFile/sync threw.
+      // Best-effort cleanup if writeFile/sync threw. The caller is
+      // about to see the outer writeFile/sync error; the cleanup
+      // failure almost certainly shares the same underlying cause
+      // (e.g. EIO on the same filesystem), so we don't surface it
+      // through the thrown error. A stray tmp file is filtered out by
+      // loadRange and is otherwise harmless. We log via console.debug
+      // so persistent tmp-file buildup is diagnosable in the unusual
+      // case the cleanup itself fails.
       try {
         await fs.promises.unlink(tmpPath)
-      } catch {
-        /* ignore */
+      } catch (cleanupErr) {
+        console.debug(
+          `[automerge-repo-storage-nodefs] failed to clean up tmp file ${tmpPath}:`,
+          cleanupErr
+        )
       }
     }
   }
@@ -228,11 +238,15 @@ const atomicWrite = async (
   try {
     await fs.promises.rename(tmpPath, targetPath)
   } catch (err) {
-    // If the rename failed, the tmp file is still lying around.
+    // If the rename failed, the tmp file is still lying around. Same
+    // best-effort cleanup semantics as above.
     try {
       await fs.promises.unlink(tmpPath)
-    } catch {
-      /* ignore */
+    } catch (cleanupErr) {
+      console.debug(
+        `[automerge-repo-storage-nodefs] failed to clean up tmp file ${tmpPath}:`,
+        cleanupErr
+      )
     }
     throw err
   }

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -7,7 +7,7 @@
  * Writes use the standard POSIX "write-to-temporary + fsync + rename"
  * pattern so that a reader or a crash never observes a half-written file:
  *
- *   1. The payload is written to `<target>.tmp.<pid>.<uuid>`.
+ *   1. The payload is written to `<baseDirectory>/.tmp/<pid>.<uuid>`.
  *   2. The temporary file is `fsync`ed so its bytes reach disk.
  *   3. `rename(2)` replaces the target atomically (POSIX) or via
  *      `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` (Windows NTFS).
@@ -15,6 +15,13 @@
  *      is durable across a crash. Windows does not expose directory
  *      fsync from user-space Node; directory metadata durability falls
  *      back to the operating system's own guarantees.
+ *
+ * Temporary files live in a dedicated `<baseDirectory>/.tmp/` directory
+ * rather than as siblings of their target files. This keeps them on the
+ * same filesystem as their targets (required for atomic rename) while
+ * making them invisible to older adapters and to {@link loadRange} /
+ * {@link load}, which are always prefix-scoped and are unlikely to walk
+ * `.tmp/` since real-world keys won't shard into a `.t` prefix.
  *
  * {@link NodeFSStorageAdapter.saveBatch | saveBatch} applies the same
  * pattern per entry — every individual write is atomic — but is not an
@@ -39,6 +46,8 @@ const IS_POSIX = os.platform() !== "win32"
 
 export class NodeFSStorageAdapter implements StorageAdapterInterface {
   private baseDirectory: string
+  private tmpDirectory: string
+  private tmpDirectoryReady: Promise<void> | undefined
   private cache: { [key: string]: Uint8Array } = {}
 
   /**
@@ -46,6 +55,40 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
    */
   constructor(baseDirectory = "automerge-repo-data") {
     this.baseDirectory = baseDirectory
+    // Same-filesystem tmp directory so rename(2) stays atomic. Hidden by
+    // a leading dot so `ls` / casual listings don't show it. Real storage
+    // keys shard by hex/base58 first two characters, so they never
+    // collide with the literal `.t` shard — older adapters walking a
+    // shard subtree will never descend into here.
+    this.tmpDirectory = path.join(baseDirectory, TMP_DIR_NAME)
+  }
+
+  /**
+   * Create `tmpDirectory` once (idempotent). Called lazily on the first
+   * write so a read-only consumer of this adapter never creates the
+   * `.tmp/` directory as a side effect of construction.
+   */
+  private ensureTmpDirectory(): Promise<void> {
+    if (!this.tmpDirectoryReady) {
+      this.tmpDirectoryReady = fs.promises
+        .mkdir(this.tmpDirectory, { recursive: true })
+        .then(() => undefined)
+        .catch(err => {
+          // Reset so subsequent writes retry the mkdir. Otherwise a
+          // transient failure would be remembered forever.
+          this.tmpDirectoryReady = undefined
+          throw err
+        })
+    }
+    return this.tmpDirectoryReady
+  }
+
+  /** Build a fresh unique path inside {@link tmpDirectory}. */
+  private makeTmpPath(): string {
+    return path.join(
+      this.tmpDirectory,
+      `${process.pid}.${crypto.randomUUID().replace(/-/g, "")}`
+    )
   }
 
   async load(keyArray: StorageKey): Promise<Uint8Array | undefined> {
@@ -92,8 +135,9 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
     const dir = path.dirname(filePath)
 
     try {
+      await this.ensureTmpDirectory()
       await fs.promises.mkdir(dir, { recursive: true })
-      await atomicWrite(filePath, binary)
+      await atomicWrite(filePath, this.makeTmpPath(), binary)
       await fsyncDir(dir)
     } catch (err) {
       rollbackCache(this.cache, key, prev)
@@ -115,6 +159,17 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
       this.cache[key] = binary
     }
 
+    // Ensure the tmp directory exists once for the whole batch.
+    try {
+      await this.ensureTmpDirectory()
+    } catch (err) {
+      // tmp dir mkdir failed before any write; roll every entry back.
+      for (const [key, prev] of prevByKey) {
+        rollbackCache(this.cache, key, prev)
+      }
+      throw err
+    }
+
     // Per-entry mkdir + atomicWrite in parallel, collecting individual
     // results so a partial failure can roll back only the affected
     // entries. mkdir is `recursive: true`, which is idempotent and
@@ -125,7 +180,7 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
         const dir = path.dirname(filePath)
         return fs.promises
           .mkdir(dir, { recursive: true })
-          .then(() => atomicWrite(filePath, binary))
+          .then(() => atomicWrite(filePath, this.makeTmpPath(), binary))
           .then(
             () => ({ ok: true as const }),
             err => ({ ok: false as const, err })
@@ -262,15 +317,22 @@ const rollbackCache = (
   }
 }
 
-const TMP_SUFFIX = ".tmp."
+/**
+ * Name of the subdirectory under `baseDirectory` that holds in-flight
+ * temporary files. Hidden by the leading dot. The `.t` two-character
+ * prefix cannot collide with any real sharded storage key, which shards
+ * by hex or base58 (see {@link NodeFSStorageAdapter.getFilePath}), so
+ * an older adapter walking a shard subtree never descends here.
+ */
+const TMP_DIR_NAME = ".tmp"
 
 /**
- * Matches the tmp-file suffix produced by {@link atomicWrite}:
- * `<target>.tmp.<pid>.<uuid-without-dashes>`. The UUID is 32 hex chars
- * after `crypto.randomUUID().replace(/-/g, "")`, and the pid is a
- * positive integer. Anchored at end-of-string to avoid matching
- * legitimate keys that happen to contain `.tmp.` somewhere in their
- * basename.
+ * Matches the legacy tmp-file suffix format produced by earlier
+ * versions of this adapter, when tmp files were siblings of their
+ * target: `<target>.tmp.<pid>.<uuid-without-dashes>`. Current code
+ * places tmp files in the {@link TMP_DIR_NAME} directory instead, so
+ * this predicate exists only to filter stale siblings left behind by
+ * crashes under the older layout during an upgrade window.
  */
 const TMP_PATH_PATTERN = /\.tmp\.\d+\.[0-9a-f]{32}$/i
 
@@ -279,7 +341,7 @@ const isTmpPath = (p: string): boolean =>
 
 /**
  * Write `bytes` to `targetPath` atomically:
- *   1. write to a temporary sibling file
+ *   1. write to `tmpPath` on the same filesystem as `targetPath`
  *   2. fsync the temporary file
  *   3. rename over the target
  *
@@ -288,15 +350,17 @@ const isTmpPath = (p: string): boolean =>
  * `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` which is atomic for
  * concurrent readers; post-crash state on Windows depends on NTFS and
  * the OS flush policy.
+ *
+ * `tmpPath` MUST be on the same filesystem as `targetPath`; otherwise
+ * `rename` will fail with `EXDEV` and no fallback is attempted. In
+ * practice callers construct `tmpPath` under `<baseDirectory>/.tmp/`,
+ * so this holds automatically.
  */
 const atomicWrite = async (
   targetPath: string,
+  tmpPath: string,
   bytes: Uint8Array
 ): Promise<void> => {
-  const tmpPath = `${targetPath}${TMP_SUFFIX}${process.pid}.${crypto
-    .randomUUID()
-    .replace(/-/g, "")}`
-
   const fh = await fs.promises.open(tmpPath, "w")
   let wroteTmp = false
   try {
@@ -396,6 +460,11 @@ const walkdir = async (dirPath: string): Promise<string[]> => {
     })
     const files = await Promise.all(
       entries.map(entry => {
+        // Defensive: never descend into the tmp directory if walkdir is
+        // ever invoked with `dirPath === baseDirectory`. Today loadRange
+        // is always called with a prefix, so walkdir starts at a shard
+        // subdirectory and this branch is effectively unreachable.
+        if (entry.isDirectory() && entry.name === TMP_DIR_NAME) return []
         const subpath = path.resolve(dirPath, entry.name)
         return entry.isDirectory() ? walkdir(subpath) : subpath
       })

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -58,50 +58,109 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
       const fileContent = await fs.promises.readFile(filePath)
       return new Uint8Array(fileContent)
     } catch (error: any) {
-      // don't throw if file not found
-      if (error.code === "ENOENT") return undefined
+      // Treat both "file not found" and "path component is not a
+      // directory" as absent. ENOTDIR can surface when a key's
+      // logical path passes through a location where some other
+      // entry occupies the expected directory slot — from load()'s
+      // perspective that still means "no file at this key".
+      if (error.code === "ENOENT" || error.code === "ENOTDIR") {
+        return undefined
+      }
       throw error
     }
   }
 
   async save(keyArray: StorageKey, binary: Uint8Array): Promise<void> {
-    this.cache[getKey(keyArray)] = binary
+    // Populate the cache synchronously — before any await — so that an
+    // in-process load() issued after this call but before the returned
+    // promise resolves still observes the latest bytes. This preserves
+    // the prior adapter's fire-and-forget contract; see
+    // packages/automerge-repo/test/StorageSubsystem.test.ts
+    // ("stores incremental changes following a load"), which performs
+    // an unawaited saveDoc() followed by a fresh-subsystem load().
+    //
+    // If the on-disk write or fsync rejects, we roll the cache back to
+    // its prior value so the cache never exposes bytes that aren't
+    // durable. Fire-and-forget callers still see the latest bytes until
+    // the promise rejects; awaited callers see a rejection and a cache
+    // consistent with disk.
+    const key = getKey(keyArray)
+    const prev = this.cache[key]
+    this.cache[key] = binary
 
     const filePath = this.getFilePath(keyArray)
     const dir = path.dirname(filePath)
 
-    await fs.promises.mkdir(dir, { recursive: true })
-    await atomicWrite(filePath, binary)
-    await fsyncDir(dir)
+    try {
+      await fs.promises.mkdir(dir, { recursive: true })
+      await atomicWrite(filePath, binary)
+      await fsyncDir(dir)
+    } catch (err) {
+      rollbackCache(this.cache, key, prev)
+      throw err
+    }
   }
 
   async saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void> {
     if (entries.length === 0) return
 
+    // Capture prior cache state per key, then populate synchronously so
+    // in-flight in-process loads still observe the batch. On failure we
+    // use the per-entry settled results to roll back only the keys whose
+    // on-disk writes did not succeed. See save() for rationale.
+    const prevByKey: Array<[string, Uint8Array | undefined]> = []
     for (const [keyArray, binary] of entries) {
-      this.cache[getKey(keyArray)] = binary
+      const key = getKey(keyArray)
+      prevByKey.push([key, this.cache[key]])
+      this.cache[key] = binary
     }
 
-    // Phase 1: ensure all target directories exist.
-    const dirs = new Set<string>()
+    // Per-entry mkdir + atomicWrite in parallel, collecting individual
+    // results so a partial failure can roll back only the affected
+    // entries. mkdir is `recursive: true`, which is idempotent and
+    // cheap on already-existing directories.
+    const writeResults = await Promise.all(
+      entries.map(([keyArray, binary]) => {
+        const filePath = this.getFilePath(keyArray)
+        const dir = path.dirname(filePath)
+        return fs.promises
+          .mkdir(dir, { recursive: true })
+          .then(() => atomicWrite(filePath, binary))
+          .then(
+            () => ({ ok: true as const }),
+            err => ({ ok: false as const, err })
+          )
+      })
+    )
 
+    const failedIndices: number[] = []
+    let firstErr: unknown
+    for (let i = 0; i < writeResults.length; i++) {
+      const r = writeResults[i]
+      if (!r.ok) {
+        failedIndices.push(i)
+        if (firstErr === undefined) firstErr = r.err
+      }
+    }
+
+    if (failedIndices.length > 0) {
+      // Roll back only the failed entries' cache state; successful
+      // entries are durable on disk and should remain in cache.
+      for (const i of failedIndices) {
+        const [key, prev] = prevByKey[i]
+        rollbackCache(this.cache, key, prev)
+      }
+      throw firstErr
+    }
+
+    // fsync each distinct parent directory once so the renames are
+    // durable. No-op on Windows. If this rejects, bytes are on disk
+    // and cache matches disk — we don't roll back, but we do surface
+    // the error so callers that care about durability see it.
+    const dirs = new Set<string>()
     for (const [keyArray] of entries) {
       dirs.add(path.dirname(this.getFilePath(keyArray)))
     }
-
-    await Promise.all(
-      Array.from(dirs).map(d => fs.promises.mkdir(d, { recursive: true }))
-    )
-
-    // Phase 2: atomic per-entry write (tmp + fsync + rename) in parallel.
-    await Promise.all(
-      entries.map(([keyArray, binary]) =>
-        atomicWrite(this.getFilePath(keyArray), binary)
-      )
-    )
-
-    // Phase 3: fsync each distinct parent directory once,
-    // so the renames are durable. No-op on Windows.
     await Promise.all(Array.from(dirs).map(d => fsyncDir(d)))
   }
 
@@ -183,9 +242,40 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
 const getKey = (key: StorageKey): string => path.join(...key)
 
+/**
+ * Restore a cache entry to its value prior to a failed write.
+ *
+ * If the key had no prior entry (`prev === undefined`), the entry is
+ * deleted entirely. Otherwise it is overwritten with the prior bytes.
+ * This keeps the in-memory cache consistent with on-disk state when
+ * save() / saveBatch() rejects partway through.
+ */
+const rollbackCache = (
+  cache: Record<string, Uint8Array>,
+  key: string,
+  prev: Uint8Array | undefined
+): void => {
+  if (prev === undefined) {
+    delete cache[key]
+  } else {
+    cache[key] = prev
+  }
+}
+
 const TMP_SUFFIX = ".tmp."
 
-const isTmpPath = (p: string): boolean => path.basename(p).includes(TMP_SUFFIX)
+/**
+ * Matches the tmp-file suffix produced by {@link atomicWrite}:
+ * `<target>.tmp.<pid>.<uuid-without-dashes>`. The UUID is 32 hex chars
+ * after `crypto.randomUUID().replace(/-/g, "")`, and the pid is a
+ * positive integer. Anchored at end-of-string to avoid matching
+ * legitimate keys that happen to contain `.tmp.` somewhere in their
+ * basename.
+ */
+const TMP_PATH_PATTERN = /\.tmp\.\d+\.[0-9a-f]{32}$/i
+
+const isTmpPath = (p: string): boolean =>
+  TMP_PATH_PATTERN.test(path.basename(p))
 
 /**
  * Write `bytes` to `targetPath` atomically:
@@ -282,7 +372,19 @@ const fsyncDir = async (dir: string): Promise<void> => {
     // hard failure — the file fsync still gave us data durability.
     if (err.code !== "EISDIR" && err.code !== "EINVAL") throw err
   } finally {
-    await fh?.close()
+    // Swallow close() failures so they can't turn a tolerated fsync
+    // outcome into a hard failure. Symmetric with the close handling
+    // in atomicWrite.
+    if (fh) {
+      try {
+        await fh.close()
+      } catch (closeErr) {
+        console.debug(
+          `[automerge-repo-storage-nodefs] fsyncDir close() failed for ${dir}:`,
+          closeErr
+        )
+      }
+    }
   }
 }
 

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -1,6 +1,27 @@
 /**
  * @packageDocumentation
- * A `StorageAdapter` which stores data in the local filesystem
+ * A `StorageAdapter` which stores data in the local filesystem.
+ *
+ * ## Durability and atomicity
+ *
+ * Writes use the standard POSIX "write-to-temporary + fsync + rename"
+ * pattern so that a reader or a crash never observes a half-written file:
+ *
+ *   1. The payload is written to `<target>.tmp.<pid>.<uuid>`.
+ *   2. The temporary file is `fsync`ed so its bytes reach disk.
+ *   3. `rename(2)` replaces the target atomically (POSIX) or via
+ *      `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` (Windows NTFS).
+ *   4. On POSIX, the parent directory is `fsync`ed so the rename itself
+ *      is durable across a crash. Windows does not expose directory
+ *      fsync from user-space Node; directory metadata durability falls
+ *      back to the operating system's own guarantees.
+ *
+ * {@link NodeFSStorageAdapter.saveBatch | saveBatch} applies the same
+ * pattern per entry — every individual write is atomic — but is not an
+ * all-or-nothing transaction across the batch. A crash midway through a
+ * `saveBatch` may leave a prefix of the entries applied. Consumers that
+ * need cross-entry atomicity must order their writes so that any
+ * partial prefix is still a valid state.
  */
 
 import {
@@ -8,9 +29,13 @@ import {
   StorageAdapterInterface,
   type StorageKey,
 } from "@automerge/automerge-repo/slim"
-import fs from "fs"
-import path from "path"
+import crypto from "node:crypto"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
 import { rimraf } from "rimraf"
+
+const IS_POSIX = os.platform() !== "win32"
 
 export class NodeFSStorageAdapter implements StorageAdapterInterface {
   private baseDirectory: string
@@ -40,24 +65,52 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
   }
 
   async save(keyArray: StorageKey, binary: Uint8Array): Promise<void> {
-    const key = getKey(keyArray)
-    this.cache[key] = binary
+    this.cache[getKey(keyArray)] = binary
 
     const filePath = this.getFilePath(keyArray)
+    const dir = path.dirname(filePath)
 
-    await fs.promises.mkdir(path.dirname(filePath), { recursive: true })
-    await fs.promises.writeFile(filePath, binary)
+    await fs.promises.mkdir(dir, { recursive: true })
+    await atomicWrite(filePath, binary)
+    await fsyncDir(dir)
+  }
+
+  async saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void> {
+    if (entries.length === 0) return
+
+    for (const [keyArray, binary] of entries) {
+      this.cache[getKey(keyArray)] = binary
+    }
+
+    // Phase 1: ensure all target directories exist.
+    const dirs = new Set<string>()
+
+    for (const [keyArray] of entries) {
+      dirs.add(path.dirname(this.getFilePath(keyArray)))
+    }
+
+    await Promise.all(
+      Array.from(dirs).map(d => fs.promises.mkdir(d, { recursive: true }))
+    )
+
+    // Phase 2: atomic per-entry write (tmp + fsync + rename) in parallel.
+    await Promise.all(
+      entries.map(([keyArray, binary]) =>
+        atomicWrite(this.getFilePath(keyArray), binary)
+      )
+    )
+
+    // Phase 3: fsync each distinct parent directory once,
+    // so the renames are durable. No-op on Windows.
+    await Promise.all(Array.from(dirs).map(d => fsyncDir(d)))
   }
 
   async remove(keyArray: string[]): Promise<void> {
-    // remove from cache
     delete this.cache[getKey(keyArray)]
-    // remove from disk
     const filePath = this.getFilePath(keyArray)
     try {
       await fs.promises.unlink(filePath)
     } catch (error: any) {
-      // don't throw if file not found
       if (error.code !== "ENOENT") throw error
     }
   }
@@ -76,10 +129,13 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
     // The "keys" in the cache don't include the baseDirectory.
     // We want to de-dupe with the cached keys so we'll use getKey to normalize them.
-    const diskKeys: string[] = diskFiles.map((fileName: string) => {
-      const k = getKey([path.relative(this.baseDirectory, fileName)])
-      return k.slice(0, 2) + k.slice(3)
-    })
+    const diskKeys: string[] = diskFiles
+      // Skip any in-flight temporary files from concurrent atomic writes.
+      .filter((fileName: string) => !isTmpPath(fileName))
+      .map((fileName: string) => {
+        const k = getKey([path.relative(this.baseDirectory, fileName)])
+        return k.slice(0, 2) + k.slice(3)
+      })
 
     // Combine and deduplicate the lists of keys
     const allKeys = [...new Set([...cachedKeys, ...diskKeys])]
@@ -127,10 +183,88 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
 const getKey = (key: StorageKey): string => path.join(...key)
 
+const TMP_SUFFIX = ".tmp."
+
+const isTmpPath = (p: string): boolean => path.basename(p).includes(TMP_SUFFIX)
+
+/**
+ * Write `bytes` to `targetPath` atomically:
+ *   1. write to a temporary sibling file
+ *   2. fsync the temporary file
+ *   3. rename over the target
+ *
+ * On POSIX, rename is atomic with respect to concurrent readers and a
+ * crash. On Windows NTFS, `fs.promises.rename` uses
+ * `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` which is atomic for
+ * concurrent readers; post-crash state on Windows depends on NTFS and
+ * the OS flush policy.
+ */
+const atomicWrite = async (
+  targetPath: string,
+  bytes: Uint8Array
+): Promise<void> => {
+  const tmpPath = `${targetPath}${TMP_SUFFIX}${process.pid}.${crypto
+    .randomUUID()
+    .replace(/-/g, "")}`
+
+  const fh = await fs.promises.open(tmpPath, "w")
+  let wroteTmp = false
+  try {
+    await fh.writeFile(bytes)
+    await fh.sync()
+    wroteTmp = true
+  } finally {
+    await fh.close()
+    if (!wroteTmp) {
+      // Best-effort cleanup if writeFile/sync threw.
+      try {
+        await fs.promises.unlink(tmpPath)
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  try {
+    await fs.promises.rename(tmpPath, targetPath)
+  } catch (err) {
+    // If the rename failed, the tmp file is still lying around.
+    try {
+      await fs.promises.unlink(tmpPath)
+    } catch {
+      /* ignore */
+    }
+    throw err
+  }
+}
+
+/**
+ * `fsync` a directory so that recent `rename(2)` calls into it are
+ * durable. POSIX only — opening a directory on Windows fails with
+ * `EISDIR`, so we skip it and rely on the OS's native guarantees.
+ */
+const fsyncDir = async (dir: string): Promise<void> => {
+  if (!IS_POSIX) return
+  let fh: fs.promises.FileHandle | undefined
+  try {
+    fh = await fs.promises.open(dir, "r")
+    await fh.sync()
+  } catch (err: any) {
+    // Some filesystems (tmpfs, certain network mounts) refuse fsync on
+    // directories. Treat that as a best-effort guarantee rather than a
+    // hard failure — the file fsync still gave us data durability.
+    if (err.code !== "EISDIR" && err.code !== "EINVAL") throw err
+  } finally {
+    await fh?.close()
+  }
+}
+
 /** returns all files in a directory, recursively  */
 const walkdir = async (dirPath: string): Promise<string[]> => {
   try {
-    const entries = await fs.promises.readdir(dirPath, { withFileTypes: true })
+    const entries = await fs.promises.readdir(dirPath, {
+      withFileTypes: true,
+    })
     const files = await Promise.all(
       entries.map(entry => {
         const subpath = path.resolve(dirPath, entry.name)

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -122,11 +122,14 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
     // ("stores incremental changes following a load"), which performs
     // an unawaited saveDoc() followed by a fresh-subsystem load().
     //
-    // If the on-disk write or fsync rejects, we roll the cache back to
-    // its prior value so the cache never exposes bytes that aren't
-    // durable. Fire-and-forget callers still see the latest bytes until
-    // the promise rejects; awaited callers see a rejection and a cache
-    // consistent with disk.
+    // Rollback semantics: if the rename has not yet completed, on-disk
+    // state is unchanged and we roll the cache back to match. Once the
+    // rename completes, on-disk state is the new bytes (visible to
+    // concurrent readers), so we do NOT roll back — cache matches disk.
+    // A subsequent fsyncDir failure means the rename may not be durable
+    // across a crash, but the bytes are still present and observable;
+    // rolling back in that case would make cache diverge from disk.
+    // The caller learns about the durability gap via the rejection.
     const key = getKey(keyArray)
     const prev = this.cache[key]
     this.cache[key] = binary
@@ -138,11 +141,27 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
       await this.ensureTmpDirectory()
       await fs.promises.mkdir(dir, { recursive: true })
       await atomicWrite(filePath, this.makeTmpPath(), binary)
-      await fsyncDir(dir)
     } catch (err) {
+      // Rename has not yet completed — disk is unchanged, so cache must
+      // also revert to prior state to stay consistent.
       rollbackCache(this.cache, key, prev)
       throw err
     }
+
+    // Rename succeeded — disk now holds `binary`. Cache and disk agree.
+    // If the directory fsync fails, surface the error so callers that
+    // care about durability see it, but do NOT roll back: bytes ARE
+    // visible on disk and in the page cache.
+    //
+    // We fsync only the leaf directory after rename. On journaled
+    // filesystems (ext4, APFS, NTFS, ZFS, btrfs) the rename's journal
+    // commit persists ancestor directory metadata transitively, so the
+    // full path to the new file is crash-durable. On non-journaled
+    // filesystems (ext2, tmpfs, FAT, some NFS configs) newly-created
+    // ancestor directories from `mkdir(recursive: true)` may not be
+    // crash-durable until a later fsync walks the chain. See follow-up
+    // issue for shard-amortized ancestor fsync.
+    await fsyncDir(dir)
   }
 
   async saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void> {
@@ -212,6 +231,9 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
     // durable. No-op on Windows. If this rejects, bytes are on disk
     // and cache matches disk — we don't roll back, but we do surface
     // the error so callers that care about durability see it.
+    //
+    // Leaf-only fsync; see the same caveat in save() about ancestor
+    // directory durability on non-journaled filesystems.
     const dirs = new Set<string>()
     for (const [keyArray] of entries) {
       dirs.add(path.dirname(this.getFilePath(keyArray)))

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -214,7 +214,20 @@ const atomicWrite = async (
     await fh.sync()
     wroteTmp = true
   } finally {
-    await fh.close()
+    // fh.close() can itself throw (e.g. EIO). Wrap it in its own
+    // try/finally so the tmp-file cleanup below still runs — otherwise
+    // a close failure would mask the original error AND leak a tmp
+    // file. We log the close error at debug level but don't re-throw;
+    // the outer writeFile/sync error (if any) is the signal the caller
+    // cares about.
+    try {
+      await fh.close()
+    } catch (closeErr) {
+      console.debug(
+        `[automerge-repo-storage-nodefs] fh.close() failed for ${tmpPath}:`,
+        closeErr
+      )
+    }
     if (!wroteTmp) {
       // Best-effort cleanup if writeFile/sync threw. The caller is
       // about to see the outer writeFile/sync error; the cleanup

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -114,16 +114,129 @@ describe("NodeFSStorageAdapter", () => {
       await adapter.save(key, new Uint8Array([1, 2, 3, 4]))
 
       // Simulate a concurrent atomic write that crashed mid-flight by
-      // dropping a stray .tmp file next to the real one.
+      // dropping a stray .tmp file next to the real one. The suffix
+      // format here matches what atomicWrite actually produces:
+      // <target>.tmp.<pid>.<32-hex-uuid-without-dashes>.
       const realFile = walkSync(dir).find(
-        f => !path.basename(f).includes(".tmp.")
+        f => !/\.tmp\.\d+\.[0-9a-f]{32}$/i.test(path.basename(f))
       )!
-      const staleTmp = `${realFile}.tmp.99999.deadbeef`
+      const staleTmp = `${realFile}.tmp.99999.${"deadbeef".repeat(4)}`
       fs.writeFileSync(staleTmp, Buffer.from([0xff, 0xff, 0xff, 0xff]))
 
       const chunks = await adapter.loadRange(["AAAAAAAA"])
       expect(chunks).toHaveLength(1)
       expect(Array.from(chunks[0].data!)).toEqual([1, 2, 3, 4])
+    })
+
+    it("loadRange does NOT hide a legitimate key whose basename contains .tmp.", async () => {
+      // Regression guard: a key whose trailing segment happens to
+      // contain ".tmp." in the middle (but doesn't match the actual
+      // tmp-file suffix pattern) must not be filtered out by the
+      // atomic-write tmp-file detection.
+      const weirdKey = ["AAAAAAAA", "blobs", "file.tmp.data"]
+      await adapter.save(weirdKey, new Uint8Array([7, 7, 7]))
+
+      const chunks = await adapter.loadRange(["AAAAAAAA"])
+      const keyStrings = chunks.map(c => c.key.join("/"))
+      expect(keyStrings).toContain(weirdKey.join("/"))
+    })
+
+    // ─── Cache rollback on failure ─────────────────────────────────────
+    //
+    // The adapter populates its in-memory cache synchronously so that
+    // fire-and-forget saves are observable within the same process. If
+    // the on-disk write subsequently fails, the cache must roll back so
+    // it never exposes bytes that aren't durable on disk.
+
+    it("save() rolls the cache back to the prior value on write failure", async () => {
+      const key = ["AAAAAAAA", "snapshot", "hash"]
+      await adapter.save(key, new Uint8Array([1, 1, 1]))
+
+      // Force the next write to fail by dropping a regular file where
+      // the nested shard directory would need to exist for a different
+      // key. More reliable: drop a regular file where this key's own
+      // parent directory would be recreated after a remove. Easiest
+      // reliable approach: point a FRESH key at a path under a pre-
+      // existing file-not-directory.
+      const blockerKey = ["BBBBBBBB", "snapshot", "hash"]
+      const adapterAny = adapter as unknown as {
+        getFilePath(k: string[]): string
+      }
+      const blockerParent = path.dirname(adapterAny.getFilePath(blockerKey))
+      // Make the intended directory path a plain file so mkdir fails.
+      fs.mkdirSync(path.dirname(blockerParent), { recursive: true })
+      fs.writeFileSync(blockerParent, Buffer.from("block"))
+
+      await expect(
+        adapter.save(blockerKey, new Uint8Array([9, 9, 9]))
+      ).rejects.toBeDefined()
+
+      // Cache must not report the failed key as having any value.
+      expect(await adapter.load(blockerKey)).toBeUndefined()
+
+      // A previously-saved key's cache must be untouched.
+      const prior = await adapter.load(key)
+      expect(prior).toBeDefined()
+      expect(Array.from(prior!)).toEqual([1, 1, 1])
+    })
+
+    it("save() restores the prior cache value when overwriting an existing key fails", async () => {
+      const key = ["AAAAAAAA", "snapshot", "hash"]
+      await adapter.save(key, new Uint8Array([1, 1, 1]))
+
+      // Clobber the parent directory's *file entry* for this key with a
+      // directory so the next rename over it fails.
+      const adapterAny = adapter as unknown as {
+        getFilePath(k: string[]): string
+      }
+      const existingFile = adapterAny.getFilePath(key)
+      fs.rmSync(existingFile)
+      fs.mkdirSync(existingFile) // now a directory where a file should be
+
+      await expect(
+        adapter.save(key, new Uint8Array([2, 2, 2]))
+      ).rejects.toBeDefined()
+
+      // Cache should have rolled back to the original bytes (1,1,1),
+      // NOT the attempted (2,2,2). load() consults the cache first, so
+      // if we rolled back correctly we get [1,1,1].
+      const loaded = await adapter.load(key)
+      expect(loaded).toBeDefined()
+      expect(Array.from(loaded!)).toEqual([1, 1, 1])
+    })
+
+    it("saveBatch() rolls back only the entries whose writes failed", async () => {
+      const okKey1 = ["AAAAAAAA", "snapshot", "one"]
+      const okKey2 = ["AAAAAAAA", "snapshot", "two"]
+      const badKey = ["BBBBBBBB", "snapshot", "hash"]
+
+      // Create a file-not-directory at the parent of the bad key so
+      // its mkdir/atomicWrite will fail, while the good keys succeed.
+      const adapterAny = adapter as unknown as {
+        getFilePath(k: string[]): string
+      }
+      const badParent = path.dirname(adapterAny.getFilePath(badKey))
+      fs.mkdirSync(path.dirname(badParent), { recursive: true })
+      fs.writeFileSync(badParent, Buffer.from("block"))
+
+      await expect(
+        adapter.saveBatch([
+          [okKey1, new Uint8Array([1])],
+          [badKey, new Uint8Array([9])],
+          [okKey2, new Uint8Array([2])],
+        ])
+      ).rejects.toBeDefined()
+
+      // The failed key must have been rolled back out of the cache...
+      expect(await adapter.load(badKey)).toBeUndefined()
+
+      // ...but the successful entries should remain in both cache and disk.
+      const one = await adapter.load(okKey1)
+      const two = await adapter.load(okKey2)
+      expect(one).toBeDefined()
+      expect(two).toBeDefined()
+      expect(Array.from(one!)).toEqual([1])
+      expect(Array.from(two!)).toEqual([2])
     })
   })
 })

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -49,7 +49,7 @@ describe("NodeFSStorageAdapter", () => {
       expect(leftover).toHaveLength(0)
     })
 
-    it("overwriting a key leaves either the old or new value, never a partial mix", async () => {
+    it("sequentially overwriting a key yields the new value with no partial mix", async () => {
       const key = ["AAAAAAAA", "snapshot", "hash"]
 
       // 64 KiB so a torn write would be visibly shorter on disk

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -113,9 +113,10 @@ describe("NodeFSStorageAdapter", () => {
       const key = ["AAAAAAAA", "snapshot", "hash"]
       await adapter.save(key, new Uint8Array([1, 2, 3, 4]))
 
-      // Simulate a concurrent atomic write that crashed mid-flight by
-      // dropping a stray .tmp file next to the real one. The suffix
-      // format here matches what atomicWrite actually produces:
+      // Simulate a legacy sibling .tmp file left behind by older adapter
+      // versions after a crashed write. Current atomicWrite uses the
+      // adapter's .tmp directory instead, but loadRange still filters
+      // this older sibling-file pattern:
       // <target>.tmp.<pid>.<32-hex-uuid-without-dashes>.
       const realFile = walkSync(dir).find(
         f => !/\.tmp\.\d+\.[0-9a-f]{32}$/i.test(path.basename(f))

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
-import { describe } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { runStorageAdapterTests } from "../../automerge-repo/src/helpers/tests/storage-adapter-tests"
 import { NodeFSStorageAdapter } from "../src"
 
@@ -16,4 +16,125 @@ describe("NodeFSStorageAdapter", () => {
   }
 
   runStorageAdapterTests(setup)
+
+  // ─── Atomicity / durability ──────────────────────────────────────────
+  //
+  // The shared acceptance tests don't cover the write-to-temp + rename
+  // atomic write pattern. These tests verify that no temporary artefacts
+  // leak into loadRange results, that saveBatch persists every entry,
+  // and that overwriting an existing key leaves the on-disk file in one
+  // of the two valid states (old value or new value) rather than a
+  // partial mix.
+
+  describe("atomic writes", () => {
+    let dir: string
+    let adapter: NodeFSStorageAdapter
+
+    beforeEach(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), "nodefs-atomic-"))
+      adapter = new NodeFSStorageAdapter(dir)
+    })
+
+    afterEach(() => {
+      fs.rmSync(dir, { force: true, recursive: true })
+    })
+
+    it("does not leave .tmp files behind after a successful save", async () => {
+      const key = ["AAAAAAAA", "snapshot", "hash"]
+      await adapter.save(key, new Uint8Array([1, 2, 3, 4]))
+
+      const leftover = walkSync(dir).filter(f =>
+        path.basename(f).includes(".tmp.")
+      )
+      expect(leftover).toHaveLength(0)
+    })
+
+    it("overwriting a key leaves either the old or new value, never a partial mix", async () => {
+      const key = ["AAAAAAAA", "snapshot", "hash"]
+
+      // 64 KiB so a torn write would be visibly shorter on disk
+      const v1 = new Uint8Array(64 * 1024).fill(0xaa)
+      const v2 = new Uint8Array(64 * 1024).fill(0xbb)
+
+      await adapter.save(key, v1)
+      await adapter.save(key, v2)
+
+      const loaded = await adapter.load(key)
+      expect(loaded).toBeDefined()
+      expect(loaded!.length).toBe(v2.length)
+      expect(loaded!.every(b => b === 0xbb)).toBe(true)
+    })
+
+    it("saveBatch persists every entry", async () => {
+      const entries: Array<[string[], Uint8Array]> = []
+      for (let i = 0; i < 32; i++) {
+        const hash = i.toString(16).padStart(8, "0")
+        entries.push([
+          ["AAAAAAAA", "incremental", hash],
+          new Uint8Array([i, i, i, i]),
+        ])
+      }
+
+      await adapter.saveBatch(entries)
+
+      for (const [key, expected] of entries) {
+        const loaded = await adapter.load(key)
+        expect(loaded).toBeDefined()
+        expect(Array.from(loaded!)).toEqual(Array.from(expected))
+      }
+    })
+
+    it("saveBatch([]) is a no-op", async () => {
+      await adapter.saveBatch([])
+      // Nothing to assert beyond "didn't throw" — but confirm directory
+      // is still empty so we didn't accidentally create anything.
+      const files = walkSync(dir)
+      expect(files).toHaveLength(0)
+    })
+
+    it("concurrent saves to the same key converge to exactly one written value", async () => {
+      const key = ["AAAAAAAA", "snapshot", "hash"]
+      const values = Array.from({ length: 16 }, (_, i) =>
+        new Uint8Array(1024).fill(i)
+      )
+
+      await Promise.all(values.map(v => adapter.save(key, v)))
+
+      const loaded = await adapter.load(key)
+      expect(loaded).toBeDefined()
+      expect(loaded!.length).toBe(1024)
+      // Must be fully one of the written values, never a mix.
+      const firstByte = loaded![0]
+      expect(loaded!.every(b => b === firstByte)).toBe(true)
+      expect(values.some(v => v[0] === firstByte)).toBe(true)
+    })
+
+    it("loadRange ignores in-flight .tmp files left over from a crashed write", async () => {
+      const key = ["AAAAAAAA", "snapshot", "hash"]
+      await adapter.save(key, new Uint8Array([1, 2, 3, 4]))
+
+      // Simulate a concurrent atomic write that crashed mid-flight by
+      // dropping a stray .tmp file next to the real one.
+      const realFile = walkSync(dir).find(
+        f => !path.basename(f).includes(".tmp.")
+      )!
+      const staleTmp = `${realFile}.tmp.99999.deadbeef`
+      fs.writeFileSync(staleTmp, Buffer.from([0xff, 0xff, 0xff, 0xff]))
+
+      const chunks = await adapter.loadRange(["AAAAAAAA"])
+      expect(chunks).toHaveLength(1)
+      expect(Array.from(chunks[0].data!)).toEqual([1, 2, 3, 4])
+    })
+  })
 })
+
+/** Recursively walk a directory and return absolute paths of every file. */
+function walkSync(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...walkSync(p))
+    else out.push(p)
+  }
+  return out
+}

--- a/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
@@ -33,11 +33,25 @@ export interface StorageAdapterInterface {
   removeRange(keyPrefix: StorageKey): Promise<void>
 
   /**
-   * Save multiple key-value pairs in a single transaction.
+   * Save multiple key-value pairs in a single batched operation.
    *
    * Optional — implementations that don't provide this will fall back to
    * individual {@link save} calls. Implementing this can significantly
    * reduce IDB transaction overhead for batch writes.
+   *
+   * ## Durability contract
+   *
+   * When the returned promise resolves, every entry in `entries` is
+   * durable. Implementations are free to execute entries in any order
+   * (including in parallel). Callers that require write-ahead ordering
+   * between entries (e.g. "blob before metadata") must split their
+   * entries across multiple sequential `saveBatch` (or `save`) calls —
+   * ordering within a single `saveBatch` call is not guaranteed.
+   *
+   * Implementations MAY provide stronger guarantees (e.g. IndexedDB's
+   * `saveBatch` is a single transaction, so the batch is fully
+   * observable-as-a-unit), but callers cannot rely on those stronger
+   * guarantees through this interface.
    */
   saveBatch?(entries: Array<[StorageKey, Uint8Array]>): Promise<void>
 }

--- a/packages/automerge-repo/src/subduction/storage.ts
+++ b/packages/automerge-repo/src/subduction/storage.ts
@@ -172,22 +172,18 @@ export class SubductionStorageBridge implements SedimentreeStorage {
       const commitKey = [PREFIX, COMMITS_PREFIX, sid, idHex]
       const blobKey = [PREFIX, BLOBS_PREFIX, sid, idHex]
 
-      if (this.adapter.saveBatch) {
-        // Even when the adapter implements saveBatch, pass the blob
-        // entry first so any adapter that serialises the batch (e.g.
-        // NodeFS: atomic per-entry but not cross-entry) preserves the
-        // "blob before commit" invariant on crash.
-        await this.adapter.saveBatch([
-          [blobKey, blobCopy],
-          [commitKey, commitCopy],
-        ])
-      } else {
-        // Write blob first, then commit metadata. Any crash between the
-        // two yields an orphan blob (harmless, skipped by the reader)
-        // rather than a commit pointing at a missing blob.
-        await this.adapter.save(blobKey, blobCopy)
-        await this.adapter.save(commitKey, commitCopy)
-      }
+      // Write blob first, then commit metadata. Any crash between the
+      // two yields an orphan blob (harmless, skipped by the reader)
+      // rather than a commit pointing at a missing blob.
+      //
+      // We deliberately don't use adapter.saveBatch here even when
+      // available: saveBatch's contract guarantees each entry lands
+      // atomically, but an implementation that executes entries in
+      // parallel (e.g. NodeFS) could still produce commit-without-blob
+      // on crash. Two sequential save() calls cost one extra `await`
+      // boundary and are unambiguously crash-consistent.
+      await this.adapter.save(blobKey, blobCopy)
+      await this.adapter.save(commitKey, commitCopy)
 
       // Emit event after save
       if (this.listeners["commit-saved"]?.length) {
@@ -305,20 +301,14 @@ export class SubductionStorageBridge implements SedimentreeStorage {
       const fragmentKey = [PREFIX, FRAGMENTS_PREFIX, sid, idHex]
       const blobKey = [PREFIX, FRAGMENT_BLOBS_PREFIX, sid, idHex]
 
-      if (this.adapter.saveBatch) {
-        // Blob first so serialising adapters preserve "blob before
-        // fragment" under crash.
-        await this.adapter.saveBatch([
-          [blobKey, blobCopy],
-          [fragmentKey, fragmentCopy],
-        ])
-      } else {
-        // Write blob first, then fragment metadata. Any crash between
-        // the two yields an orphan blob (harmless) rather than a
-        // fragment pointing at missing data.
-        await this.adapter.save(blobKey, blobCopy)
-        await this.adapter.save(fragmentKey, fragmentCopy)
-      }
+      // Write blob first, then fragment metadata. Any crash between
+      // the two yields an orphan blob (harmless) rather than a
+      // fragment pointing at missing data.
+      //
+      // We deliberately don't use adapter.saveBatch here; see the
+      // matching comment in saveCommit for rationale.
+      await this.adapter.save(blobKey, blobCopy)
+      await this.adapter.save(fragmentKey, fragmentCopy)
 
       // Emit event after save
       if (this.listeners["fragment-saved"]?.length) {
@@ -418,14 +408,20 @@ export class SubductionStorageBridge implements SedimentreeStorage {
   // ==================== Batch Operations ====================
 
   /**
-   * Save a batch of commits and fragments in a single IDB transaction.
+   * Save a batch of commits and fragments.
    *
    * Called from Subduction's Wasm `save_batch` during sync ingestion.
-   * Instead of N individual `saveCommit`/`saveFragment` calls (each creating
-   * its own IDB readwrite transaction), this collects all key-value pairs
-   * and writes them in one `adapter.saveBatch()` call.
+   * Instead of N individual `saveCommit`/`saveFragment` calls (each
+   * creating its own underlying transaction), this issues at most three
+   * `adapter.saveBatch()` calls (blobs, metadata, sedimentree ID marker)
+   * in order.
    *
-   * For 50 commits this reduces ~100 IDB transactions to 1.
+   * The three-phase structure enforces write-ahead ordering so that any
+   * crash-prefix state is consistent: orphan blobs (harmless), or blobs
+   * + metadata without the ID marker (invisible to enumeration).
+   *
+   * For 50 commits this reduces ~100 round-trips to 3 on adapters that
+   * implement `adapter.saveBatch`.
    */
   async saveBatchAll(
     sedimentreeId: SedimentreeId,
@@ -456,11 +452,15 @@ export class SubductionStorageBridge implements SedimentreeStorage {
     //      durable; a crash before this point leaves invisible-but-
     //      otherwise-consistent state that the next run will ignore.
     //
-    // For adapters that implement saveBatch, we still group the entries
-    // in this order so a serialising adapter (e.g. NodeFS, whose
-    // saveBatch is atomic per-entry but not cross-entry) preserves the
-    // invariant on crash. For adapters whose saveBatch is truly
-    // transactional (e.g. IndexedDB), order is inert.
+    // We enforce the ordering at the `await` boundary between phases
+    // rather than relying on in-batch entry order. An `adapter.saveBatch`
+    // call may internally parallelise entries (e.g. NodeFS), so stuffing
+    // all three phases into one saveBatch call doesn't preserve the
+    // invariant on crash. Three sequential saveBatch calls preserve the
+    // invariant for any adapter whose single saveBatch is "atomic per
+    // entry and durable before returning" — a much weaker contract than
+    // full cross-entry transactionality, which IDB happens to satisfy
+    // but NodeFS does not.
     const blobEntries: Array<[string[], Uint8Array]> = []
     const metaEntries: Array<[string[], Uint8Array]> = []
 
@@ -493,15 +493,16 @@ export class SubductionStorageBridge implements SedimentreeStorage {
     this.pendingSaves++
     try {
       if (this.adapter.saveBatch) {
-        // Pass entries in write-ahead order. An adapter that serialises
-        // entries within the batch (NodeFS) preserves the invariant
-        // under crash; an adapter with a true transactional saveBatch
-        // (IDB) ignores the ordering and writes atomically.
-        await this.adapter.saveBatch([
-          ...blobEntries,
-          ...metaEntries,
-          markerEntry,
-        ])
+        // Three sequential saveBatch calls. Each phase is parallelised
+        // inside the adapter (fast); the `await` boundary between phases
+        // enforces the write-ahead ordering (correct under crash).
+        if (blobEntries.length > 0) {
+          await this.adapter.saveBatch(blobEntries)
+        }
+        if (metaEntries.length > 0) {
+          await this.adapter.saveBatch(metaEntries)
+        }
+        await this.adapter.saveBatch([markerEntry])
       } else {
         // Fallback: three sequential phases, parallel within each phase.
         // A crash between phases leaves a consistent prefix (orphan

--- a/packages/automerge-repo/src/subduction/storage.ts
+++ b/packages/automerge-repo/src/subduction/storage.ts
@@ -173,15 +173,20 @@ export class SubductionStorageBridge implements SedimentreeStorage {
       const blobKey = [PREFIX, BLOBS_PREFIX, sid, idHex]
 
       if (this.adapter.saveBatch) {
+        // Even when the adapter implements saveBatch, pass the blob
+        // entry first so any adapter that serialises the batch (e.g.
+        // NodeFS: atomic per-entry but not cross-entry) preserves the
+        // "blob before commit" invariant on crash.
         await this.adapter.saveBatch([
-          [commitKey, commitCopy],
           [blobKey, blobCopy],
+          [commitKey, commitCopy],
         ])
       } else {
-        await Promise.all([
-          this.adapter.save(commitKey, commitCopy),
-          this.adapter.save(blobKey, blobCopy),
-        ])
+        // Write blob first, then commit metadata. Any crash between the
+        // two yields an orphan blob (harmless, skipped by the reader)
+        // rather than a commit pointing at a missing blob.
+        await this.adapter.save(blobKey, blobCopy)
+        await this.adapter.save(commitKey, commitCopy)
       }
 
       // Emit event after save
@@ -301,15 +306,18 @@ export class SubductionStorageBridge implements SedimentreeStorage {
       const blobKey = [PREFIX, FRAGMENT_BLOBS_PREFIX, sid, idHex]
 
       if (this.adapter.saveBatch) {
+        // Blob first so serialising adapters preserve "blob before
+        // fragment" under crash.
         await this.adapter.saveBatch([
-          [fragmentKey, fragmentCopy],
           [blobKey, blobCopy],
+          [fragmentKey, fragmentCopy],
         ])
       } else {
-        await Promise.all([
-          this.adapter.save(fragmentKey, fragmentCopy),
-          this.adapter.save(blobKey, blobCopy),
-        ])
+        // Write blob first, then fragment metadata. Any crash between
+        // the two yields an orphan blob (harmless) rather than a
+        // fragment pointing at missing data.
+        await this.adapter.save(blobKey, blobCopy)
+        await this.adapter.save(fragmentKey, fragmentCopy)
       }
 
       // Emit event after save
@@ -433,12 +441,29 @@ export class SubductionStorageBridge implements SedimentreeStorage {
     }>
   ): Promise<number> {
     const sid = sedimentreeId.toString()
-    const entries: Array<[string[], Uint8Array]> = []
 
-    // Sedimentree ID marker
-    entries.push([[PREFIX, IDS_PREFIX, sid], ID_MARKER])
+    // Write-ahead ordering: collect entries in three groups that must
+    // be written in order so any crash-prefix state is consistent.
+    //
+    //   1. All blobs (commit blobs and fragment blobs). Orphan blobs
+    //      without their metadata are skipped silently by loadAll* and
+    //      are harmless on-disk garbage.
+    //   2. All metadata (signed commits and signed fragments). By the
+    //      time any of this is visible, every blob it references is
+    //      already durable.
+    //   3. The sedimentree ID marker. This makes the sedimentree
+    //      enumerable via loadAllSedimentreeIds only once its data is
+    //      durable; a crash before this point leaves invisible-but-
+    //      otherwise-consistent state that the next run will ignore.
+    //
+    // For adapters that implement saveBatch, we still group the entries
+    // in this order so a serialising adapter (e.g. NodeFS, whose
+    // saveBatch is atomic per-entry but not cross-entry) preserves the
+    // invariant on crash. For adapters whose saveBatch is truly
+    // transactional (e.g. IndexedDB), order is inert.
+    const blobEntries: Array<[string[], Uint8Array]> = []
+    const metaEntries: Array<[string[], Uint8Array]> = []
 
-    // Collect all commit key-value pairs
     for (const { commitId, signedCommit, blob } of commits) {
       const idHex = commitId.toHexString()
       const commitBytes = signedCommit.encode()
@@ -446,31 +471,48 @@ export class SubductionStorageBridge implements SedimentreeStorage {
       const commitCopy = new Uint8Array(commitBytes)
       const blobCopy = new Uint8Array(blob)
 
-      entries.push([[PREFIX, COMMITS_PREFIX, sid, idHex], commitCopy])
-      entries.push([[PREFIX, BLOBS_PREFIX, sid, idHex], blobCopy])
+      blobEntries.push([[PREFIX, BLOBS_PREFIX, sid, idHex], blobCopy])
+      metaEntries.push([[PREFIX, COMMITS_PREFIX, sid, idHex], commitCopy])
     }
 
-    // Collect all fragment key-value pairs
     for (const { fragmentHead, signedFragment, blob } of fragments) {
       const idHex = fragmentHead.toHexString()
       const fragBytes = signedFragment.encode()
       const fragCopy = new Uint8Array(fragBytes)
       const blobCopy = new Uint8Array(blob)
 
-      entries.push([[PREFIX, FRAGMENTS_PREFIX, sid, idHex], fragCopy])
-      entries.push([[PREFIX, FRAGMENT_BLOBS_PREFIX, sid, idHex], blobCopy])
+      blobEntries.push([[PREFIX, FRAGMENT_BLOBS_PREFIX, sid, idHex], blobCopy])
+      metaEntries.push([[PREFIX, FRAGMENTS_PREFIX, sid, idHex], fragCopy])
     }
 
-    // Single IDB transaction for all entries
+    const markerEntry: [string[], Uint8Array] = [
+      [PREFIX, IDS_PREFIX, sid],
+      ID_MARKER,
+    ]
+
     this.pendingSaves++
     try {
       if (this.adapter.saveBatch) {
-        await this.adapter.saveBatch(entries)
+        // Pass entries in write-ahead order. An adapter that serialises
+        // entries within the batch (NodeFS) preserves the invariant
+        // under crash; an adapter with a true transactional saveBatch
+        // (IDB) ignores the ordering and writes atomically.
+        await this.adapter.saveBatch([
+          ...blobEntries,
+          ...metaEntries,
+          markerEntry,
+        ])
       } else {
-        // Fallback: parallel individual saves (still better than sequential)
+        // Fallback: three sequential phases, parallel within each phase.
+        // A crash between phases leaves a consistent prefix (orphan
+        // blobs, or blobs+metadata without marker).
         await Promise.all(
-          entries.map(([key, data]) => this.adapter.save(key, data))
+          blobEntries.map(([key, data]) => this.adapter.save(key, data))
         )
+        await Promise.all(
+          metaEntries.map(([key, data]) => this.adapter.save(key, data))
+        )
+        await this.adapter.save(markerEntry[0], markerEntry[1])
       }
 
       // Emit events after successful save


### PR DESCRIPTION
The NodeFS storage backend can fail and leave torn writes. This PR improves the NodeFS write safety guarantees for POSIX and Windows targets, and updates the Subduction storage bridge to write in the correct order given how this new atomic API works. Possibly controversial is that we explicitly `fsync` on POSIX, which adds up to 100us per write in exchange for durability guarantees.