### PR TITLE
Don't manually call `free`

### DIFF
--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -672,9 +672,9 @@ export class SubductionSource implements DocumentSource {
     // 5. Wait for SubductionStorageBridge writes to land on disk
     await this.#storage.awaitSettled()
 
-    // 6. Disconnect all Wasm-side transports gracefully, then free.
+    // 6. Disconnect all Wasm-side transports gracefully.
     //    If hydration failed, this.#subduction is a rejected promise —
-    //    treat that as a no-op (nothing to disconnect or free).
+    //    treat that as a no-op (nothing to disconnect).
     let subduction: Subduction | null = null
     try {
       subduction = await this.#subduction
@@ -686,12 +686,6 @@ export class SubductionSource implements DocumentSource {
       await subduction.disconnectAll()
     } catch (e) {
       this.#log("error disconnecting subduction transports: %O", e)
-    } finally {
-      try {
-        subduction.free()
-      } catch (e) {
-        this.#log("error freeing subduction resources: %O", e)
-      }
     }
   }
 


### PR DESCRIPTION
@alexjg this one is me missing one very critical line in some LLM-generated code that I was supervising. This was introduced during work on graceful shutdown — i.e. not quit before Subduction is ready to. Unfortunately `free` is called in a `finally` block. In theory this could be fine (we're "shutting down" after all) but if _anything_ tries to call into this like a forked process with shared access, then we'd be hooped. There's a high chance that this is the source of the null pointer issue in `pushwork`. Even if it's not, we should not be manually calling `free`.

This PR makes it so that we let the JS environment GC the reference instead