### PR TITLE
Add `saveBatch` and safer write order for Subduction bridge

### DIFF
--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -105,17 +105,7 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
       const fileContent = await fs.promises.readFile(filePath)
       return new Uint8Array(fileContent)
     } catch (error: any) {
-      // "No file at this key" covers three fs-error codes:
-      //   ENOENT  — path doesn't exist
-      //   ENOTDIR — a path component is a file where a directory
-      //             was expected
-      //   EISDIR  — the target itself is a directory, not a file
-      // All three correctly mean "no stored value for this key".
-      if (
-        error.code === "ENOENT" ||
-        error.code === "ENOTDIR" ||
-        error.code === "EISDIR"
-      ) {
+      if (error.code === "ENOENT" || error.code === "ENOTDIR") {
         return undefined
       }
       throw error
@@ -291,7 +281,17 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
       commitResults.forEach((r, i) => {
         if (r.ok) successDirs.add(path.dirname(targetPaths[i]))
       })
-      await Promise.allSettled(Array.from(successDirs).map(d => fsyncDir(d)))
+      const fsyncResults = await Promise.allSettled(
+        Array.from(successDirs).map(d => fsyncDir(d))
+      )
+      fsyncResults.forEach(r => {
+        if (r.status === "rejected") {
+          console.debug(
+            `[automerge-repo-storage-nodefs] fsyncDir failed during partial-commit recovery:`,
+            r.reason
+          )
+        }
+      })
 
       throw firstCommitErr
     }

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -22,6 +22,13 @@
  * making them invisible to older adapters and to {@link loadRange} /
  * {@link load}, which are always prefix-scoped and are unlikely to walk
  * `.tmp/` since real-world keys won't shard into a `.t` prefix.
+ *
+ * {@link NodeFSStorageAdapter.saveBatch | saveBatch} applies the same
+ * pattern per entry — every individual write is atomic — but is not an
+ * all-or-nothing transaction across the batch. A crash midway through a
+ * `saveBatch` may leave any subset of entries applied. Consumers that
+ * need cross-entry atomicity must order their writes so that any
+ * partial prefix is still a valid state.
  */
 
 import {
@@ -129,6 +136,90 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
     }
 
     await fsyncDir(dir)
+  }
+
+  async saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void> {
+    if (entries.length === 0) return
+
+    // Capture prior cache state per key, then populate synchronously so
+    // in-flight in-process loads still observe the batch. On failure we
+    // use the per-entry settled results to roll back only the keys whose
+    // on-disk writes did not succeed. See save() for rationale.
+    //
+    // Per-entry concurrency guard (matching save()): only roll back if
+    // the cache still holds the bytes WE wrote. A later concurrent
+    // saveBatch or save may have superseded our entry; clobbering its
+    // value would diverge cache from disk.
+    const prevByKey: Array<[string, Uint8Array | undefined, Uint8Array]> = []
+    for (const [keyArray, binary] of entries) {
+      const key = getKey(keyArray)
+      prevByKey.push([key, this.cache[key], binary])
+      this.cache[key] = binary
+    }
+
+    // Ensure the tmp directory exists once for the whole batch.
+    try {
+      await this.ensureTmpDirectory()
+    } catch (err) {
+      // tmp dir mkdir failed before any write; roll every entry back
+      // (subject to the concurrency guard).
+      for (const [key, prev, ours] of prevByKey) {
+        if (this.cache[key] === ours) {
+          rollbackCache(this.cache, key, prev)
+        }
+      }
+      throw err
+    }
+
+    // Per-entry mkdir + atomicWrite in parallel, collecting individual
+    // results so a partial failure can roll back only the affected
+    // entries. mkdir is `recursive: true`, which is idempotent and
+    // cheap on already-existing directories.
+    const writeResults = await Promise.all(
+      entries.map(([keyArray, binary]) => {
+        const filePath = this.getFilePath(keyArray)
+        const dir = path.dirname(filePath)
+        return fs.promises
+          .mkdir(dir, { recursive: true })
+          .then(() => atomicWrite(filePath, this.makeTmpPath(), binary))
+          .then(
+            () => ({ ok: true as const }),
+            err => ({ ok: false as const, err })
+          )
+      })
+    )
+
+    const failedIndices: number[] = []
+    let firstErr: unknown
+    for (let i = 0; i < writeResults.length; i++) {
+      const r = writeResults[i]
+      if (!r.ok) {
+        failedIndices.push(i)
+        if (firstErr === undefined) firstErr = r.err
+      }
+    }
+
+    if (failedIndices.length > 0) {
+      // Roll back only the failed entries' cache state; successful
+      // entries are durable on disk and should remain in cache.
+      for (const i of failedIndices) {
+        const [key, prev, ours] = prevByKey[i]
+        if (this.cache[key] === ours) {
+          rollbackCache(this.cache, key, prev)
+        }
+      }
+      throw firstErr
+    }
+
+    // fsync each distinct parent directory once so the renames are
+    // durable. No-op on Windows. If this rejects, bytes are on disk
+    // and cache matches disk — we don't roll back, but we do surface
+    // the error so callers that care about durability see it.
+    const dirs = new Set<string>()
+    for (const [keyArray] of entries) {
+      dirs.add(path.dirname(this.getFilePath(keyArray)))
+    }
+    await Promise.all(Array.from(dirs).map(d => fsyncDir(d)))
   }
 
   async remove(keyArray: string[]): Promise<void> {

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -150,16 +150,6 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
   async saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void> {
     if (entries.length === 0) return
 
-    // Populate the cache synchronously, matching save()'s fire-and-
-    // forget contract. If the stage phase rejects before any rename
-    // completes, disk is unchanged — we roll cache back to match (with
-    // per-entry concurrency guard: only revert entries where the cache
-    // still holds OUR bytes; a later concurrent save/saveBatch may have
-    // superseded them).
-    //
-    // Once the commit (rename) phase begins, successful renames make
-    // bytes observable on disk — we do NOT roll those entries back even
-    // if later renames fail, because cache matches disk for them.
     const prevByKey: Array<[string, Uint8Array | undefined, Uint8Array]> = []
     for (const [keyArray, binary] of entries) {
       const key = getKey(keyArray)

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -277,6 +277,18 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
         })
       )
       rollbackCacheForIndices(commitFailures)
+
+      // fsync the parent directories of any entries whose rename
+      // *did* succeed, so their renames are durable across a crash
+      // even though we're about to throw. Otherwise a partial-commit
+      // saveBatch leaves successful renames observable but not
+      // durable, which is strictly weaker than a single save().
+      const successDirs = new Set<string>()
+      commitResults.forEach((r, i) => {
+        if (r.ok) successDirs.add(path.dirname(targetPaths[i]))
+      })
+      await Promise.allSettled(Array.from(successDirs).map(d => fsyncDir(d)))
+
       throw firstCommitErr
     }
 

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -29,15 +29,15 @@
  *
  *   1. Stage every entry's value to a tmp file (write + fsync). No
  *      target is yet observable.
- *   2. Verify every CAS precondition.
- *   3. Commit by renaming every tmp file over its target in turn.
- *   4. fsync every distinct parent directory.
+ *   2. Commit by renaming every tmp file over its target.
+ *   3. fsync every distinct parent directory once all renames have
+ *      completed, so the renames themselves are durable across a crash.
  *
- * If any stage operation or CAS precondition fails, no commits happen
- * and the staged tmp files are cleaned up. A crash during the commit
- * phase may leave an arbitrary subset of entries observable, but each
- * individual committed entry is atomic — readers never see partial
- * bytes for any single key.
+ * If any stage operation fails, no commits happen and the staged tmp
+ * files are cleaned up. A crash during the commit phase may leave an
+ * arbitrary subset of entries observable, but each individual
+ * committed entry is atomic — readers never see partial bytes for any
+ * single key.
  */
 
 import {

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -210,11 +210,6 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
     }
 
     // ── Phase 1: Stage ─────────────────────────────────────────────
-    //
-    // Write every entry to a tmp file under `.tmp/` and fsync it. No
-    // target files are touched yet. If any stage fails, the batch is
-    // aborted: no targets are observable, all successfully-staged tmp
-    // files are cleaned up, and the cache is rolled back in full.
     const tmpPaths: string[] = entries.map(() => this.makeTmpPath())
     const targetPaths: string[] = entries.map(([keyArray]) =>
       this.getFilePath(keyArray)
@@ -240,8 +235,6 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
     }
 
     if (stageFailures.length > 0) {
-      // Clean up any successfully-staged tmp files. No renames have
-      // happened; the on-disk target state is unchanged.
       await Promise.all(
         stageResults.map(async (r, i) => {
           if (r.ok) {
@@ -261,10 +254,6 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
     }
 
     // ── Phase 2: Commit ────────────────────────────────────────────
-    //
-    // Every tmp file is durable. Rename each into place. Per-entry
-    // atomicity: readers never see torn bytes for any single key.
-    // Cross-entry: an arbitrary subset may succeed before a crash.
     const commitResults = await Promise.all(
       tmpPaths.map((tmpPath, i) =>
         fs.promises.rename(tmpPath, targetPaths[i]).then(
@@ -285,8 +274,6 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
     }
 
     if (commitFailures.length > 0) {
-      // Best-effort: unlink the un-renamed tmp files for the failed
-      // entries. Successful renames remain; their cache entries stay.
       await Promise.all(
         commitFailures.map(async i => {
           try {
@@ -299,17 +286,10 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
           }
         })
       )
-      // Roll back the cache only for the failed commits. Successful
-      // commits are durable on disk and should remain in the cache.
       rollbackCacheForIndices(commitFailures)
       throw firstCommitErr
     }
 
-    // ── Phase 3: fsync parent directories ──────────────────────────
-    //
-    // Ensures the renames are durable across a crash. If this rejects,
-    // bytes are on disk (and cache matches) — we surface the error but
-    // don't roll back.
     await Promise.all(Array.from(targetDirs).map(d => fsyncDir(d)))
   }
 

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -105,12 +105,17 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
       const fileContent = await fs.promises.readFile(filePath)
       return new Uint8Array(fileContent)
     } catch (error: any) {
-      // Treat both "file not found" and "path component is not a
-      // directory" as absent. ENOTDIR can surface when a key's
-      // logical path passes through a location where some other
-      // entry occupies the expected directory slot — from load()'s
-      // perspective that still means "no file at this key".
-      if (error.code === "ENOENT" || error.code === "ENOTDIR") {
+      // "No file at this key" covers three fs-error codes:
+      //   ENOENT  — path doesn't exist
+      //   ENOTDIR — a path component is a file where a directory
+      //             was expected
+      //   EISDIR  — the target itself is a directory, not a file
+      // All three correctly mean "no stored value for this key".
+      if (
+        error.code === "ENOENT" ||
+        error.code === "ENOTDIR" ||
+        error.code === "EISDIR"
+      ) {
         return undefined
       }
       throw error

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -281,6 +281,7 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
       commitResults.forEach((r, i) => {
         if (r.ok) successDirs.add(path.dirname(targetPaths[i]))
       })
+
       const fsyncResults = await Promise.allSettled(
         Array.from(successDirs).map(d => fsyncDir(d))
       )
@@ -572,9 +573,6 @@ const fsyncDir = async (dir: string): Promise<void> => {
   } catch (err: any) {
     if (err.code !== "EISDIR" && err.code !== "EINVAL") throw err
   } finally {
-    // Swallow close() failures so they can't turn a tolerated fsync
-    // outcome into a hard failure. Symmetric with the close handling
-    // in atomicWrite.
     if (fh) {
       try {
         await fh.close()

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -23,12 +23,21 @@
  * {@link load}, which are always prefix-scoped and are unlikely to walk
  * `.tmp/` since real-world keys won't shard into a `.t` prefix.
  *
- * {@link NodeFSStorageAdapter.saveBatch | saveBatch} applies the same
- * pattern per entry — every individual write is atomic — but is not an
- * all-or-nothing transaction across the batch. A crash midway through a
- * `saveBatch` may leave any subset of entries applied. Consumers that
- * need cross-entry atomicity must order their writes so that any
- * partial prefix is still a valid state.
+ * {@link NodeFSStorageAdapter.saveBatch | saveBatch} uses the same
+ * pattern per entry, plus a two-phase stage/commit structure across
+ * the batch:
+ *
+ *   1. Stage every entry's value to a tmp file (write + fsync). No
+ *      target is yet observable.
+ *   2. Verify every CAS precondition.
+ *   3. Commit by renaming every tmp file over its target in turn.
+ *   4. fsync every distinct parent directory.
+ *
+ * If any stage operation or CAS precondition fails, no commits happen
+ * and the staged tmp files are cleaned up. A crash during the commit
+ * phase may leave an arbitrary subset of entries observable, but each
+ * individual committed entry is atomic — readers never see partial
+ * bytes for any single key.
  */
 
 import {
@@ -141,15 +150,16 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
   async saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void> {
     if (entries.length === 0) return
 
-    // Capture prior cache state per key, then populate synchronously so
-    // in-flight in-process loads still observe the batch. On failure we
-    // use the per-entry settled results to roll back only the keys whose
-    // on-disk writes did not succeed. See save() for rationale.
+    // Populate the cache synchronously, matching save()'s fire-and-
+    // forget contract. If the stage phase rejects before any rename
+    // completes, disk is unchanged — we roll cache back to match (with
+    // per-entry concurrency guard: only revert entries where the cache
+    // still holds OUR bytes; a later concurrent save/saveBatch may have
+    // superseded them).
     //
-    // Per-entry concurrency guard (matching save()): only roll back if
-    // the cache still holds the bytes WE wrote. A later concurrent
-    // saveBatch or save may have superseded our entry; clobbering its
-    // value would diverge cache from disk.
+    // Once the commit (rename) phase begins, successful renames make
+    // bytes observable on disk — we do NOT roll those entries back even
+    // if later renames fail, because cache matches disk for them.
     const prevByKey: Array<[string, Uint8Array | undefined, Uint8Array]> = []
     for (const [keyArray, binary] of entries) {
       const key = getKey(keyArray)
@@ -157,69 +167,150 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
       this.cache[key] = binary
     }
 
-    // Ensure the tmp directory exists once for the whole batch.
-    try {
-      await this.ensureTmpDirectory()
-    } catch (err) {
-      // tmp dir mkdir failed before any write; roll every entry back
-      // (subject to the concurrency guard).
+    const rollbackAllCache = () => {
       for (const [key, prev, ours] of prevByKey) {
         if (this.cache[key] === ours) {
           rollbackCache(this.cache, key, prev)
         }
       }
-      throw err
     }
 
-    // Per-entry mkdir + atomicWrite in parallel, collecting individual
-    // results so a partial failure can roll back only the affected
-    // entries. mkdir is `recursive: true`, which is idempotent and
-    // cheap on already-existing directories.
-    const writeResults = await Promise.all(
-      entries.map(([keyArray, binary]) => {
-        const filePath = this.getFilePath(keyArray)
-        const dir = path.dirname(filePath)
-        return fs.promises
-          .mkdir(dir, { recursive: true })
-          .then(() => atomicWrite(filePath, this.makeTmpPath(), binary))
-          .then(
-            () => ({ ok: true as const }),
-            err => ({ ok: false as const, err })
-          )
-      })
-    )
-
-    const failedIndices: number[] = []
-    let firstErr: unknown
-    for (let i = 0; i < writeResults.length; i++) {
-      const r = writeResults[i]
-      if (!r.ok) {
-        failedIndices.push(i)
-        if (firstErr === undefined) firstErr = r.err
-      }
-    }
-
-    if (failedIndices.length > 0) {
-      // Roll back only the failed entries' cache state; successful
-      // entries are durable on disk and should remain in cache.
-      for (const i of failedIndices) {
+    const rollbackCacheForIndices = (indices: number[]) => {
+      for (const i of indices) {
         const [key, prev, ours] = prevByKey[i]
         if (this.cache[key] === ours) {
           rollbackCache(this.cache, key, prev)
         }
       }
-      throw firstErr
     }
 
-    // fsync each distinct parent directory once so the renames are
-    // durable. No-op on Windows. If this rejects, bytes are on disk
-    // and cache matches disk — we don't roll back, but we do surface
-    // the error so callers that care about durability see it.
-    const dirs = new Set<string>()
-    for (const [keyArray] of entries) {
-      dirs.add(path.dirname(this.getFilePath(keyArray)))
+    // Ensure the tmp directory exists once for the whole batch.
+    try {
+      await this.ensureTmpDirectory()
+    } catch (err) {
+      rollbackAllCache()
+      throw err
     }
-    await Promise.all(Array.from(dirs).map(d => fsyncDir(d)))
+
+    // Ensure every target's parent directory exists (deduped by
+    // directory path). mkdir is `recursive: true`, idempotent.
+    const targetDirs = new Set<string>()
+    for (const [keyArray] of entries) {
+      targetDirs.add(path.dirname(this.getFilePath(keyArray)))
+    }
+    try {
+      await Promise.all(
+        Array.from(targetDirs).map(d =>
+          fs.promises.mkdir(d, { recursive: true })
+        )
+      )
+    } catch (err) {
+      rollbackAllCache()
+      throw err
+    }
+
+    // ── Phase 1: Stage ─────────────────────────────────────────────
+    //
+    // Write every entry to a tmp file under `.tmp/` and fsync it. No
+    // target files are touched yet. If any stage fails, the batch is
+    // aborted: no targets are observable, all successfully-staged tmp
+    // files are cleaned up, and the cache is rolled back in full.
+    const tmpPaths: string[] = entries.map(() => this.makeTmpPath())
+    const targetPaths: string[] = entries.map(([keyArray]) =>
+      this.getFilePath(keyArray)
+    )
+
+    const stageResults = await Promise.all(
+      entries.map(([, binary], i) =>
+        stageToTmp(tmpPaths[i], binary).then(
+          () => ({ ok: true as const }),
+          err => ({ ok: false as const, err })
+        )
+      )
+    )
+
+    const stageFailures: number[] = []
+    let firstStageErr: unknown
+    for (let i = 0; i < stageResults.length; i++) {
+      const r = stageResults[i]
+      if (!r.ok) {
+        stageFailures.push(i)
+        if (firstStageErr === undefined) firstStageErr = r.err
+      }
+    }
+
+    if (stageFailures.length > 0) {
+      // Clean up any successfully-staged tmp files. No renames have
+      // happened; the on-disk target state is unchanged.
+      await Promise.all(
+        stageResults.map(async (r, i) => {
+          if (r.ok) {
+            try {
+              await fs.promises.unlink(tmpPaths[i])
+            } catch (cleanupErr) {
+              console.debug(
+                `[automerge-repo-storage-nodefs] failed to clean up staged tmp file ${tmpPaths[i]}:`,
+                cleanupErr
+              )
+            }
+          }
+        })
+      )
+      rollbackAllCache()
+      throw firstStageErr
+    }
+
+    // ── Phase 2: Commit ────────────────────────────────────────────
+    //
+    // Every tmp file is durable. Rename each into place. Per-entry
+    // atomicity: readers never see torn bytes for any single key.
+    // Cross-entry: an arbitrary subset may succeed before a crash.
+    const commitResults = await Promise.all(
+      tmpPaths.map((tmpPath, i) =>
+        fs.promises.rename(tmpPath, targetPaths[i]).then(
+          () => ({ ok: true as const }),
+          err => ({ ok: false as const, err })
+        )
+      )
+    )
+
+    const commitFailures: number[] = []
+    let firstCommitErr: unknown
+    for (let i = 0; i < commitResults.length; i++) {
+      const r = commitResults[i]
+      if (!r.ok) {
+        commitFailures.push(i)
+        if (firstCommitErr === undefined) firstCommitErr = r.err
+      }
+    }
+
+    if (commitFailures.length > 0) {
+      // Best-effort: unlink the un-renamed tmp files for the failed
+      // entries. Successful renames remain; their cache entries stay.
+      await Promise.all(
+        commitFailures.map(async i => {
+          try {
+            await fs.promises.unlink(tmpPaths[i])
+          } catch (cleanupErr) {
+            console.debug(
+              `[automerge-repo-storage-nodefs] failed to clean up staged tmp file ${tmpPaths[i]}:`,
+              cleanupErr
+            )
+          }
+        })
+      )
+      // Roll back the cache only for the failed commits. Successful
+      // commits are durable on disk and should remain in the cache.
+      rollbackCacheForIndices(commitFailures)
+      throw firstCommitErr
+    }
+
+    // ── Phase 3: fsync parent directories ──────────────────────────
+    //
+    // Ensures the renames are durable across a crash. If this rejects,
+    // bytes are on disk (and cache matches) — we surface the error but
+    // don't roll back.
+    await Promise.all(Array.from(targetDirs).map(d => fsyncDir(d)))
   }
 
   async remove(keyArray: string[]): Promise<void> {
@@ -415,6 +506,68 @@ const atomicWrite = async (
       )
     }
     throw err
+  }
+}
+
+/**
+ * Write `bytes` to `tmpPath` durably, without touching any target
+ * file. Used by {@link NodeFSStorageAdapter.saveBatch} to stage each
+ * entry before the commit (rename) phase.
+ *
+ *   1. open + writeFile + fsync + close
+ *   2. if open/write/sync threw, best-effort unlink the tmp file and
+ *      re-throw
+ *   3. if close threw after a successful write+fsync, surface that
+ *      error (on some filesystems close is where delayed write errors
+ *      appear; see atomicWrite for the same pattern)
+ */
+const stageToTmp = async (
+  tmpPath: string,
+  bytes: Uint8Array
+): Promise<void> => {
+  const fh = await fs.promises.open(tmpPath, "w")
+  let wroteTmp = false
+  let closeErr: unknown
+  try {
+    await fh.writeFile(bytes)
+    await fh.sync()
+    wroteTmp = true
+  } finally {
+    try {
+      await fh.close()
+    } catch (e) {
+      closeErr = e
+    }
+    if (!wroteTmp) {
+      if (closeErr !== undefined) {
+        console.debug(
+          `[automerge-repo-storage-nodefs] fh.close() failed for ${tmpPath}:`,
+          closeErr
+        )
+      }
+      try {
+        await fs.promises.unlink(tmpPath)
+      } catch (cleanupErr) {
+        console.debug(
+          `[automerge-repo-storage-nodefs] failed to clean up tmp file ${tmpPath}:`,
+          cleanupErr
+        )
+      }
+    }
+  }
+
+  if (closeErr !== undefined) {
+    // Write + sync succeeded but close threw. Don't trust the tmp
+    // file's durability; clean it up and surface the error.
+    try {
+      await fs.promises.unlink(tmpPath)
+    } catch (cleanupErr) {
+      console.debug(
+        `[automerge-repo-storage-nodefs] failed to clean up tmp file ${tmpPath}:`,
+        cleanupErr
+      )
+    }
+    throw closeErr
   }
 }
 

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -226,16 +226,15 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
     if (stageFailures.length > 0) {
       await Promise.all(
-        stageResults.map(async (r, i) => {
-          if (r.ok) {
-            try {
-              await fs.promises.unlink(tmpPaths[i])
-            } catch (cleanupErr) {
-              console.debug(
-                `[automerge-repo-storage-nodefs] failed to clean up staged tmp file ${tmpPaths[i]}:`,
-                cleanupErr
-              )
-            }
+        tmpPaths.map(async tmpPath => {
+          try {
+            await fs.promises.unlink(tmpPath)
+          } catch (cleanupErr: any) {
+            if (cleanupErr?.code === "ENOENT") return
+            console.debug(
+              `[automerge-repo-storage-nodefs] failed to clean up staged tmp file ${tmpPath}:`,
+              cleanupErr
+            )
           }
         })
       )
@@ -538,9 +537,12 @@ const stageToTmp = async (
     }
   }
 
-  if (closeErr !== undefined) {
+  if (wroteTmp && closeErr !== undefined) {
     // Write + sync succeeded but close threw. Don't trust the tmp
     // file's durability; clean it up and surface the error.
+    //
+    // Note: guarded by `wroteTmp` so we don't double-unlink when the
+    // !wroteTmp branch above already cleaned up and logged.
     try {
       await fs.promises.unlink(tmpPath)
     } catch (cleanupErr) {

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -255,20 +255,21 @@ describe("NodeFSStorageAdapter", () => {
       // in <dir>/.tmp/). The commit phase's rename fails for badKey
       // because its target path already exists as a directory; the
       // other entries rename successfully. Expected outcome:
-      //   - successful entries are observable on disk
-      //   - successful entries' cache retains the new bytes
-      //   - failed entry is absent from disk and rolled back in cache
-      //   - no tmp files remain (successful renames moved the tmp
-      //     file to target; failed entry's tmp was unlinked)
+      //   - successful entries are observable on disk and in cache
+      //   - failed entry's cache is rolled back
+      //   - load(badKey) throws EISDIR (directory squatting on a key
+      //     path is a corruption signal that must propagate)
+      //   - no tmp files remain
       const okKey1 = ["AAAAAAAA", "snapshot", "one"]
       const okKey2 = ["CCCCCCCC", "snapshot", "two"]
       const badKey = ["BBBBBBBB", "snapshot", "hash"]
 
       // Make the bad key's target path a directory so rename fails
-      // with EISDIR during the commit phase. Its parent dir exists,
-      // so stage-phase mkdir of the parent succeeds.
+      // during the commit phase. Its parent dir exists, so stage-phase
+      // mkdir of the parent succeeds.
       const adapterAny = adapter as unknown as {
         getFilePath(k: string[]): string
+        cache: Record<string, Uint8Array>
       }
       const badTarget = adapterAny.getFilePath(badKey)
       fs.mkdirSync(path.dirname(badTarget), { recursive: true })
@@ -285,21 +286,31 @@ describe("NodeFSStorageAdapter", () => {
       // Successful entries should be durable on disk (visible via a
       // fresh adapter bypassing the writer's cache).
       const fresh = new NodeFSStorageAdapter(dir)
-      const one = await fresh.load(okKey1)
-      const two = await fresh.load(okKey2)
-      expect(one).toBeDefined()
-      expect(two).toBeDefined()
-      expect(Array.from(one!)).toEqual([1])
-      expect(Array.from(two!)).toEqual([2])
+      expect(Array.from((await fresh.load(okKey1))!)).toEqual([1])
+      expect(Array.from((await fresh.load(okKey2))!)).toEqual([2])
 
       // Successful entries remain in the writer's cache too.
       expect(Array.from((await adapter.load(okKey1))!)).toEqual([1])
       expect(Array.from((await adapter.load(okKey2))!)).toEqual([2])
 
-      // Failed entry: target still exists (it's the directory we
-      // pre-created, not the file we tried to write), and the key
-      // is absent from the writer's cache.
-      expect(await adapter.load(badKey)).toBeUndefined()
+      // Failed entry: directory is still at the target path, so load()
+      // surfaces EISDIR rather than silently returning undefined. This
+      // is the corruption signal; load() MUST propagate it.
+      await expect(adapter.load(badKey)).rejects.toMatchObject({
+        code: "EISDIR",
+      })
+      await expect(fresh.load(badKey)).rejects.toMatchObject({
+        code: "EISDIR",
+      })
+
+      // Direct cache-state check: the failed entry is rolled back in
+      // the writer's cache. The successful entries retain their new
+      // bytes. (Separating this from the load() assertions above
+      // isolates cache behavior from the EISDIR-propagation behavior.)
+      const keyStr = (k: string[]) => k.join(path.sep)
+      expect(adapterAny.cache[keyStr(badKey)]).toBeUndefined()
+      expect(Array.from(adapterAny.cache[keyStr(okKey1)])).toEqual([1])
+      expect(Array.from(adapterAny.cache[keyStr(okKey2)])).toEqual([2])
 
       // No staged tmp files should remain — successful renames moved
       // them to targets; the failing rename's tmp was unlinked.

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -202,13 +202,18 @@ describe("NodeFSStorageAdapter", () => {
       expect(files).toHaveLength(0)
     })
 
-    it("saveBatch() rolls back only the entries whose writes failed", async () => {
+    it("saveBatch() aborts the whole batch when any entry's stage phase fails", async () => {
+      // Staged semantics: if any entry can't be prepared (e.g. its
+      // target directory can't be created), the whole batch is
+      // aborted before any rename happens. No entry should end up
+      // observable on disk, and all cache entries should be rolled
+      // back.
       const okKey1 = ["AAAAAAAA", "snapshot", "one"]
       const okKey2 = ["AAAAAAAA", "snapshot", "two"]
       const badKey = ["BBBBBBBB", "snapshot", "hash"]
 
-      // Create a file-not-directory at the parent of the bad key so
-      // its mkdir/atomicWrite will fail, while the good keys succeed.
+      // Create a file-not-directory at an ancestor of the bad key so
+      // its parent-dir mkdir fails.
       const adapterAny = adapter as unknown as {
         getFilePath(k: string[]): string
       }
@@ -224,16 +229,43 @@ describe("NodeFSStorageAdapter", () => {
         ])
       ).rejects.toBeDefined()
 
-      // The failed key must have been rolled back out of the cache...
-      expect(await adapter.load(badKey)).toBeUndefined()
+      // None of the entries should be observable: the batch was
+      // aborted before any commit. Read via a fresh adapter to verify
+      // on-disk state bypassing any in-memory cache.
+      const fresh = new NodeFSStorageAdapter(dir)
+      expect(await fresh.load(okKey1)).toBeUndefined()
+      expect(await fresh.load(okKey2)).toBeUndefined()
+      expect(await fresh.load(badKey)).toBeUndefined()
 
-      // ...but the successful entries should remain in both cache and disk.
-      const one = await adapter.load(okKey1)
-      const two = await adapter.load(okKey2)
-      expect(one).toBeDefined()
-      expect(two).toBeDefined()
-      expect(Array.from(one!)).toEqual([1])
-      expect(Array.from(two!)).toEqual([2])
+      // The in-memory cache must also be rolled back for all entries.
+      expect(await adapter.load(okKey1)).toBeUndefined()
+      expect(await adapter.load(okKey2)).toBeUndefined()
+      expect(await adapter.load(badKey)).toBeUndefined()
+    })
+
+    it("saveBatch() commits every entry when the stage phase succeeds", async () => {
+      // Successful-path regression: make sure the two-phase design
+      // doesn't accidentally leave tmp files hanging around or fail
+      // to commit.
+      const entries: Array<[string[], Uint8Array]> = [
+        [["AAAAAAAA", "snapshot", "one"], new Uint8Array([1])],
+        [["AAAAAAAA", "snapshot", "two"], new Uint8Array([2])],
+        [["BBBBBBBB", "snapshot", "one"], new Uint8Array([11])],
+      ]
+
+      await adapter.saveBatch(entries)
+
+      // Every entry is persisted.
+      const fresh = new NodeFSStorageAdapter(dir)
+      for (const [key, expected] of entries) {
+        const loaded = await fresh.load(key)
+        expect(loaded).toBeDefined()
+        expect(Array.from(loaded!)).toEqual(Array.from(expected))
+      }
+
+      // No staged tmp files are left behind.
+      const tmpDir = path.join(dir, ".tmp")
+      expect(fs.readdirSync(tmpDir)).toEqual([])
     })
   })
 })

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -249,6 +249,63 @@ describe("NodeFSStorageAdapter", () => {
       expect(await adapter.load(okKey2)).toBeUndefined()
       expect(await adapter.load(badKey)).toBeUndefined()
     })
+
+    it("saveBatch() with a commit-phase failure keeps successful entries and rolls back only the failed one", async () => {
+      // Stage phase succeeds for every entry (tmp files are created
+      // in <dir>/.tmp/). The commit phase's rename fails for badKey
+      // because its target path already exists as a directory; the
+      // other entries rename successfully. Expected outcome:
+      //   - successful entries are observable on disk
+      //   - successful entries' cache retains the new bytes
+      //   - failed entry is absent from disk and rolled back in cache
+      //   - no tmp files remain (successful renames moved the tmp
+      //     file to target; failed entry's tmp was unlinked)
+      const okKey1 = ["AAAAAAAA", "snapshot", "one"]
+      const okKey2 = ["CCCCCCCC", "snapshot", "two"]
+      const badKey = ["BBBBBBBB", "snapshot", "hash"]
+
+      // Make the bad key's target path a directory so rename fails
+      // with EISDIR during the commit phase. Its parent dir exists,
+      // so stage-phase mkdir of the parent succeeds.
+      const adapterAny = adapter as unknown as {
+        getFilePath(k: string[]): string
+      }
+      const badTarget = adapterAny.getFilePath(badKey)
+      fs.mkdirSync(path.dirname(badTarget), { recursive: true })
+      fs.mkdirSync(badTarget) // target-as-directory blocks rename
+
+      await expect(
+        adapter.saveBatch([
+          [okKey1, new Uint8Array([1])],
+          [badKey, new Uint8Array([9])],
+          [okKey2, new Uint8Array([2])],
+        ])
+      ).rejects.toBeDefined()
+
+      // Successful entries should be durable on disk (visible via a
+      // fresh adapter bypassing the writer's cache).
+      const fresh = new NodeFSStorageAdapter(dir)
+      const one = await fresh.load(okKey1)
+      const two = await fresh.load(okKey2)
+      expect(one).toBeDefined()
+      expect(two).toBeDefined()
+      expect(Array.from(one!)).toEqual([1])
+      expect(Array.from(two!)).toEqual([2])
+
+      // Successful entries remain in the writer's cache too.
+      expect(Array.from((await adapter.load(okKey1))!)).toEqual([1])
+      expect(Array.from((await adapter.load(okKey2))!)).toEqual([2])
+
+      // Failed entry: target still exists (it's the directory we
+      // pre-created, not the file we tried to write), and the key
+      // is absent from the writer's cache.
+      expect(await adapter.load(badKey)).toBeUndefined()
+
+      // No staged tmp files should remain — successful renames moved
+      // them to targets; the failing rename's tmp was unlinked.
+      const tmpDir = path.join(dir, ".tmp")
+      expect(fs.readdirSync(tmpDir)).toEqual([])
+    })
   })
 })
 

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -169,6 +169,72 @@ describe("NodeFSStorageAdapter", () => {
       expect(loaded).toBeDefined()
       expect(Array.from(loaded!)).toEqual([1, 1, 1])
     })
+
+    // ─── saveBatch ────────────────────────────────────────────────────
+
+    it("saveBatch persists every entry", async () => {
+      const entries: Array<[string[], Uint8Array]> = []
+      for (let i = 0; i < 32; i++) {
+        const hash = i.toString(16).padStart(8, "0")
+        entries.push([
+          ["AAAAAAAA", "incremental", hash],
+          new Uint8Array([i, i, i, i]),
+        ])
+      }
+
+      await adapter.saveBatch(entries)
+
+      // Read via a fresh adapter so we hit on-disk bytes, not the
+      // writer's in-memory cache.
+      const fresh = new NodeFSStorageAdapter(dir)
+      for (const [key, expected] of entries) {
+        const loaded = await fresh.load(key)
+        expect(loaded).toBeDefined()
+        expect(Array.from(loaded!)).toEqual(Array.from(expected))
+      }
+    })
+
+    it("saveBatch([]) is a no-op", async () => {
+      await adapter.saveBatch([])
+      // Nothing to assert beyond "didn't throw" — but confirm directory
+      // is still empty so we didn't accidentally create anything.
+      const files = walkSync(dir)
+      expect(files).toHaveLength(0)
+    })
+
+    it("saveBatch() rolls back only the entries whose writes failed", async () => {
+      const okKey1 = ["AAAAAAAA", "snapshot", "one"]
+      const okKey2 = ["AAAAAAAA", "snapshot", "two"]
+      const badKey = ["BBBBBBBB", "snapshot", "hash"]
+
+      // Create a file-not-directory at the parent of the bad key so
+      // its mkdir/atomicWrite will fail, while the good keys succeed.
+      const adapterAny = adapter as unknown as {
+        getFilePath(k: string[]): string
+      }
+      const badParent = path.dirname(adapterAny.getFilePath(badKey))
+      fs.mkdirSync(path.dirname(badParent), { recursive: true })
+      fs.writeFileSync(badParent, Buffer.from("block"))
+
+      await expect(
+        adapter.saveBatch([
+          [okKey1, new Uint8Array([1])],
+          [badKey, new Uint8Array([9])],
+          [okKey2, new Uint8Array([2])],
+        ])
+      ).rejects.toBeDefined()
+
+      // The failed key must have been rolled back out of the cache...
+      expect(await adapter.load(badKey)).toBeUndefined()
+
+      // ...but the successful entries should remain in both cache and disk.
+      const one = await adapter.load(okKey1)
+      const two = await adapter.load(okKey2)
+      expect(one).toBeDefined()
+      expect(two).toBeDefined()
+      expect(Array.from(one!)).toEqual([1])
+      expect(Array.from(two!)).toEqual([2])
+    })
   })
 })
 

--- a/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/NodeFSStorageAdapter.test.ts
@@ -172,12 +172,14 @@ describe("NodeFSStorageAdapter", () => {
 
     // ─── saveBatch ────────────────────────────────────────────────────
 
-    it("saveBatch persists every entry", async () => {
+    it("saveBatch persists every entry across multiple shards and leaves no tmp files", async () => {
       const entries: Array<[string[], Uint8Array]> = []
       for (let i = 0; i < 32; i++) {
         const hash = i.toString(16).padStart(8, "0")
+        // Alternate shards so the batch spans multiple target dirs.
+        const shard = i % 2 === 0 ? "AAAAAAAA" : "BBBBBBBB"
         entries.push([
-          ["AAAAAAAA", "incremental", hash],
+          [shard, "incremental", hash],
           new Uint8Array([i, i, i, i]),
         ])
       }
@@ -192,6 +194,11 @@ describe("NodeFSStorageAdapter", () => {
         expect(loaded).toBeDefined()
         expect(Array.from(loaded!)).toEqual(Array.from(expected))
       }
+
+      // The two-phase design must leave no staged tmp files behind on
+      // successful commit.
+      const tmpDir = path.join(dir, ".tmp")
+      expect(fs.readdirSync(tmpDir)).toEqual([])
     })
 
     it("saveBatch([]) is a no-op", async () => {
@@ -202,7 +209,7 @@ describe("NodeFSStorageAdapter", () => {
       expect(files).toHaveLength(0)
     })
 
-    it("saveBatch() aborts the whole batch when any entry's stage phase fails", async () => {
+    it("saveBatch() aborts the whole batch when any entry's setup fails", async () => {
       // Staged semantics: if any entry can't be prepared (e.g. its
       // target directory can't be created), the whole batch is
       // aborted before any rename happens. No entry should end up
@@ -241,31 +248,6 @@ describe("NodeFSStorageAdapter", () => {
       expect(await adapter.load(okKey1)).toBeUndefined()
       expect(await adapter.load(okKey2)).toBeUndefined()
       expect(await adapter.load(badKey)).toBeUndefined()
-    })
-
-    it("saveBatch() commits every entry when the stage phase succeeds", async () => {
-      // Successful-path regression: make sure the two-phase design
-      // doesn't accidentally leave tmp files hanging around or fail
-      // to commit.
-      const entries: Array<[string[], Uint8Array]> = [
-        [["AAAAAAAA", "snapshot", "one"], new Uint8Array([1])],
-        [["AAAAAAAA", "snapshot", "two"], new Uint8Array([2])],
-        [["BBBBBBBB", "snapshot", "one"], new Uint8Array([11])],
-      ]
-
-      await adapter.saveBatch(entries)
-
-      // Every entry is persisted.
-      const fresh = new NodeFSStorageAdapter(dir)
-      for (const [key, expected] of entries) {
-        const loaded = await fresh.load(key)
-        expect(loaded).toBeDefined()
-        expect(Array.from(loaded!)).toEqual(Array.from(expected))
-      }
-
-      // No staged tmp files are left behind.
-      const tmpDir = path.join(dir, ".tmp")
-      expect(fs.readdirSync(tmpDir)).toEqual([])
     })
   })
 })

--- a/packages/automerge-repo/src/helpers/DummyStorageAdapter.ts
+++ b/packages/automerge-repo/src/helpers/DummyStorageAdapter.ts
@@ -41,6 +41,12 @@ export class DummyStorageAdapter implements StorageAdapterInterface {
     delete this.#data[this.#keyToString(key)]
   }
 
+  async saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void> {
+    for (const [key, data] of entries) {
+      await this.save(key, data)
+    }
+  }
+
   keys() {
     return Object.keys(this.#data)
   }

--- a/packages/automerge-repo/src/storage/StorageAdapter.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapter.ts
@@ -33,4 +33,21 @@ export abstract class StorageAdapter implements StorageAdapterInterface {
 
   /** Remove all values with keys that start with `keyPrefix` */
   abstract removeRange(keyPrefix: StorageKey): Promise<void>
+
+  /**
+   * Save multiple key-value pairs as a staged batch.
+   *
+   * Default implementation falls back to sequential {@link save}
+   * calls. Adapters that support a transactional or otherwise more
+   * efficient batch path should override this.
+   *
+   * See {@link StorageAdapterInterface.saveBatch} for the full
+   * semantic contract (two-phase stage/commit, per-entry atomicity,
+   * no intra-batch ordering guarantee).
+   */
+  async saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void> {
+    for (const [key, data] of entries) {
+      await this.save(key, data)
+    }
+  }
 }

--- a/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
@@ -33,11 +33,25 @@ export interface StorageAdapterInterface {
   removeRange(keyPrefix: StorageKey): Promise<void>
 
   /**
-   * Save multiple key-value pairs in a single transaction.
+   * Save multiple key-value pairs in a single batched operation.
    *
    * Optional — implementations that don't provide this will fall back to
    * individual {@link save} calls. Implementing this can significantly
    * reduce IDB transaction overhead for batch writes.
+   *
+   * ## Durability contract
+   *
+   * When the returned promise resolves, every entry in `entries` is
+   * durable. Implementations are free to execute entries in any order
+   * (including in parallel). Callers that require write-ahead ordering
+   * between entries (e.g. "blob before metadata") must split their
+   * entries across multiple sequential `saveBatch` (or `save`) calls —
+   * ordering within a single `saveBatch` call is not guaranteed.
+   *
+   * Implementations MAY provide stronger guarantees (e.g. IndexedDB's
+   * `saveBatch` is a single transaction, so the batch is fully
+   * observable-as-a-unit), but callers cannot rely on those stronger
+   * guarantees through this interface.
    */
   saveBatch?(entries: Array<[StorageKey, Uint8Array]>): Promise<void>
 }

--- a/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
@@ -35,9 +35,6 @@ export interface StorageAdapterInterface {
   /**
    * Save multiple key-value pairs as a staged batch.
    *
-   * Optional — implementations that don't provide this will fall back to
-   * individual {@link save} calls.
-   *
    * ## Two-phase semantics
    *
    * Implementations SHOULD apply the batch in two phases:
@@ -67,6 +64,10 @@ export interface StorageAdapterInterface {
    * ahead ordering between entries (e.g. "blob before metadata") must
    * split their entries across multiple sequential `saveBatch` (or
    * `save`) calls.
+   *
+   * {@link StorageAdapter} provides a default implementation that
+   * simply falls back to sequential {@link save} calls; adapters are
+   * free to override it with a more efficient backend-specific path.
    */
-  saveBatch?(entries: Array<[StorageKey, Uint8Array]>): Promise<void>
+  saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void>
 }

--- a/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
@@ -7,76 +7,45 @@ import { StorageKey, Chunk } from "./types.js"
  * ({@link StorageKey}) and the values are binary blobs.
  */
 export interface StorageAdapterInterface {
-  /** Load the single value corresponding to `key` */
-  load(key: StorageKey): Promise<Uint8Array | undefined>
+    /** Load the single value corresponding to `key` */
+    load(key: StorageKey): Promise<Uint8Array | undefined>
 
-  /** Save the value `data` to the key `key` */
-  save(key: StorageKey, data: Uint8Array): Promise<void>
+    /** Save the value `data` to the key `key` */
+    save(key: StorageKey, data: Uint8Array): Promise<void>
 
-  /** Remove the value corresponding to `key` */
-  remove(key: StorageKey): Promise<void>
+    /** Remove the value corresponding to `key` */
+    remove(key: StorageKey): Promise<void>
 
-  /**
-   * Load all values with keys that start with `keyPrefix`.
-   *
-   * @remarks
-   * The `keyprefix` will match any key that starts with the given array. For example:
-   * - `[documentId, "incremental"]` will match all incremental saves
-   * - `[documentId]` will match all data for a given document.
-   *
-   * Be careful! `[documentId]` would also match something like `[documentId, "syncState"]`! We
-   * aren't using this yet but keep it in mind.)
-   */
-  loadRange(keyPrefix: StorageKey): Promise<Chunk[]>
+    /**
+     * Load all values with keys that start with `keyPrefix`.
+     *
+     * @remarks
+     * The `keyprefix` will match any key that starts with the given array. For example:
+     * - `[documentId, "incremental"]` will match all incremental saves
+     * - `[documentId]` will match all data for a given document.
+     *
+     * Be careful! `[documentId]` would also match something like `[documentId, "syncState"]`! We
+     * aren't using this yet but keep it in mind.)
+     */
+    loadRange(keyPrefix: StorageKey): Promise<Chunk[]>
 
-  /** Remove all values with keys that start with `keyPrefix` */
-  removeRange(keyPrefix: StorageKey): Promise<void>
+    /** Remove all values with keys that start with `keyPrefix` */
+    removeRange(keyPrefix: StorageKey): Promise<void>
 
-  /**
-   * Save multiple key-value pairs as a staged batch.
-   *
-   * ## Two-phase semantics
-   *
-   * Implementations SHOULD apply the batch in two phases:
-   *
-   *   1. **Stage**: every entry's value is written to durable temporary
-   *      storage (e.g. tmp file + fsync). No target is observable yet.
-   *   2. **Commit**: every staged write is committed to its final
-   *      target (e.g. rename over target).
-   *
-   * If any stage operation fails, the batch is aborted before any
-   * commit happens — no entries become observable.
-   *
-   * ## Commit-phase semantics vary by implementation
-   *
-   * - **Transactional implementations** (e.g. IndexedDB, where the
-   *   whole batch runs inside one readwrite transaction) commit the
-   *   entire batch atomically. A crash either leaves the full batch
-   *   observable or none of it — never a partial prefix.
-   * - **Non-transactional implementations** (e.g. NodeFS, where the
-   *   commit phase is a sequence of `rename(2)` calls) may leave an
-   *   arbitrary subset observable on crash. Each individual committed
-   *   entry is still atomic — readers never see partial bytes for any
-   *   single key — but cross-entry ordering within the commit phase
-   *   is not guaranteed.
-   *
-   * Callers that need strict cross-entry ordering across crashes (on
-   * any adapter) must split their entries across multiple sequential
-   * `saveBatch` (or `save`) calls: the phase boundary between calls
-   * gives them the ordering guarantee they need.
-   *
-   * Callers whose downstream readers tolerate partial-batch outcomes
-   * (e.g. a reader that checks for a related key's presence before
-   * surfacing an entry) can safely pass related keys as a single
-   * `saveBatch` call — on transactional adapters they get atomicity,
-   * and on non-transactional adapters the tolerated-partial case is
-   * handled at read time.
-   *
-   * {@link StorageAdapter} provides a default implementation that
-   * simply falls back to sequential {@link save} calls. The default
-   * offers only per-entry atomicity — not the stage/commit separation
-   * — so consumers that depend on the stage/commit semantics above
-   * should require an adapter that overrides `saveBatch` explicitly.
-   */
-  saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void>
+    /**
+     * Save multiple key-value pairs as a staged batch.
+     *
+     * ## Two-phase semantics
+     *
+     * Implementations SHOULD apply the batch in two phases:
+     *
+     *   1. **Stage**: every entry's value is written to durable temporary
+     *      storage (e.g. tmp file + fsync). No target is observable yet.
+     *   2. **Commit**: every staged write is committed to its final
+     *      target (e.g. rename over target).
+     *
+     * If any stage operation fails, the batch is aborted before any
+     * commit happens — no entries become observable.
+     */
+    saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void>
 }

--- a/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
@@ -47,27 +47,36 @@ export interface StorageAdapterInterface {
    * If any stage operation fails, the batch is aborted before any
    * commit happens — no entries become observable.
    *
-   * If a crash occurs:
-   *   - During the stage phase: zero entries are observable. Staged
-   *     tmp files may be left behind as garbage.
-   *   - During the commit phase: an arbitrary subset of entries may be
-   *     observable. Each individual committed entry is atomic; readers
-   *     never see partial bytes for any single key.
+   * ## Commit-phase semantics vary by implementation
    *
-   * Implementations MAY provide stronger guarantees (e.g. IndexedDB's
-   * `saveBatch` runs as a single transaction, so the entire batch is
-   * fully observable-as-a-unit even across crash). Callers cannot rely
-   * on the stronger guarantees through this interface.
+   * - **Transactional implementations** (e.g. IndexedDB, where the
+   *   whole batch runs inside one readwrite transaction) commit the
+   *   entire batch atomically. A crash either leaves the full batch
+   *   observable or none of it — never a partial prefix.
+   * - **Non-transactional implementations** (e.g. NodeFS, where the
+   *   commit phase is a sequence of `rename(2)` calls) may leave an
+   *   arbitrary subset observable on crash. Each individual committed
+   *   entry is still atomic — readers never see partial bytes for any
+   *   single key — but cross-entry ordering within the commit phase
+   *   is not guaranteed.
    *
-   * Ordering within the `entries` array is not guaranteed to be
-   * preserved across the commit phase. Callers that require write-
-   * ahead ordering between entries (e.g. "blob before metadata") must
-   * split their entries across multiple sequential `saveBatch` (or
-   * `save`) calls.
+   * Callers that need strict cross-entry ordering across crashes (on
+   * any adapter) must split their entries across multiple sequential
+   * `saveBatch` (or `save`) calls: the phase boundary between calls
+   * gives them the ordering guarantee they need.
+   *
+   * Callers whose downstream readers tolerate partial-batch outcomes
+   * (e.g. a reader that checks for a related key's presence before
+   * surfacing an entry) can safely pass related keys as a single
+   * `saveBatch` call — on transactional adapters they get atomicity,
+   * and on non-transactional adapters the tolerated-partial case is
+   * handled at read time.
    *
    * {@link StorageAdapter} provides a default implementation that
-   * simply falls back to sequential {@link save} calls; adapters are
-   * free to override it with a more efficient backend-specific path.
+   * simply falls back to sequential {@link save} calls. The default
+   * offers only per-entry atomicity — not the stage/commit separation
+   * — so consumers that depend on the stage/commit semantics above
+   * should require an adapter that overrides `saveBatch` explicitly.
    */
   saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void>
 }

--- a/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
@@ -7,45 +7,45 @@ import { StorageKey, Chunk } from "./types.js"
  * ({@link StorageKey}) and the values are binary blobs.
  */
 export interface StorageAdapterInterface {
-    /** Load the single value corresponding to `key` */
-    load(key: StorageKey): Promise<Uint8Array | undefined>
+  /** Load the single value corresponding to `key` */
+  load(key: StorageKey): Promise<Uint8Array | undefined>
 
-    /** Save the value `data` to the key `key` */
-    save(key: StorageKey, data: Uint8Array): Promise<void>
+  /** Save the value `data` to the key `key` */
+  save(key: StorageKey, data: Uint8Array): Promise<void>
 
-    /** Remove the value corresponding to `key` */
-    remove(key: StorageKey): Promise<void>
+  /** Remove the value corresponding to `key` */
+  remove(key: StorageKey): Promise<void>
 
-    /**
-     * Load all values with keys that start with `keyPrefix`.
-     *
-     * @remarks
-     * The `keyprefix` will match any key that starts with the given array. For example:
-     * - `[documentId, "incremental"]` will match all incremental saves
-     * - `[documentId]` will match all data for a given document.
-     *
-     * Be careful! `[documentId]` would also match something like `[documentId, "syncState"]`! We
-     * aren't using this yet but keep it in mind.)
-     */
-    loadRange(keyPrefix: StorageKey): Promise<Chunk[]>
+  /**
+   * Load all values with keys that start with `keyPrefix`.
+   *
+   * @remarks
+   * The `keyprefix` will match any key that starts with the given array. For example:
+   * - `[documentId, "incremental"]` will match all incremental saves
+   * - `[documentId]` will match all data for a given document.
+   *
+   * Be careful! `[documentId]` would also match something like `[documentId, "syncState"]`! We
+   * aren't using this yet but keep it in mind.)
+   */
+  loadRange(keyPrefix: StorageKey): Promise<Chunk[]>
 
-    /** Remove all values with keys that start with `keyPrefix` */
-    removeRange(keyPrefix: StorageKey): Promise<void>
+  /** Remove all values with keys that start with `keyPrefix` */
+  removeRange(keyPrefix: StorageKey): Promise<void>
 
-    /**
-     * Save multiple key-value pairs as a staged batch.
-     *
-     * ## Two-phase semantics
-     *
-     * Implementations SHOULD apply the batch in two phases:
-     *
-     *   1. **Stage**: every entry's value is written to durable temporary
-     *      storage (e.g. tmp file + fsync). No target is observable yet.
-     *   2. **Commit**: every staged write is committed to its final
-     *      target (e.g. rename over target).
-     *
-     * If any stage operation fails, the batch is aborted before any
-     * commit happens — no entries become observable.
-     */
-    saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void>
+  /**
+   * Save multiple key-value pairs as a staged batch.
+   *
+   * ## Two-phase semantics
+   *
+   * Implementations SHOULD apply the batch in two phases:
+   *
+   *   1. **Stage**: every entry's value is written to durable temporary
+   *      storage (e.g. tmp file + fsync). No target is observable yet.
+   *   2. **Commit**: every staged write is committed to its final
+   *      target (e.g. rename over target).
+   *
+   * If any stage operation fails, the batch is aborted before any
+   * commit happens — no entries become observable.
+   */
+  saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void>
 }

--- a/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
@@ -33,25 +33,40 @@ export interface StorageAdapterInterface {
   removeRange(keyPrefix: StorageKey): Promise<void>
 
   /**
-   * Save multiple key-value pairs in a single batched operation.
+   * Save multiple key-value pairs as a staged batch.
    *
    * Optional — implementations that don't provide this will fall back to
-   * individual {@link save} calls. Implementing this can significantly
-   * reduce IDB transaction overhead for batch writes.
+   * individual {@link save} calls.
    *
-   * ## Durability contract
+   * ## Two-phase semantics
    *
-   * When the returned promise resolves, every entry in `entries` is
-   * durable. Implementations are free to execute entries in any order
-   * (including in parallel). Callers that require write-ahead ordering
-   * between entries (e.g. "blob before metadata") must split their
-   * entries across multiple sequential `saveBatch` (or `save`) calls —
-   * ordering within a single `saveBatch` call is not guaranteed.
+   * Implementations SHOULD apply the batch in two phases:
+   *
+   *   1. **Stage**: every entry's value is written to durable temporary
+   *      storage (e.g. tmp file + fsync). No target is observable yet.
+   *   2. **Commit**: every staged write is committed to its final
+   *      target (e.g. rename over target).
+   *
+   * If any stage operation fails, the batch is aborted before any
+   * commit happens — no entries become observable.
+   *
+   * If a crash occurs:
+   *   - During the stage phase: zero entries are observable. Staged
+   *     tmp files may be left behind as garbage.
+   *   - During the commit phase: an arbitrary subset of entries may be
+   *     observable. Each individual committed entry is atomic; readers
+   *     never see partial bytes for any single key.
    *
    * Implementations MAY provide stronger guarantees (e.g. IndexedDB's
-   * `saveBatch` is a single transaction, so the batch is fully
-   * observable-as-a-unit), but callers cannot rely on those stronger
-   * guarantees through this interface.
+   * `saveBatch` runs as a single transaction, so the entire batch is
+   * fully observable-as-a-unit even across crash). Callers cannot rely
+   * on the stronger guarantees through this interface.
+   *
+   * Ordering within the `entries` array is not guaranteed to be
+   * preserved across the commit phase. Callers that require write-
+   * ahead ordering between entries (e.g. "blob before metadata") must
+   * split their entries across multiple sequential `saveBatch` (or
+   * `save`) calls.
    */
   saveBatch?(entries: Array<[StorageKey, Uint8Array]>): Promise<void>
 }

--- a/packages/automerge-repo/src/subduction/storage.ts
+++ b/packages/automerge-repo/src/subduction/storage.ts
@@ -438,29 +438,6 @@ export class SubductionStorageBridge implements SedimentreeStorage {
   ): Promise<number> {
     const sid = sedimentreeId.toString()
 
-    // Write-ahead ordering: collect entries in three groups that must
-    // be written in order so any crash-prefix state is consistent.
-    //
-    //   1. All blobs (commit blobs and fragment blobs). Orphan blobs
-    //      without their metadata are skipped silently by loadAll* and
-    //      are harmless on-disk garbage.
-    //   2. All metadata (signed commits and signed fragments). By the
-    //      time any of this is visible, every blob it references is
-    //      already durable.
-    //   3. The sedimentree ID marker. This makes the sedimentree
-    //      enumerable via loadAllSedimentreeIds only once its data is
-    //      durable; a crash before this point leaves invisible-but-
-    //      otherwise-consistent state that the next run will ignore.
-    //
-    // We enforce the ordering at the `await` boundary between phases
-    // rather than relying on in-batch entry order. An `adapter.saveBatch`
-    // call may internally parallelise entries (e.g. NodeFS), so stuffing
-    // all three phases into one saveBatch call doesn't preserve the
-    // invariant on crash. Three sequential saveBatch calls preserve the
-    // invariant for any adapter whose single saveBatch is "atomic per
-    // entry and durable before returning" — a much weaker contract than
-    // full cross-entry transactionality, which IDB happens to satisfy
-    // but NodeFS does not.
     const blobEntries: Array<[string[], Uint8Array]> = []
     const metaEntries: Array<[string[], Uint8Array]> = []
 

--- a/packages/automerge-repo/src/subduction/storage.ts
+++ b/packages/automerge-repo/src/subduction/storage.ts
@@ -177,6 +177,10 @@ export class SubductionStorageBridge implements SedimentreeStorage {
         [commitKey, commitCopy],
       ])
 
+      // Emit a fresh copy per event. `blobCopy` is already the bytes
+      // we handed to the adapter, and adapters (e.g. NodeFS) cache by
+      // reference. A listener that mutates the shared reference would
+      // corrupt the adapter's cache and affect other listeners.
       if (this.listeners["commit-saved"]?.length) {
         this.emit(
           "commit-saved",
@@ -303,6 +307,7 @@ export class SubductionStorageBridge implements SedimentreeStorage {
         [fragmentKey, fragmentCopy],
       ])
 
+      // Defensive copy per event; see comment in saveCommit.
       if (this.listeners["fragment-saved"]?.length) {
         this.emit(
           "fragment-saved",
@@ -480,6 +485,7 @@ export class SubductionStorageBridge implements SedimentreeStorage {
       }
       await this.adapter.saveBatch([markerEntry])
 
+      // Defensive copy per event; see comment in saveCommit.
       if (this.listeners["commit-saved"]?.length) {
         commits.forEach(({ commitId }, i) => {
           this.emit(

--- a/packages/automerge-repo/src/subduction/storage.ts
+++ b/packages/automerge-repo/src/subduction/storage.ts
@@ -177,9 +177,13 @@ export class SubductionStorageBridge implements SedimentreeStorage {
         [commitKey, commitCopy],
       ])
 
-      // Emit event after save
       if (this.listeners["commit-saved"]?.length) {
-        this.emit("commit-saved", sedimentreeId, commitId, blobCopy)
+        this.emit(
+          "commit-saved",
+          sedimentreeId,
+          commitId,
+          new Uint8Array(blobCopy)
+        )
       }
     } finally {
       this.decrementPending()
@@ -299,9 +303,13 @@ export class SubductionStorageBridge implements SedimentreeStorage {
         [fragmentKey, fragmentCopy],
       ])
 
-      // Emit event after save
       if (this.listeners["fragment-saved"]?.length) {
-        this.emit("fragment-saved", sedimentreeId, fragmentHead, blobCopy)
+        this.emit(
+          "fragment-saved",
+          sedimentreeId,
+          fragmentHead,
+          new Uint8Array(blobCopy)
+        )
       }
     } finally {
       this.decrementPending()
@@ -478,7 +486,7 @@ export class SubductionStorageBridge implements SedimentreeStorage {
             "commit-saved",
             sedimentreeId,
             commitId,
-            commitBlobCopies[i]
+            new Uint8Array(commitBlobCopies[i])
           )
         })
       }
@@ -488,7 +496,7 @@ export class SubductionStorageBridge implements SedimentreeStorage {
             "fragment-saved",
             sedimentreeId,
             fragmentHead,
-            fragmentBlobCopies[i]
+            new Uint8Array(fragmentBlobCopies[i])
           )
         })
       }

--- a/packages/automerge-repo/src/subduction/storage.ts
+++ b/packages/automerge-repo/src/subduction/storage.ts
@@ -464,6 +464,10 @@ export class SubductionStorageBridge implements SedimentreeStorage {
     const blobEntries: Array<[string[], Uint8Array]> = []
     const metaEntries: Array<[string[], Uint8Array]> = []
 
+    // Retain copies of each blob so we can emit them after the save.
+    const commitBlobCopies: Uint8Array[] = []
+    const fragmentBlobCopies: Uint8Array[] = []
+
     for (const { commitId, signedCommit, blob } of commits) {
       const idHex = commitId.toHexString()
       const commitBytes = signedCommit.encode()
@@ -473,6 +477,7 @@ export class SubductionStorageBridge implements SedimentreeStorage {
 
       blobEntries.push([[PREFIX, BLOBS_PREFIX, sid, idHex], blobCopy])
       metaEntries.push([[PREFIX, COMMITS_PREFIX, sid, idHex], commitCopy])
+      commitBlobCopies.push(blobCopy)
     }
 
     for (const { fragmentHead, signedFragment, blob } of fragments) {
@@ -483,6 +488,7 @@ export class SubductionStorageBridge implements SedimentreeStorage {
 
       blobEntries.push([[PREFIX, FRAGMENT_BLOBS_PREFIX, sid, idHex], blobCopy])
       metaEntries.push([[PREFIX, FRAGMENTS_PREFIX, sid, idHex], fragCopy])
+      fragmentBlobCopies.push(blobCopy)
     }
 
     const markerEntry: [string[], Uint8Array] = [
@@ -516,26 +522,25 @@ export class SubductionStorageBridge implements SedimentreeStorage {
         await this.adapter.save(markerEntry[0], markerEntry[1])
       }
 
-      // Emit events after successful save
-      for (const { commitId, blob } of commits) {
-        if (this.listeners["commit-saved"]?.length) {
+      if (this.listeners["commit-saved"]?.length) {
+        commits.forEach(({ commitId }, i) => {
           this.emit(
             "commit-saved",
             sedimentreeId,
             commitId,
-            new Uint8Array(blob)
+            commitBlobCopies[i]
           )
-        }
+        })
       }
-      for (const { fragmentHead, blob } of fragments) {
-        if (this.listeners["fragment-saved"]?.length) {
+      if (this.listeners["fragment-saved"]?.length) {
+        fragments.forEach(({ fragmentHead }, i) => {
           this.emit(
             "fragment-saved",
             sedimentreeId,
             fragmentHead,
-            new Uint8Array(blob)
+            fragmentBlobCopies[i]
           )
-        }
+        })
       }
     } finally {
       this.decrementPending()

--- a/packages/automerge-repo/src/subduction/storage.ts
+++ b/packages/automerge-repo/src/subduction/storage.ts
@@ -172,17 +172,18 @@ export class SubductionStorageBridge implements SedimentreeStorage {
       const commitKey = [PREFIX, COMMITS_PREFIX, sid, idHex]
       const blobKey = [PREFIX, BLOBS_PREFIX, sid, idHex]
 
-      if (this.adapter.saveBatch) {
-        await this.adapter.saveBatch([
-          [commitKey, commitCopy],
-          [blobKey, blobCopy],
-        ])
-      } else {
-        await Promise.all([
-          this.adapter.save(commitKey, commitCopy),
-          this.adapter.save(blobKey, blobCopy),
-        ])
-      }
+      // Write blob first, then commit metadata. Any crash between the
+      // two yields an orphan blob (harmless, skipped by the reader)
+      // rather than a commit pointing at a missing blob.
+      //
+      // We deliberately don't use adapter.saveBatch here even when
+      // available: saveBatch's contract guarantees each entry lands
+      // atomically, but an implementation that executes entries in
+      // parallel (e.g. NodeFS) could still produce commit-without-blob
+      // on crash. Two sequential save() calls cost one extra `await`
+      // boundary and are unambiguously crash-consistent.
+      await this.adapter.save(blobKey, blobCopy)
+      await this.adapter.save(commitKey, commitCopy)
 
       // Emit event after save
       if (this.listeners["commit-saved"]?.length) {
@@ -300,17 +301,14 @@ export class SubductionStorageBridge implements SedimentreeStorage {
       const fragmentKey = [PREFIX, FRAGMENTS_PREFIX, sid, idHex]
       const blobKey = [PREFIX, FRAGMENT_BLOBS_PREFIX, sid, idHex]
 
-      if (this.adapter.saveBatch) {
-        await this.adapter.saveBatch([
-          [fragmentKey, fragmentCopy],
-          [blobKey, blobCopy],
-        ])
-      } else {
-        await Promise.all([
-          this.adapter.save(fragmentKey, fragmentCopy),
-          this.adapter.save(blobKey, blobCopy),
-        ])
-      }
+      // Write blob first, then fragment metadata. Any crash between
+      // the two yields an orphan blob (harmless) rather than a
+      // fragment pointing at missing data.
+      //
+      // We deliberately don't use adapter.saveBatch here; see the
+      // matching comment in saveCommit for rationale.
+      await this.adapter.save(blobKey, blobCopy)
+      await this.adapter.save(fragmentKey, fragmentCopy)
 
       // Emit event after save
       if (this.listeners["fragment-saved"]?.length) {
@@ -410,14 +408,20 @@ export class SubductionStorageBridge implements SedimentreeStorage {
   // ==================== Batch Operations ====================
 
   /**
-   * Save a batch of commits and fragments in a single IDB transaction.
+   * Save a batch of commits and fragments.
    *
    * Called from Subduction's Wasm `save_batch` during sync ingestion.
-   * Instead of N individual `saveCommit`/`saveFragment` calls (each creating
-   * its own IDB readwrite transaction), this collects all key-value pairs
-   * and writes them in one `adapter.saveBatch()` call.
+   * Instead of N individual `saveCommit`/`saveFragment` calls (each
+   * creating its own underlying transaction), this issues at most three
+   * `adapter.saveBatch()` calls (blobs, metadata, sedimentree ID marker)
+   * in order.
    *
-   * For 50 commits this reduces ~100 IDB transactions to 1.
+   * The three-phase structure enforces write-ahead ordering so that any
+   * crash-prefix state is consistent: orphan blobs (harmless), or blobs
+   * + metadata without the ID marker (invisible to enumeration).
+   *
+   * For 50 commits this reduces ~100 round-trips to 3 on adapters that
+   * implement `adapter.saveBatch`.
    */
   async saveBatchAll(
     sedimentreeId: SedimentreeId,
@@ -433,12 +437,33 @@ export class SubductionStorageBridge implements SedimentreeStorage {
     }>
   ): Promise<number> {
     const sid = sedimentreeId.toString()
-    const entries: Array<[string[], Uint8Array]> = []
 
-    // Sedimentree ID marker
-    entries.push([[PREFIX, IDS_PREFIX, sid], ID_MARKER])
+    // Write-ahead ordering: collect entries in three groups that must
+    // be written in order so any crash-prefix state is consistent.
+    //
+    //   1. All blobs (commit blobs and fragment blobs). Orphan blobs
+    //      without their metadata are skipped silently by loadAll* and
+    //      are harmless on-disk garbage.
+    //   2. All metadata (signed commits and signed fragments). By the
+    //      time any of this is visible, every blob it references is
+    //      already durable.
+    //   3. The sedimentree ID marker. This makes the sedimentree
+    //      enumerable via loadAllSedimentreeIds only once its data is
+    //      durable; a crash before this point leaves invisible-but-
+    //      otherwise-consistent state that the next run will ignore.
+    //
+    // We enforce the ordering at the `await` boundary between phases
+    // rather than relying on in-batch entry order. An `adapter.saveBatch`
+    // call may internally parallelise entries (e.g. NodeFS), so stuffing
+    // all three phases into one saveBatch call doesn't preserve the
+    // invariant on crash. Three sequential saveBatch calls preserve the
+    // invariant for any adapter whose single saveBatch is "atomic per
+    // entry and durable before returning" — a much weaker contract than
+    // full cross-entry transactionality, which IDB happens to satisfy
+    // but NodeFS does not.
+    const blobEntries: Array<[string[], Uint8Array]> = []
+    const metaEntries: Array<[string[], Uint8Array]> = []
 
-    // Collect all commit key-value pairs
     for (const { commitId, signedCommit, blob } of commits) {
       const idHex = commitId.toHexString()
       const commitBytes = signedCommit.encode()
@@ -446,31 +471,49 @@ export class SubductionStorageBridge implements SedimentreeStorage {
       const commitCopy = new Uint8Array(commitBytes)
       const blobCopy = new Uint8Array(blob)
 
-      entries.push([[PREFIX, COMMITS_PREFIX, sid, idHex], commitCopy])
-      entries.push([[PREFIX, BLOBS_PREFIX, sid, idHex], blobCopy])
+      blobEntries.push([[PREFIX, BLOBS_PREFIX, sid, idHex], blobCopy])
+      metaEntries.push([[PREFIX, COMMITS_PREFIX, sid, idHex], commitCopy])
     }
 
-    // Collect all fragment key-value pairs
     for (const { fragmentHead, signedFragment, blob } of fragments) {
       const idHex = fragmentHead.toHexString()
       const fragBytes = signedFragment.encode()
       const fragCopy = new Uint8Array(fragBytes)
       const blobCopy = new Uint8Array(blob)
 
-      entries.push([[PREFIX, FRAGMENTS_PREFIX, sid, idHex], fragCopy])
-      entries.push([[PREFIX, FRAGMENT_BLOBS_PREFIX, sid, idHex], blobCopy])
+      blobEntries.push([[PREFIX, FRAGMENT_BLOBS_PREFIX, sid, idHex], blobCopy])
+      metaEntries.push([[PREFIX, FRAGMENTS_PREFIX, sid, idHex], fragCopy])
     }
 
-    // Single IDB transaction for all entries
+    const markerEntry: [string[], Uint8Array] = [
+      [PREFIX, IDS_PREFIX, sid],
+      ID_MARKER,
+    ]
+
     this.pendingSaves++
     try {
       if (this.adapter.saveBatch) {
-        await this.adapter.saveBatch(entries)
+        // Three sequential saveBatch calls. Each phase is parallelised
+        // inside the adapter (fast); the `await` boundary between phases
+        // enforces the write-ahead ordering (correct under crash).
+        if (blobEntries.length > 0) {
+          await this.adapter.saveBatch(blobEntries)
+        }
+        if (metaEntries.length > 0) {
+          await this.adapter.saveBatch(metaEntries)
+        }
+        await this.adapter.saveBatch([markerEntry])
       } else {
-        // Fallback: parallel individual saves (still better than sequential)
+        // Fallback: three sequential phases, parallel within each phase.
+        // A crash between phases leaves a consistent prefix (orphan
+        // blobs, or blobs+metadata without marker).
         await Promise.all(
-          entries.map(([key, data]) => this.adapter.save(key, data))
+          blobEntries.map(([key, data]) => this.adapter.save(key, data))
         )
+        await Promise.all(
+          metaEntries.map(([key, data]) => this.adapter.save(key, data))
+        )
+        await this.adapter.save(markerEntry[0], markerEntry[1])
       }
 
       // Emit events after successful save

--- a/packages/automerge-repo/src/subduction/storage.ts
+++ b/packages/automerge-repo/src/subduction/storage.ts
@@ -409,8 +409,8 @@ export class SubductionStorageBridge implements SedimentreeStorage {
    * crash-prefix state is consistent: orphan blobs (harmless), or blobs
    * + metadata without the ID marker (invisible to enumeration).
    *
-   * For 50 commits this reduces ~100 round-trips to 3 on adapters that
-   * implement `adapter.saveBatch`.
+   * For 50 commits this reduces ~100 round-trips to 3 on adapters
+   * that override the default `saveBatch` with a native batch path.
    */
   async saveBatchAll(
     sedimentreeId: SedimentreeId,

--- a/packages/automerge-repo/src/subduction/storage.ts
+++ b/packages/automerge-repo/src/subduction/storage.ts
@@ -172,18 +172,10 @@ export class SubductionStorageBridge implements SedimentreeStorage {
       const commitKey = [PREFIX, COMMITS_PREFIX, sid, idHex]
       const blobKey = [PREFIX, BLOBS_PREFIX, sid, idHex]
 
-      // Write blob first, then commit metadata. Any crash between the
-      // two yields an orphan blob (harmless, skipped by the reader)
-      // rather than a commit pointing at a missing blob.
-      //
-      // We deliberately don't use adapter.saveBatch here even when
-      // available: saveBatch's contract guarantees each entry lands
-      // atomically, but an implementation that executes entries in
-      // parallel (e.g. NodeFS) could still produce commit-without-blob
-      // on crash. Two sequential save() calls cost one extra `await`
-      // boundary and are unambiguously crash-consistent.
-      await this.adapter.save(blobKey, blobCopy)
-      await this.adapter.save(commitKey, commitCopy)
+      await this.adapter.saveBatch([
+        [blobKey, blobCopy],
+        [commitKey, commitCopy],
+      ])
 
       // Emit event after save
       if (this.listeners["commit-saved"]?.length) {
@@ -301,14 +293,11 @@ export class SubductionStorageBridge implements SedimentreeStorage {
       const fragmentKey = [PREFIX, FRAGMENTS_PREFIX, sid, idHex]
       const blobKey = [PREFIX, FRAGMENT_BLOBS_PREFIX, sid, idHex]
 
-      // Write blob first, then fragment metadata. Any crash between
-      // the two yields an orphan blob (harmless) rather than a
-      // fragment pointing at missing data.
-      //
-      // We deliberately don't use adapter.saveBatch here; see the
-      // matching comment in saveCommit for rationale.
-      await this.adapter.save(blobKey, blobCopy)
-      await this.adapter.save(fragmentKey, fragmentCopy)
+      // See the matching comment in saveCommit for rationale.
+      await this.adapter.saveBatch([
+        [blobKey, blobCopy],
+        [fragmentKey, fragmentCopy],
+      ])
 
       // Emit event after save
       if (this.listeners["fragment-saved"]?.length) {
@@ -475,29 +464,13 @@ export class SubductionStorageBridge implements SedimentreeStorage {
 
     this.pendingSaves++
     try {
-      if (this.adapter.saveBatch) {
-        // Three sequential saveBatch calls. Each phase is parallelised
-        // inside the adapter (fast); the `await` boundary between phases
-        // enforces the write-ahead ordering (correct under crash).
-        if (blobEntries.length > 0) {
-          await this.adapter.saveBatch(blobEntries)
-        }
-        if (metaEntries.length > 0) {
-          await this.adapter.saveBatch(metaEntries)
-        }
-        await this.adapter.saveBatch([markerEntry])
-      } else {
-        // Fallback: three sequential phases, parallel within each phase.
-        // A crash between phases leaves a consistent prefix (orphan
-        // blobs, or blobs+metadata without marker).
-        await Promise.all(
-          blobEntries.map(([key, data]) => this.adapter.save(key, data))
-        )
-        await Promise.all(
-          metaEntries.map(([key, data]) => this.adapter.save(key, data))
-        )
-        await this.adapter.save(markerEntry[0], markerEntry[1])
+      if (blobEntries.length > 0) {
+        await this.adapter.saveBatch(blobEntries)
       }
+      if (metaEntries.length > 0) {
+        await this.adapter.saveBatch(metaEntries)
+      }
+      await this.adapter.saveBatch([markerEntry])
 
       if (this.listeners["commit-saved"]?.length) {
         commits.forEach(({ commitId }, i) => {

--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -353,6 +353,9 @@ describe("StorageSubsystem", () => {
       async removeRange(keyPrefix: StorageKey) {
         return this.#inner.removeRange(keyPrefix)
       }
+      async saveBatch(entries: Array<[StorageKey, Uint8Array]>) {
+        return this.#inner.saveBatch(entries)
+      }
       keys() {
         return this.#inner.keys()
       }
@@ -451,6 +454,9 @@ describe("StorageSubsystem", () => {
         }
         async removeRange(keyPrefix: StorageKey) {
           return this.#inner.removeRange(keyPrefix)
+        }
+        async saveBatch(entries: Array<[StorageKey, Uint8Array]>) {
+          return this.#inner.saveBatch(entries)
         }
       }
 


### PR DESCRIPTION
This PR:

1. Adds a `saveBatch` to the storage interface to provide better semantic guarantees and speed up many backends (e.g. IDB)
2. changes the write order of storage in the Subduction bridge so that it provides better guarantees on failure and leads to fewer torn writes. This depends on changes in #600.

Writing blobs before metadata means that for backends that can observe partial failure, Subduction will only pick up on a value _if_ the metadata exists. At this stage, we may orphan failed writes. We can come back and clean them up later but at least naively it requires checking for bad data on lookup which slows things down.

We may still end up with partial failure, but the windows for that are MUCH narrower thanks to the 2-phase "stage each, then quickly `rename(2)` all and `fsync`" strategy.