### PR TITLE
add refFromObject function which constructs a Ref from a doc sub-object

### DIFF
--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -122,7 +122,13 @@ export type {
   RefUrl,
   ChangeFn as RefChangeFn,
 } from "./refs/types.js"
-export { cursor, findRef, refFromUrl, refFromString } from "./refs/utils.js"
+export {
+  cursor,
+  findRef,
+  refFromUrl,
+  refFromString,
+  refFromObject,
+} from "./refs/utils.js"
 
 // Automerge re-exports
 //

--- a/packages/automerge-repo/src/refs/index.ts
+++ b/packages/automerge-repo/src/refs/index.ts
@@ -8,4 +8,10 @@ export type {
   Ref,
 } from "./types.js"
 
-export { cursor, findRef, refFromUrl, refFromString } from "./utils.js"
+export {
+  cursor,
+  findRef,
+  refFromUrl,
+  refFromString,
+  refFromObject,
+} from "./utils.js"

--- a/packages/automerge-repo/src/refs/utils.ts
+++ b/packages/automerge-repo/src/refs/utils.ts
@@ -16,8 +16,6 @@ import { CURSOR_MARKER } from "./types.js"
 import { RefImpl } from "./ref.js"
 import { parseRefUrl } from "./parser.js"
 
-const AUTOMERGE_STATE = Symbol.for("_am_meta")
-
 /**
  * Create a cursor-based range segment for stable text selection.
  *
@@ -138,8 +136,9 @@ export async function findRef<TValue = unknown>(
  * ref.change(f => { f.x = 42 })
  * ```
  *
- * Works both on the materialized document returned by `handle.doc()` and on
- * the live proxy passed into `handle.change(d => ...)` callbacks.
+ * Works on the materialized document returned by `handle.doc()`, the live
+ * proxy passed into `handle.change(d => ...)` callbacks, and objects read
+ * from any view of the same document.
  *
  * Limitations:
  * - The value must be a map or list sub-object of the document. Primitives
@@ -150,12 +149,14 @@ export async function findRef<TValue = unknown>(
  * - Array element refs are position-based, just like `handle.ref('list', 0)`.
  *   If you need stability across concurrent inserts, build a pattern ref
  *   instead: `handle.ref('list', { id })`.
- * - The object must belong to the same document as the provided handle.
+ * - The object must exist in the current state of `handle`'s document.
+ *   Objects from a different document, or objects that have been deleted,
+ *   will throw.
  *
  * @experimental This API is experimental and may change in future versions.
  *
  * @throws Error if `value` is not an Automerge map or list sub-object.
- * @throws Error if the object does not belong to `handle`'s document.
+ * @throws Error if the object does not exist in `handle`'s current document.
  */
 export function refFromObject<TValue = unknown>(
   handle: DocHandle<any>,
@@ -179,16 +180,13 @@ export function refFromObject<TValue = unknown>(
     )
   }
 
-  const doc = handle.doc()
-  const docBackend = Automerge.getBackend(doc)
+  // Object IDs are stable across clones and history, so an object looked up
+  // from a view (or any past state) of the same document will still resolve
+  // against the current backend. We only care whether the object exists in
+  // the current document and is still reachable.
+  const docBackend = Automerge.getBackend(handle.doc())
 
   if (objectId === "_root") {
-    const stateBackend = (value as any)[AUTOMERGE_STATE]?.handle
-    if (stateBackend && stateBackend !== docBackend) {
-      throw new Error(
-        "refFromObject: object belongs to a different document or view"
-      )
-    }
     return new RefImpl(handle, [] as unknown as AnyPathInput[]) as Ref<TValue>
   }
 
@@ -198,14 +196,15 @@ export function refFromObject<TValue = unknown>(
   } catch (err) {
     throw new Error(
       "refFromObject: object is not present in the current document. " +
-        "It may belong to a different document or a stale view. " +
+        "It may belong to a different document. " +
         `(underlying error: ${(err as Error).message})`
     )
   }
 
   if (!info.path) {
     throw new Error(
-      `refFromObject: Automerge did not return a path for object ${objectId}`
+      `refFromObject: object ${objectId} has no path in the current ` +
+        "document. It may have been deleted."
     )
   }
 

--- a/packages/automerge-repo/src/refs/utils.ts
+++ b/packages/automerge-repo/src/refs/utils.ts
@@ -1,3 +1,4 @@
+import * as Automerge from "@automerge/automerge/slim"
 import type { DocHandle } from "../DocHandle.js"
 import type { Repo } from "../Repo.js"
 import { encodeHeads } from "../AutomergeUrl.js"
@@ -9,10 +10,13 @@ import type {
   SegmentsFromString,
   Ref,
   InferRefTypeFromString,
+  AnyPathInput,
 } from "./types.js"
 import { CURSOR_MARKER } from "./types.js"
 import { RefImpl } from "./ref.js"
 import { parseRefUrl } from "./parser.js"
+
+const AUTOMERGE_STATE = Symbol.for("_am_meta")
 
 /**
  * Create a cursor-based range segment for stable text selection.
@@ -117,6 +121,98 @@ export async function findRef<TValue = unknown>(
   await handle.whenReady()
 
   return refFromUrl<TValue>(handle, url)
+}
+
+/**
+ * Create a ref from a sub-object of an Automerge document.
+ *
+ * This lets you take a value read out of the document (a map or list) and
+ * recover a {@link Ref} pointing at that location, without having to know or
+ * re-construct the path by hand.
+ *
+ * ```ts
+ * const doc = handle.doc()
+ * const foo = doc.bar.foo
+ * const ref = refFromObject(handle, foo)
+ * ref.value()          // same object
+ * ref.change(f => { f.x = 42 })
+ * ```
+ *
+ * Works both on the materialized document returned by `handle.doc()` and on
+ * the live proxy passed into `handle.change(d => ...)` callbacks.
+ *
+ * Limitations:
+ * - The value must be a map or list sub-object of the document. Primitives
+ *   (numbers, booleans), text strings, {@link Counter}s,
+ *   {@link ImmutableString}s, and {@link Date} values do not carry path
+ *   information and cannot be used. For those, use `handle.ref(...)` or
+ *   {@link refFromString} with an explicit path.
+ * - Array element refs are position-based, just like `handle.ref('list', 0)`.
+ *   If you need stability across concurrent inserts, build a pattern ref
+ *   instead: `handle.ref('list', { id })`.
+ * - The object must belong to the same document as the provided handle.
+ *
+ * @experimental This API is experimental and may change in future versions.
+ *
+ * @throws Error if `value` is not an Automerge map or list sub-object.
+ * @throws Error if the object does not belong to `handle`'s document.
+ */
+export function refFromObject<TValue = unknown>(
+  handle: DocHandle<any>,
+  value: TValue
+): Ref<TValue> {
+  if (value === null || typeof value !== "object") {
+    throw new Error(
+      "refFromObject: value is not an Automerge document sub-object. " +
+        "Primitives, text strings, Counter, ImmutableString, and Date " +
+        "values do not carry path information. " +
+        "Use handle.ref(...) with an explicit path instead."
+    )
+  }
+
+  const objectId = Automerge.getObjectId(value as any) as string | null
+  if (objectId == null) {
+    throw new Error(
+      "refFromObject: value is not an Automerge document sub-object. " +
+        "Only map and list sub-objects of a doc are supported. " +
+        "Use handle.ref(...) with an explicit path instead."
+    )
+  }
+
+  const doc = handle.doc()
+  const docBackend = Automerge.getBackend(doc)
+
+  if (objectId === "_root") {
+    const stateBackend = (value as any)[AUTOMERGE_STATE]?.handle
+    if (stateBackend && stateBackend !== docBackend) {
+      throw new Error(
+        "refFromObject: object belongs to a different document or view"
+      )
+    }
+    return new RefImpl(handle, [] as unknown as AnyPathInput[]) as Ref<TValue>
+  }
+
+  let info: { path?: Automerge.Prop[] }
+  try {
+    info = docBackend.objInfo(objectId)
+  } catch (err) {
+    throw new Error(
+      "refFromObject: object is not present in the current document. " +
+        "It may belong to a different document or a stale view. " +
+        `(underlying error: ${(err as Error).message})`
+    )
+  }
+
+  if (!info.path) {
+    throw new Error(
+      `refFromObject: Automerge did not return a path for object ${objectId}`
+    )
+  }
+
+  return new RefImpl(
+    handle,
+    info.path as unknown as AnyPathInput[]
+  ) as Ref<TValue>
 }
 
 /**

--- a/packages/automerge-repo/src/refs/utils.ts
+++ b/packages/automerge-repo/src/refs/utils.ts
@@ -1,7 +1,7 @@
 import * as Automerge from "@automerge/automerge/slim"
 import type { DocHandle } from "../DocHandle.js"
 import type { Repo } from "../Repo.js"
-import { encodeHeads } from "../AutomergeUrl.js"
+import { decodeHeads, encodeHeads } from "../AutomergeUrl.js"
 import type { Heads } from "@automerge/automerge/slim"
 import type {
   Pattern,
@@ -182,29 +182,35 @@ export function refFromObject<TValue = unknown>(
 
   // Object IDs are stable across clones and history, so an object looked up
   // from a view (or any past state) of the same document will still resolve
-  // against the current backend. We only care whether the object exists in
-  // the current document and is still reachable.
+  // against the current backend. We only care whether the object exists at
+  // the handle's heads and is reachable from root there.
   const docBackend = Automerge.getBackend(handle.doc())
 
   if (objectId === "_root") {
     return new RefImpl(handle, [] as unknown as AnyPathInput[]) as Ref<TValue>
   }
 
+  // Look up the path at the handle's heads so the ref's path is consistent
+  // with what `ref.value()` will read through `handle.doc()`. For a live
+  // handle this is the current heads; for a view handle it's the fixed heads.
+  const heads = decodeHeads(handle.heads())
+
   let info: { path?: Automerge.Prop[] }
   try {
-    info = docBackend.objInfo(objectId)
+    info = docBackend.objInfo(objectId, heads)
   } catch (err) {
     throw new Error(
-      "refFromObject: object is not present in the current document. " +
-        "It may belong to a different document. " +
+      "refFromObject: object is not present in the document at the " +
+        "handle's heads. It may belong to a different document or did " +
+        "not exist yet at those heads. " +
         `(underlying error: ${(err as Error).message})`
     )
   }
 
   if (!info.path) {
     throw new Error(
-      `refFromObject: object ${objectId} has no path in the current ` +
-        "document. It may have been deleted."
+      `refFromObject: object ${objectId} has no path in the document at ` +
+        "the handle's heads. It may have been deleted."
     )
   }
 

--- a/packages/automerge-repo/test/refs/utils.test.ts
+++ b/packages/automerge-repo/test/refs/utils.test.ts
@@ -418,6 +418,68 @@ describe("utils", () => {
       expect(nestedRef.path.map(s => s.prop)).toEqual(["nested"])
     })
 
+    it("should resolve an object from a view against the live handle", () => {
+      // Object IDs are stable across history. Passing an object read from a
+      // view of the same doc to the live handle should work fine and produce
+      // a ref on the live handle.
+      handle.change((d: any) => {
+        d.nested = { value: "v1" }
+      })
+
+      const heads1 = Automerge.getHeads(handle.doc() as any)
+      const encodedHeads1 = encodeHeads(heads1)
+
+      handle.change((d: any) => {
+        d.nested.value = "v2"
+      })
+
+      const viewHandle = handle.view(encodedHeads1)
+      const nestedFromView = (viewHandle.doc() as any).nested
+
+      const liveRef = refFromObject(handle, nestedFromView)
+      expect(liveRef.path.map(s => s.prop)).toEqual(["nested"])
+      // Points at the live doc, so value reflects the latest state.
+      expect(liveRef.value()).toEqual({ value: "v2" })
+      expect(liveRef.docHandle).toBe(handle)
+    })
+
+    it("should resolve a root from a view against the live handle", () => {
+      handle.change((d: any) => {
+        d.value = 42
+      })
+
+      const heads1 = Automerge.getHeads(handle.doc() as any)
+      const viewHandle = handle.view(encodeHeads(heads1))
+      const viewDoc = viewHandle.doc()
+
+      handle.change((d: any) => {
+        d.value = 100
+      })
+
+      const rootRef = refFromObject(handle, viewDoc)
+      expect(rootRef.path).toEqual([])
+      expect(rootRef.value()).toEqual({ value: 100 })
+    })
+
+    it("should throw when the object has been deleted from the current doc", () => {
+      handle.change((d: any) => {
+        d.thing = { v: 1 }
+      })
+
+      const heads1 = Automerge.getHeads(handle.doc() as any)
+      const viewHandle = handle.view(encodeHeads(heads1))
+      const thingFromView = (viewHandle.doc() as any).thing
+
+      handle.change((d: any) => {
+        delete d.thing
+      })
+
+      // Object exists in the view but has no reachable path in the live doc.
+      expect(() => refFromObject(handle, thingFromView)).toThrow(
+        /no path in the current document|deleted/
+      )
+    })
+
     it("should be reactive via onChange", () => {
       handle.change((d: any) => {
         d.user = { name: "Alice", age: 30 }

--- a/packages/automerge-repo/test/refs/utils.test.ts
+++ b/packages/automerge-repo/test/refs/utils.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest"
 import * as Automerge from "@automerge/automerge"
 import { Repo } from "../../src/Repo.js"
 import type { DocHandle } from "../../src/DocHandle.js"
-import { cursor, findRef } from "../../src/refs/utils.js"
+import { cursor, findRef, refFromObject } from "../../src/refs/utils.js"
 import { encodeHeads } from "../../src/AutomergeUrl.js"
 import type { RefUrl } from "../../src/refs/types.js"
 import { CURSOR_MARKER } from "../../src/refs/types.js"
@@ -220,6 +220,277 @@ describe("utils", () => {
 
       const foundRef = await findRef(repo, url)
       expect(foundRef.value()).toEqual({ value: 42 })
+    })
+  })
+
+  describe("refFromObject", () => {
+    let repo: Repo
+    let handle: DocHandle<any>
+
+    beforeEach(() => {
+      repo = new Repo()
+      handle = repo.create()
+    })
+
+    it("should create a ref from a map value", () => {
+      handle.change((d: any) => {
+        d.user = { name: "Alice", age: 30 }
+      })
+
+      const doc = handle.doc() as any
+      const userRef = refFromObject<{ name: string; age: number }>(
+        handle,
+        doc.user
+      )
+
+      expect(userRef.value()).toEqual({ name: "Alice", age: 30 })
+      expect(userRef.path.map(s => s.prop)).toEqual(["user"])
+    })
+
+    it("should create a ref from a nested map value", () => {
+      handle.change((d: any) => {
+        d.app = { settings: { theme: { color: "blue" } } }
+      })
+
+      const doc = handle.doc() as any
+      const themeRef = refFromObject(handle, doc.app.settings.theme)
+
+      expect(themeRef.value()).toEqual({ color: "blue" })
+      expect(themeRef.path.map(s => s.prop)).toEqual([
+        "app",
+        "settings",
+        "theme",
+      ])
+    })
+
+    it("should create a ref from a list value", () => {
+      handle.change((d: any) => {
+        d.items = [
+          { title: "First", done: false },
+          { title: "Second", done: true },
+        ]
+      })
+
+      const doc = handle.doc() as any
+      const itemsRef = refFromObject(handle, doc.items)
+
+      expect(itemsRef.value()).toEqual([
+        { title: "First", done: false },
+        { title: "Second", done: true },
+      ])
+      expect(itemsRef.path.map(s => s.prop)).toEqual(["items"])
+    })
+
+    it("should create a ref from an array element", () => {
+      handle.change((d: any) => {
+        d.todos = [
+          { title: "First", done: false },
+          { title: "Second", done: true },
+        ]
+      })
+
+      const doc = handle.doc() as any
+      const firstTodoRef = refFromObject(handle, doc.todos[0])
+
+      expect(firstTodoRef.value()).toEqual({ title: "First", done: false })
+      expect(firstTodoRef.path.map(s => s.prop)).toEqual(["todos", 0])
+    })
+
+    it("should return a ref to the root when given the doc itself", () => {
+      handle.change((d: any) => {
+        d.value = 42
+      })
+
+      const doc = handle.doc() as any
+      const rootRef = refFromObject(handle, doc)
+
+      expect(rootRef.path).toEqual([])
+      expect(rootRef.value()).toEqual({ value: 42 })
+    })
+
+    it("should produce refs whose change() mutates the document", () => {
+      handle.change((d: any) => {
+        d.user = { name: "Alice", age: 30 }
+      })
+
+      const userRef = refFromObject<{ name: string; age: number }>(
+        handle,
+        (handle.doc() as any).user
+      )
+
+      userRef.change(user => {
+        user.age = 31
+      })
+
+      expect((handle.doc() as any).user).toEqual({ name: "Alice", age: 31 })
+    })
+
+    it("should produce refs that are equivalent to handle.ref()", () => {
+      handle.change((d: any) => {
+        d.todos = [{ title: "First" }, { title: "Second" }]
+      })
+
+      const doc = handle.doc() as any
+      const fromObject = refFromObject(handle, doc.todos[1])
+      const fromPath = handle.ref("todos", 1)
+
+      expect(fromObject.url).toBe(fromPath.url)
+      expect(fromObject.isEquivalent(fromPath)).toBe(true)
+    })
+
+    it("should throw when called on a primitive", () => {
+      handle.change((d: any) => {
+        d.count = 42
+        d.flag = true
+      })
+
+      const doc = handle.doc() as any
+
+      expect(() => refFromObject(handle, doc.count)).toThrow(
+        /not an Automerge document sub-object/
+      )
+      expect(() => refFromObject(handle, doc.flag)).toThrow(
+        /not an Automerge document sub-object/
+      )
+      expect(() => refFromObject(handle, null)).toThrow(
+        /not an Automerge document sub-object/
+      )
+      expect(() => refFromObject(handle, undefined)).toThrow(
+        /not an Automerge document sub-object/
+      )
+    })
+
+    it("should throw when called on a text string value", () => {
+      handle.change((d: any) => {
+        d.note = "hello world"
+      })
+
+      const doc = handle.doc() as any
+      expect(() => refFromObject(handle, doc.note)).toThrow(
+        /not an Automerge document sub-object/
+      )
+    })
+
+    it("should throw when called on a plain object not attached to a doc", () => {
+      expect(() => refFromObject(handle, { a: 1, b: 2 })).toThrow(
+        /not an Automerge document sub-object/
+      )
+      expect(() => refFromObject(handle, [1, 2, 3])).toThrow(
+        /not an Automerge document sub-object/
+      )
+    })
+
+    it("should throw when the value belongs to a different document", () => {
+      handle.change((d: any) => {
+        d.user = { name: "Alice" }
+      })
+
+      const otherHandle = repo.create()
+      otherHandle.change((d: any) => {
+        d.user = { name: "Bob" }
+      })
+
+      const otherDoc = otherHandle.doc() as any
+      expect(() => refFromObject(handle, otherDoc.user)).toThrow(
+        /not present in the current document|different document/
+      )
+    })
+
+    it("should work with objects returned by handle.view()", () => {
+      handle.change((d: any) => {
+        d.counter = 1
+        d.nested = { value: "v1" }
+      })
+
+      const heads1 = Automerge.getHeads(handle.doc() as any)
+      const encodedHeads1 = encodeHeads(heads1)
+
+      handle.change((d: any) => {
+        d.counter = 2
+        d.nested.value = "v2"
+      })
+
+      const viewHandle = handle.view(encodedHeads1)
+      const viewDoc = viewHandle.doc() as any
+      const nestedRef = refFromObject(viewHandle, viewDoc.nested)
+
+      expect(nestedRef.value()).toEqual({ value: "v1" })
+      expect(nestedRef.path.map(s => s.prop)).toEqual(["nested"])
+    })
+
+    it("should be reactive via onChange", () => {
+      handle.change((d: any) => {
+        d.user = { name: "Alice", age: 30 }
+      })
+
+      const userRef = refFromObject<{ name: string; age: number }>(
+        handle,
+        (handle.doc() as any).user
+      )
+
+      const updates: any[] = []
+      const unsubscribe = userRef.onChange(value => {
+        updates.push(value)
+      })
+
+      handle.change((d: any) => {
+        d.user.age = 31
+      })
+
+      expect(updates).toEqual([{ name: "Alice", age: 31 }])
+
+      unsubscribe()
+    })
+
+    it("should preserve identity with other refs to the same path", () => {
+      handle.change((d: any) => {
+        d.items = [{ v: 1 }, { v: 2 }]
+      })
+
+      const doc = handle.doc() as any
+      const objectRef = refFromObject(handle, doc.items[0])
+      const pathRef = handle.ref("items", 0)
+
+      // Different Ref instances (refFromObject does not go through the cache),
+      // but they must be equivalent.
+      expect(objectRef.equals(pathRef)).toBe(true)
+      expect(objectRef.isEquivalent(pathRef)).toBe(true)
+    })
+
+    it("should work with the live proxy inside a change() callback", () => {
+      handle.change((d: any) => {
+        d.user = { name: "Alice" }
+      })
+
+      let capturedPath: (string | number | undefined)[] = []
+      handle.change((d: any) => {
+        const ref = refFromObject(handle, d.user)
+        capturedPath = ref.path.map(s => s.prop)
+      })
+
+      expect(capturedPath).toEqual(["user"])
+    })
+
+    it("should track the object across a reorder when using index paths", () => {
+      handle.change((d: any) => {
+        d.todos = [
+          { id: "a", title: "First" },
+          { id: "b", title: "Second" },
+        ]
+      })
+
+      const doc = handle.doc() as any
+      const ref = refFromObject(handle, doc.todos[1])
+      expect(ref.path.map(s => s.prop)).toEqual(["todos", 1])
+
+      // An insert at the front shifts index 1 to index 2. Since refFromObject
+      // produced an index-based path, ref.value() now points at a different
+      // logical item. This is documented/expected behaviour.
+      handle.change((d: any) => {
+        d.todos.insertAt(0, { id: "z", title: "Zeroth" })
+      })
+
+      expect(ref.value()).toEqual({ id: "a", title: "First" })
     })
   })
 })

--- a/packages/automerge-repo/test/refs/utils.test.ts
+++ b/packages/automerge-repo/test/refs/utils.test.ts
@@ -392,7 +392,7 @@ describe("utils", () => {
 
       const otherDoc = otherHandle.doc() as any
       expect(() => refFromObject(handle, otherDoc.user)).toThrow(
-        /not present in the current document|different document/
+        /not present in the document|different document/
       )
     })
 
@@ -461,6 +461,38 @@ describe("utils", () => {
       expect(rootRef.value()).toEqual({ value: 100 })
     })
 
+    it("should return the path at the handle's heads, not the object's source", () => {
+      // A list element's path (index) can change across heads. The ref we
+      // build must use the path as of the handle we bind to, regardless of
+      // which doc state the input object was read from.
+      handle.change((d: any) => {
+        d.items = [{ v: 1 }]
+      })
+      const heads1 = Automerge.getHeads(handle.doc() as any)
+
+      handle.change((d: any) => {
+        d.items.unshift({ v: 0 })
+      })
+
+      // At heads1 the object lives at items[0]; now it lives at items[1].
+      const liveItem = (handle.doc() as any).items[1]
+      const liveRef = refFromObject(handle, liveItem)
+      expect(liveRef.path.map(s => s.prop)).toEqual(["items", 1])
+      expect(liveRef.value()).toEqual({ v: 1 })
+
+      const viewHandle = handle.view(encodeHeads(heads1))
+      const viewItem = (viewHandle.doc() as any).items[0]
+      const viewRef = refFromObject(viewHandle, viewItem)
+      expect(viewRef.path.map(s => s.prop)).toEqual(["items", 0])
+      expect(viewRef.value()).toEqual({ v: 1 })
+
+      // Same object read from a view, but bound to the live handle: we
+      // should get the live path, not the view path.
+      const liveRefFromViewObj = refFromObject(handle, viewItem)
+      expect(liveRefFromViewObj.path.map(s => s.prop)).toEqual(["items", 1])
+      expect(liveRefFromViewObj.docHandle).toBe(handle)
+    })
+
     it("should throw when the object has been deleted from the current doc", () => {
       handle.change((d: any) => {
         d.thing = { v: 1 }
@@ -476,7 +508,7 @@ describe("utils", () => {
 
       // Object exists in the view but has no reachable path in the live doc.
       expect(() => refFromObject(handle, thingFromView)).toThrow(
-        /no path in the current document|deleted/
+        /no path|deleted/
       )
     })
 


### PR DESCRIPTION
```ts
/**
 * Create a ref from a sub-object of an Automerge document.
 *
 * This lets you take a value read out of the document (a map or list) and
 * recover a {@link Ref} pointing at that location, without having to know or
 * re-construct the path by hand.
 *
 * ```ts
 * const doc = handle.doc()
 * const foo = doc.bar.foo
 * const ref = refFromObject(handle, foo)
 * ref.value()          // same object
 * ref.change(f => { f.x = 42 })
 * ```
 *
 * Works both on the materialized document returned by `handle.doc()` and on
 * the live proxy passed into `handle.change(d => ...)` callbacks.
 *
 * Limitations:
 * - The value must be a map or list sub-object of the document. Primitives
 *   (numbers, booleans), text strings, {@link Counter}s,
 *   {@link ImmutableString}s, and {@link Date} values do not carry path
 *   information and cannot be used. For those, use `handle.ref(...)` or
 *   {@link refFromString} with an explicit path.
 * - Array element refs are position-based, just like `handle.ref('list', 0)`.
 *   If you need stability across concurrent inserts, build a pattern ref
 *   instead: `handle.ref('list', { id })`.
 * - The object must belong to the same document as the provided handle.
 *
 * @experimental This API is experimental and may change in future versions.
 *
 * @throws Error if `value` is not an Automerge map or list sub-object.
 * @throws Error if the object does not belong to `handle`'s document.
 */
 function refFromObject<TValue = unknown>(
  handle: DocHandle<any>,
  value: TValue
): Ref<TValue>
```