### PR TITLE
Add asyncThrottle() to prevent races, strengthen abortable() and add consts to keep code DRY 

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -19,7 +19,7 @@ import {
 } from "./DocHandle.js"
 import { RemoteHeadsSubscriptions } from "./RemoteHeadsSubscriptions.js"
 import { headsAreSame } from "./helpers/headsAreSame.js"
-import { throttle } from "./helpers/throttle.js"
+import { asyncThrottle } from "./helpers/throttle.js"
 import {
   NetworkAdapterInterface,
   type PeerMetadata,
@@ -102,7 +102,7 @@ export class Repo extends EventEmitter<RepoEvents> {
   #progressCache: Record<DocumentId, FindProgress<any>> = {}
   #saveFns: Record<
     DocumentId,
-    (payload: DocHandleEncodedChangePayload<any>) => void
+    (payload: DocHandleEncodedChangePayload<any>) => Promise<void>
   > = {}
   #idFactory: ((initialHeads: Heads) => Promise<Uint8Array>) | null
 
@@ -190,13 +190,14 @@ export class Repo extends EventEmitter<RepoEvents> {
       this.#saveFn = ({ handle, doc }: DocHandleEncodedChangePayload<any>) => {
         let fn = this.#saveFns[handle.documentId]
         if (!fn) {
-          fn = throttle(
-            ({ doc, handle }: DocHandleEncodedChangePayload<any>) => {
-              void this.storageSubsystem!.saveDoc(handle.documentId, doc)
-            },
+          fn = this.#saveFns[handle.documentId] = asyncThrottle(
+            ({
+              doc,
+              handle,
+            }: DocHandleEncodedChangePayload<any>): Promise<void> =>
+              this.storageSubsystem!.saveDoc(handle.documentId, doc),
             this.#saveDebounceRate
           )
-          this.#saveFns[handle.documentId] = fn
         }
         fn({ handle, doc })
       }
@@ -364,7 +365,7 @@ export class Repo extends EventEmitter<RepoEvents> {
 
   #throttledSaveSyncStateHandlers: Record<
     StorageId,
-    (payload: SyncStatePayload) => void
+    (payload: SyncStatePayload) => Promise<void>
   > = {}
 
   /** saves sync state throttled per storage id, if a peer doesn't have a storage id it's sync state is not persisted */
@@ -382,14 +383,13 @@ export class Repo extends EventEmitter<RepoEvents> {
 
     let handler = this.#throttledSaveSyncStateHandlers[storageId]
     if (!handler) {
-      handler = this.#throttledSaveSyncStateHandlers[storageId] = throttle(
-        ({ documentId, syncState }: SyncStatePayload) => {
-          void this.storageSubsystem!.saveSyncState(
+      handler = this.#throttledSaveSyncStateHandlers[storageId] = asyncThrottle(
+        ({ documentId, syncState }: SyncStatePayload) =>
+          this.storageSubsystem!.saveSyncState(
             documentId,
             storageId,
             syncState
-          )
-        },
+          ),
         this.#saveDebounceRate
       )
     }

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -45,6 +45,7 @@ import { abortable, AbortOptions, AbortError } from "./helpers/abortable.js"
 import { FindProgress } from "./FindProgress.js"
 import { RefImpl } from "./refs/ref.js"
 import { foreverPromise } from "./helpers/foreverPromise.js"
+import { noop } from "./helpers/noop.js"
 
 export type FindProgressWithMethods<T> = FindProgress<T> & {
   untilReady: (allowableStates: string[]) => Promise<DocHandle<T>>
@@ -203,7 +204,7 @@ export class Repo extends EventEmitter<RepoEvents> {
         fn({ handle, doc })
       }
     } else {
-      this.#saveFn = () => {}
+      this.#saveFn = noop
     }
 
     // NETWORK

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -202,7 +202,7 @@ export class Repo extends EventEmitter<RepoEvents> {
             this.#saveDebounceRate
           )
         }
-        fn({ handle, doc })
+        void fn({ handle, doc })
       }
     } else {
       this.#saveFn = noop
@@ -397,7 +397,7 @@ export class Repo extends EventEmitter<RepoEvents> {
       )
     }
 
-    handler(payload)
+    void handler(payload)
   }
 
   /** Returns an existing handle if we have it; creates one otherwise. */

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -46,6 +46,7 @@ import { FindProgress } from "./FindProgress.js"
 import { RefImpl } from "./refs/ref.js"
 import { foreverPromise } from "./helpers/foreverPromise.js"
 import { noop } from "./helpers/noop.js"
+import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
 
 export type FindProgressWithMethods<T> = FindProgress<T> & {
   untilReady: (allowableStates: string[]) => Promise<DocHandle<T>>
@@ -91,8 +92,8 @@ export class Repo extends EventEmitter<RepoEvents> {
   synchronizer: CollectionSynchronizer
 
   #shareConfig: ShareConfig = {
-    announce: async () => true,
-    access: async () => true,
+    announce: truePromiseFactory,
+    access: truePromiseFactory,
   }
 
   /** maps peer id to to persistence information (storageId, isEphemeral), access by collection synchronizer  */
@@ -132,7 +133,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     if (sharePolicy) {
       this.#shareConfig = {
         announce: sharePolicy,
-        access: async () => true,
+        access: truePromiseFactory,
       }
     }
     if (shareConfig) {

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -44,6 +44,7 @@ import type {
 import { abortable, AbortOptions, AbortError } from "./helpers/abortable.js"
 import { FindProgress } from "./FindProgress.js"
 import { RefImpl } from "./refs/ref.js"
+import { foreverPromise } from "./helpers/foreverPromise.js"
 
 export type FindProgressWithMethods<T> = FindProgress<T> & {
   untilReady: (allowableStates: string[]) => Promise<DocHandle<T>>
@@ -642,7 +643,8 @@ export class Repo extends EventEmitter<RepoEvents> {
       documentId,
       handle,
       progressSignal,
-      signal ? abortable(new Promise(() => {}), signal) : new Promise(() => {})
+      //IMPORTANT: Reuse foreverPromise. Don't keep re-creating promises that never settle like `new Promise(() => {})`
+      signal ? abortable(foreverPromise, signal) : foreverPromise
     )
 
     const result = {

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -645,7 +645,6 @@ export class Repo extends EventEmitter<RepoEvents> {
       documentId,
       handle,
       progressSignal,
-      //IMPORTANT: Reuse foreverPromise. Don't keep re-creating promises that never settle like `new Promise(() => {})`
       signal ? abortable(foreverPromise, signal) : foreverPromise
     )
 

--- a/packages/automerge-repo/src/helpers/abortable.ts
+++ b/packages/automerge-repo/src/helpers/abortable.ts
@@ -38,6 +38,7 @@ export const isAbortErrorLike = (candidate: unknown): boolean => {
  * @remarks
  * This utility wraps a Promise and rejects when the provided AbortSignal is aborted.
  * It's designed to make Promise awaits abortable.
+ * It is unnecessary for async APIs like `fetch()` that support abort already
  *
  * @example
  * ```typescript
@@ -52,6 +53,8 @@ export const isAbortErrorLike = (candidate: unknown): boolean => {
  *   }
  * }
  *
+ * // fetch already supports signal; so abortable() is NOT needed:
+ * const a = await fetch(url, { signal });
  * ```
  *
  * @param p - A Promise to wrap
@@ -64,17 +67,15 @@ export function abortable<T>(
   p: Promise<T>,
   signal: AbortSignal | undefined
 ): Promise<T> {
+  if (signal?.aborted) return Promise.reject(signal.reason)
   let settled = false
   return new Promise((resolve, reject) => {
-    signal?.addEventListener(
-      "abort",
-      () => {
-        if (!settled) {
-          reject(new AbortError())
-        }
-      },
-      { once: true }
-    )
+    const onAbort = () => {
+      if (!settled) {
+        reject(new AbortError())
+      }
+    }
+    signal?.addEventListener("abort", onAbort, { once: true })
     p.then(result => {
       resolve(result)
     })
@@ -83,6 +84,9 @@ export function abortable<T>(
       })
       .finally(() => {
         settled = true
+        //listener is added with `{ once: true }`, but this is not enough if signal never receives abort.
+        //onAbort is noop once settled, but it is important to cleanup because of closure to Promise's reject
+        signal?.removeEventListener("abort", onAbort)
       })
   })
 }

--- a/packages/automerge-repo/src/helpers/falsePromiseFactory.ts
+++ b/packages/automerge-repo/src/helpers/falsePromiseFactory.ts
@@ -1,0 +1,3 @@
+/* c8 ignore start */
+export const falsePromiseFactory = async () => false
+/* c8 ignore end */

--- a/packages/automerge-repo/src/helpers/foreverPromise.ts
+++ b/packages/automerge-repo/src/helpers/foreverPromise.ts
@@ -1,0 +1,6 @@
+/* c8 ignore start */
+/**
+ * A promise that never settles
+ */
+export const foreverPromise = new Promise<never>(() => {})
+/* c8 ignore end */

--- a/packages/automerge-repo/src/helpers/noop.ts
+++ b/packages/automerge-repo/src/helpers/noop.ts
@@ -1,0 +1,3 @@
+/* c8 ignore start */
+export const noop = (): void => {}
+/* c8 ignore end */

--- a/packages/automerge-repo/src/helpers/pause.ts
+++ b/packages/automerge-repo/src/helpers/pause.ts
@@ -1,6 +1,72 @@
 /* c8 ignore start */
+import { AbortError } from "./abortable.js"
 
-export const pause = (t = 0) =>
-  new Promise<void>(resolve => setTimeout(() => resolve(), t))
+type AbortListener = (
+  this: AbortSignal,
+  ev: AbortSignalEventMap["abort"]
+) => void
+
+const abortEvent = "abort"
+
+/**
+ * Creates a promise that resolves after a specified number of milliseconds.
+ * The pause can be aborted using an AbortSignal.
+ *
+ * @param milliseconds - The number of milliseconds to pause. Defaults to 0.
+ * @param signal - An optional AbortSignal that can be used to cancel the pause.
+ * @returns A Promise that resolves after the specified delay, or rejects with an AbortError if cancelled.
+ *
+ * @throws {AbortError} Thrown when the pause is cancelled via the AbortSignal.
+ *
+ * @example
+ * ```typescript
+ * // Basic usage
+ * await pause(1000); // Pause for 1 second
+ *
+ * // With abort signal
+ * const controller = new AbortController();
+ * setTimeout(() => controller.abort(), 500); // Cancel after 500ms
+ * await pause(1000, controller.signal); // Will be cancelled
+ * ```
+ *
+ * @remarks
+ * Multiple signals can be observed using the AbortSignal.any() static method.
+ * This allows you to pause until either the timeout completes or any of multiple
+ * abort signals are triggered.
+ *
+ * @example
+ * ```typescript
+ * const signal1 = new AbortController().signal;
+ * const signal2 = new AbortController().signal;
+ * const combinedSignal = AbortSignal.any([signal1, signal2]);
+ * await pause(5000, combinedSignal); // Pause until timeout or either signal aborts
+ * ```
+ */
+export const pause = (
+  milliseconds: number = 0,
+  options?: { signal?: AbortSignal }
+) => {
+  return new Promise<void>((resolve, reject) => {
+    const { signal } = options ?? {}
+    if (signal?.aborted) {
+      reject(new AbortError())
+      return
+    }
+    const abortListener: AbortListener | undefined =
+      signal &&
+      ((): void => {
+        reject(new AbortError())
+        clearTimeout(id)
+      })
+
+    abortListener &&
+      signal?.addEventListener(abortEvent, abortListener, { once: true })
+
+    const id = setTimeout(() => {
+      resolve()
+      abortListener && signal?.removeEventListener(abortEvent, abortListener)
+    }, milliseconds)
+  })
+}
 
 /* c8 ignore end */

--- a/packages/automerge-repo/src/helpers/throttle.ts
+++ b/packages/automerge-repo/src/helpers/throttle.ts
@@ -28,16 +28,99 @@
 export const throttle = <F extends (...args: Parameters<F>) => ReturnType<F>>(
   fn: F,
   delay: number
-) => {
+): ((...args: Parameters<F>) => void) => {
   let lastCall = Date.now()
-  let wait
+  let wait: number | undefined
   let timeout: ReturnType<typeof setTimeout>
-  return function (...args: Parameters<F>) {
+  return function (...args: Parameters<F>): void {
     wait = lastCall + delay - Date.now()
     clearTimeout(timeout)
     timeout = setTimeout(() => {
       fn(...args)
       lastCall = Date.now()
     }, wait)
+  }
+}
+
+/**
+ * Throttles an async function to execute at most once per delay period
+ *
+ * Unlike regular throttle, this ensures:
+ * - Previous calls complete before new ones start (so there is no race with previous calls)
+ * - There's always a minimum delay between executions
+ * - The latest call always runs (canceling previous pending calls)
+ * - Each call waits for the previous execution to complete
+ *
+ * This creates a batching behavior that prevents flooding while ensuring
+ * the final state is always committed.
+ *
+ * **Note on AbortSignal**: If you need abort functionality, implement it as an
+ * argument to `fn`. The wrapped function is responsible for responding to the
+ * abort signal, not the throttle mechanism itself.
+ *
+ * @param fn - The async function to throttle
+ * @param delay - Minimum delay in milliseconds between executions
+ * @returns A throttled version of the function
+ *
+ * @example
+ * ```typescript
+ * const throttledSave = asyncThrottle(async (data) => {
+ *   await save(data)
+ * }, 100)
+ *
+ * // Multiple rapid calls will be throttled
+ * throttledSave(data1) // Waits 100ms, then executes
+ * throttledSave(data2) // Waits for data1 to complete + 100ms delay
+ * throttledSave(data3) // Cancels data2, waits for data1 + 100ms delay
+ *
+ * // Example with AbortSignal support
+ * const throttledFetch = asyncThrottle(async (url, signal) => {
+ *   return fetch(url, { signal })
+ * }, 100)
+ * const controller = new AbortController()
+ * throttledFetch('/api/data', controller.signal)
+ * controller.abort() // Aborts the fetch inside fn
+ * ```
+ */
+export const asyncThrottle = <TArgs extends unknown[], TReturn>(
+  fn: (...args: TArgs) => Promise<TReturn>,
+  delay: number
+): ((...args: TArgs) => Promise<TReturn>) => {
+  let lastCall = Date.now()
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let currentPromise: Promise<TReturn> | undefined
+
+  return async function (...args: TArgs): Promise<TReturn> {
+    // Wait for any previous call to settle, so that there is not a race with
+    // throttled calls still running
+    if (currentPromise) {
+      try {
+        await currentPromise
+      } catch {
+        // noop if error thrown here (just waiting for it to settle)
+      }
+    }
+
+    // Clear any pending timeout
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+
+    const wait = lastCall + delay - Date.now() //if negative, executes immediately
+
+    return new Promise<TReturn>((resolve, reject) => {
+      timeout = setTimeout(async () => {
+        try {
+          currentPromise = fn(...args)
+          resolve(await currentPromise)
+        } catch (error) {
+          reject(error)
+        } finally {
+          lastCall = Date.now()
+          currentPromise = undefined
+          timeout = undefined
+        }
+      }, wait)
+    })
   }
 }

--- a/packages/automerge-repo/src/helpers/truePromiseFactory.ts
+++ b/packages/automerge-repo/src/helpers/truePromiseFactory.ts
@@ -1,0 +1,3 @@
+/* c8 ignore start */
+export const truePromiseFactory = async () => true
+/* c8 ignore end */

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -19,7 +19,7 @@ import {
 } from "../network/messages.js"
 import { PeerId } from "../types.js"
 import { Synchronizer } from "./Synchronizer.js"
-import { throttle } from "../helpers/throttle.js"
+import { asyncThrottle } from "../helpers/throttle.js"
 
 type PeerDocumentStatus = "unknown" | "has" | "unavailable" | "wants"
 
@@ -77,7 +77,10 @@ export class DocSynchronizer extends Synchronizer {
 
     handle.on(
       "change",
-      throttle(() => this.#syncWithPeers(), this.syncDebounceRate)
+      asyncThrottle(
+        () => this.#syncWithPeers(),
+        this.syncDebounceRate
+      ) as () => void
     )
 
     handle.on("ephemeral-message-outbound", payload =>

--- a/packages/automerge-repo/test/AutomergeUrl.test.ts
+++ b/packages/automerge-repo/test/AutomergeUrl.test.ts
@@ -8,12 +8,12 @@ import {
   isValidAutomergeUrl,
   parseAutomergeUrl,
   stringifyAutomergeUrl,
-  UrlHeads,
 } from "../src/AutomergeUrl.js"
 import type {
   AutomergeUrl,
   BinaryDocumentId,
   DocumentId,
+  UrlHeads,
 } from "../src/types.js"
 import { interpretAsDocumentId } from "../src/AutomergeUrl.js"
 

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/AutomergeUrl.js"
 import { DocHandle } from "../src/DocHandle.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
+import { pause } from "../src/helpers/pause.js"
 import {
   DocumentUnavailableMessage,
   MessageContents,
@@ -79,6 +80,51 @@ describe("DocSynchronizer", () => {
       encodeHeads(message2.syncState.lastSentHeads),
       handle.heads()
     )
+  })
+
+  it("asyncThrottle on the 'change' handler serializes #syncWithPeers (never re-entered while in flight)", async () => {
+    const { handle, docSynchronizer } = setup()
+    docSynchronizer.beginSync([alice])
+    // Wait for the initial beginSync message so any whenReady calls inside
+    // beginSync have settled before we install the measurement patch.
+    await eventPromise(docSynchronizer, "message")
+
+    // #syncWithPeers starts with `await this.#handle.whenReady()`. By patching
+    // whenReady on this specific handle to be slow, we make each run of
+    // #syncWithPeers take measurable time. asyncThrottle wraps the 'change'
+    // handler's `() => this.#syncWithPeers()`, so if it correctly awaits the
+    // prior run before scheduling the next, whenReady must never be concurrent.
+    const origWhenReady = handle.whenReady.bind(handle)
+    let concurrent = 0
+    let maxConcurrent = 0
+    let whenReadyCalls = 0
+    handle.whenReady = async (...args: Parameters<typeof origWhenReady>) => {
+      concurrent++
+      whenReadyCalls++
+      maxConcurrent = Math.max(maxConcurrent, concurrent)
+      try {
+        await origWhenReady(...args)
+        await pause(80)
+      } finally {
+        concurrent--
+      }
+    }
+
+    // Fire rapid changes spaced so later ones land while a prior run is still
+    // in #syncWithPeers (waiting on the slow whenReady).
+    for (let i = 0; i < 6; i++) {
+      handle.change(doc => {
+        doc.foo = `v${i}`
+      })
+      await pause(30)
+    }
+    await pause(600)
+
+    assert(
+      whenReadyCalls > 0,
+      `expected #syncWithPeers to call whenReady, got ${whenReadyCalls}`
+    )
+    assert.equal(maxConcurrent, 1)
   })
 
   it("still syncs with a peer after it disconnects and reconnects", async () => {

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -84,6 +84,21 @@ describe("DocSynchronizer", () => {
 
   it("asyncThrottle on the 'change' handler serializes #syncWithPeers (never re-entered while in flight)", async () => {
     const { handle, docSynchronizer } = setup()
+
+    // asyncThrottle is configured with docSynchronizer.syncDebounceRate as
+    // its delay. The pauses below are tuned relative to that, not arbitrary:
+    //  - CHANGE_INTERVAL_MS < THROTTLE_MS so multiple changes coalesce into
+    //    one throttle window.
+    //  - SLOW_WHEN_READY_MS > CHANGE_INTERVAL_MS so each #syncWithPeers run
+    //    spans multiple change firings — without serialization this would
+    //    expose re-entry.
+    //  - DRAIN_MS is generous enough for all throttled and queued work to
+    //    settle before we assert.
+    const THROTTLE_MS = docSynchronizer.syncDebounceRate
+    const CHANGE_INTERVAL_MS = THROTTLE_MS * 0.3
+    const SLOW_WHEN_READY_MS = THROTTLE_MS * 0.8
+    const DRAIN_MS = THROTTLE_MS * 6
+
     docSynchronizer.beginSync([alice])
     // Wait for the initial beginSync message so any whenReady calls inside
     // beginSync have settled before we install the measurement patch.
@@ -104,7 +119,7 @@ describe("DocSynchronizer", () => {
       maxConcurrent = Math.max(maxConcurrent, concurrent)
       try {
         await origWhenReady(...args)
-        await pause(80)
+        await pause(SLOW_WHEN_READY_MS)
       } finally {
         concurrent--
       }
@@ -116,9 +131,9 @@ describe("DocSynchronizer", () => {
       handle.change(doc => {
         doc.foo = `v${i}`
       })
-      await pause(30)
+      await pause(CHANGE_INTERVAL_MS)
     }
-    await pause(600)
+    await pause(DRAIN_MS)
 
     assert(
       whenReadyCalls > 0,

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert"
-import { describe, it } from "vitest"
+import { describe, it, vi } from "vitest"
 import { next as Automerge } from "@automerge/automerge"
 import {
   encodeHeads,
@@ -83,63 +83,70 @@ describe("DocSynchronizer", () => {
   })
 
   it("asyncThrottle on the 'change' handler serializes #syncWithPeers (never re-entered while in flight)", async () => {
-    const { handle, docSynchronizer } = setup()
+    vi.useFakeTimers()
+    try {
+      const { handle, docSynchronizer } = setup()
 
-    // asyncThrottle is configured with docSynchronizer.syncDebounceRate as
-    // its delay. The pauses below are tuned relative to that, not arbitrary:
-    //  - CHANGE_INTERVAL_MS < THROTTLE_MS so multiple changes coalesce into
-    //    one throttle window.
-    //  - SLOW_WHEN_READY_MS > CHANGE_INTERVAL_MS so each #syncWithPeers run
-    //    spans multiple change firings — without serialization this would
-    //    expose re-entry.
-    //  - DRAIN_MS is generous enough for all throttled and queued work to
-    //    settle before we assert.
-    const THROTTLE_MS = docSynchronizer.syncDebounceRate
-    const CHANGE_INTERVAL_MS = THROTTLE_MS * 0.3
-    const SLOW_WHEN_READY_MS = THROTTLE_MS * 0.8
-    const DRAIN_MS = THROTTLE_MS * 6
+      // asyncThrottle is configured with docSynchronizer.syncDebounceRate as
+      // its delay. The advances below are tuned relative to that, not arbitrary:
+      //  - CHANGE_INTERVAL_MS < THROTTLE_MS so multiple changes coalesce into
+      //    one throttle window.
+      //  - SLOW_WHEN_READY_MS > CHANGE_INTERVAL_MS so each #syncWithPeers run
+      //    spans multiple change firings — without serialization this would
+      //    expose re-entry.
+      //  - DRAIN_MS is generous enough for all throttled and queued work to
+      //    settle before we assert.
+      const THROTTLE_MS = docSynchronizer.syncDebounceRate
+      const CHANGE_INTERVAL_MS = THROTTLE_MS * 0.3
+      const SLOW_WHEN_READY_MS = THROTTLE_MS * 0.8
+      const DRAIN_MS = THROTTLE_MS * 6
 
-    docSynchronizer.beginSync([alice])
-    // Wait for the initial beginSync message so any whenReady calls inside
-    // beginSync have settled before we install the measurement patch.
-    await eventPromise(docSynchronizer, "message")
+      docSynchronizer.beginSync([alice])
+      // Wait for the initial beginSync message so any whenReady calls inside
+      // beginSync have settled before we install the measurement patch.
+      // beginSync's whenReady chain is microtask-driven (handle is doneLoading),
+      // so the message emits without needing the clock to advance.
+      await eventPromise(docSynchronizer, "message")
 
-    // #syncWithPeers starts with `await this.#handle.whenReady()`. By patching
-    // whenReady on this specific handle to be slow, we make each run of
-    // #syncWithPeers take measurable time. asyncThrottle wraps the 'change'
-    // handler's `() => this.#syncWithPeers()`, so if it correctly awaits the
-    // prior run before scheduling the next, whenReady must never be concurrent.
-    const origWhenReady = handle.whenReady.bind(handle)
-    let concurrent = 0
-    let maxConcurrent = 0
-    let whenReadyCalls = 0
-    handle.whenReady = async (...args: Parameters<typeof origWhenReady>) => {
-      concurrent++
-      whenReadyCalls++
-      maxConcurrent = Math.max(maxConcurrent, concurrent)
-      try {
-        await origWhenReady(...args)
-        await pause(SLOW_WHEN_READY_MS)
-      } finally {
-        concurrent--
+      // #syncWithPeers starts with `await this.#handle.whenReady()`. By patching
+      // whenReady on this specific handle to be slow, we make each run of
+      // #syncWithPeers take measurable time. asyncThrottle wraps the 'change'
+      // handler's `() => this.#syncWithPeers()`, so if it correctly awaits the
+      // prior run before scheduling the next, whenReady must never be concurrent.
+      const origWhenReady = handle.whenReady.bind(handle)
+      let concurrent = 0
+      let maxConcurrent = 0
+      let whenReadyCalls = 0
+      handle.whenReady = async (...args: Parameters<typeof origWhenReady>) => {
+        concurrent++
+        whenReadyCalls++
+        maxConcurrent = Math.max(maxConcurrent, concurrent)
+        try {
+          await origWhenReady(...args)
+          await pause(SLOW_WHEN_READY_MS)
+        } finally {
+          concurrent--
+        }
       }
-    }
 
-    // Fire rapid changes spaced so later ones land while a prior run is still
-    // in #syncWithPeers (waiting on the slow whenReady).
-    for (let i = 0; i < 6; i++) {
-      handle.change(doc => {
-        doc.foo = `v${i}`
-      })
-      await pause(CHANGE_INTERVAL_MS)
-    }
-    await pause(DRAIN_MS)
+      // Fire rapid changes spaced so later ones land while a prior run is still
+      // in #syncWithPeers (waiting on the slow whenReady).
+      for (let i = 0; i < 6; i++) {
+        handle.change(doc => {
+          doc.foo = `v${i}`
+        })
+        await vi.advanceTimersByTimeAsync(CHANGE_INTERVAL_MS)
+      }
+      await vi.advanceTimersByTimeAsync(DRAIN_MS)
 
-    assert(
-      whenReadyCalls > 0,
-      `expected #syncWithPeers to call whenReady, got ${whenReadyCalls}`
-    )
-    assert.equal(maxConcurrent, 1)
+      assert(
+        whenReadyCalls > 0,
+        `expected #syncWithPeers to call whenReady, got ${whenReadyCalls}`
+      )
+      assert.equal(maxConcurrent, 1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("still syncs with a peer after it disconnects and reconnects", async () => {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -815,9 +815,7 @@ describe("Repo", () => {
         // exercise is actually reached.
         const aliceStorageId = await aliceStorage
           .load(["storage-adapter-id"])
-          .then(
-            bytes => new TextDecoder().decode(bytes!) as StorageId
-          )
+          .then(bytes => new TextDecoder().decode(bytes!) as StorageId)
         bob.peerMetadataByPeerId["alice" as PeerId] = {
           storageId: aliceStorageId,
           isEphemeral: false,

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -733,6 +733,114 @@ describe("Repo", () => {
         await pause(10)
         assert.equal(handle.listenerCount("heads-changed"), 1)
       })
+
+      it("saveDoc never has two concurrent saves in flight for the same document (asyncThrottle serialization)", async () => {
+        const storageAdapter = new DummyStorageAdapter()
+        const repo = new Repo({ storage: storageAdapter, saveDebounceRate: 20 })
+
+        let concurrent = 0
+        let maxConcurrent = 0
+        const originalSaveDoc = repo.storageSubsystem!.saveDoc.bind(
+          repo.storageSubsystem
+        )
+        repo.storageSubsystem!.saveDoc = async (documentId, doc) => {
+          concurrent++
+          maxConcurrent = Math.max(maxConcurrent, concurrent)
+          // saveDoc is deliberately slower than the debounce rate so a second
+          // asyncThrottled call arrives while the first is still saving.
+          await pause(80)
+          try {
+            return await originalSaveDoc(documentId, doc)
+          } finally {
+            concurrent--
+          }
+        }
+
+        const handle = repo.create<TestDoc>()
+        for (let i = 0; i < 10; i++) {
+          handle.change(d => {
+            d.foo = `v${i}`
+          })
+          await pause(15)
+        }
+        await pause(500)
+
+        assert.equal(maxConcurrent, 1)
+      })
+
+      it("saveSyncState never has two concurrent saves in flight for the same storageId (asyncThrottle serialization)", async () => {
+        const aliceStorage = new DummyStorageAdapter()
+        const bobStorage = new DummyStorageAdapter()
+        const alice = new Repo({
+          peerId: "alice" as PeerId,
+          storage: aliceStorage,
+          saveDebounceRate: 20,
+        })
+        const bob = new Repo({
+          peerId: "bob" as PeerId,
+          storage: bobStorage,
+          saveDebounceRate: 20,
+        })
+
+        // Count concurrent sync-state saves by intercepting the adapter's
+        // save method and filtering by the sync-state key prefix. The Repo
+        // wraps StorageSubsystem.saveSyncState with asyncThrottle keyed by
+        // storageId, so even across many rapid events the adapter should
+        // never see two sync-state saves in flight for the same storageId.
+        let concurrent = 0
+        let maxConcurrent = 0
+        let syncStateSaveCalls = 0
+        const originalBobSave = bobStorage.save.bind(bobStorage)
+        bobStorage.save = async (key, binary) => {
+          const isSyncState = key[1] === "sync-state"
+          if (isSyncState) {
+            concurrent++
+            syncStateSaveCalls++
+            maxConcurrent = Math.max(maxConcurrent, concurrent)
+          }
+          try {
+            if (isSyncState) await pause(80)
+            return await originalBobSave(key, binary)
+          } finally {
+            if (isSyncState) concurrent--
+          }
+        }
+
+        await connectRepos(alice, bob)
+
+        // DummyNetworkAdapter does not transmit the remote peer's metadata
+        // (see peerCandidate in DummyNetworkAdapter); without it, Repo's
+        // #saveSyncState early-returns because there is no storageId for the
+        // peer. Populate it manually so the asyncThrottle path we want to
+        // exercise is actually reached.
+        const aliceStorageId = await aliceStorage
+          .load(["storage-adapter-id"])
+          .then(
+            bytes => new TextDecoder().decode(bytes!) as StorageId
+          )
+        bob.peerMetadataByPeerId["alice" as PeerId] = {
+          storageId: aliceStorageId,
+          isEphemeral: false,
+        }
+
+        const aliceHandle = alice.create<TestDoc>({ foo: "init" })
+        await bob.find(aliceHandle.url)
+        await pause(20) // let the initial sync settle
+
+        for (let i = 0; i < 15; i++) {
+          aliceHandle.change(d => {
+            d.foo = `v${i}`
+          })
+          await pause(15)
+        }
+        await pause(800)
+
+        assert(
+          syncStateSaveCalls > 0,
+          `expected sync-state saves to be triggered, got ${syncStateSaveCalls}`
+        )
+        assert.equal(maxConcurrent, 1)
+      })
     })
   })
 

--- a/packages/automerge-repo/test/abortable.test.ts
+++ b/packages/automerge-repo/test/abortable.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from "vitest"
+import {
+  abortable,
+  AbortError,
+  isAbortErrorLike,
+} from "../src/helpers/abortable.js"
+import { pause } from "../src/helpers/pause.js"
+
+describe("abortable", () => {
+  describe("fast-path: signal already aborted before the call", () => {
+    it("rejects immediately with signal.reason when signal was aborted with a custom reason", async () => {
+      const controller = new AbortController()
+      const customReason = new AbortError("custom abort reason")
+      controller.abort(customReason)
+
+      // Underlying promise never settles; if the fast-path weren't there,
+      // the wrapper would depend on the abort-listener firing.
+      const forever = new Promise<number>(() => {})
+      await expect(abortable(forever, controller.signal)).rejects.toBe(
+        customReason
+      )
+    })
+
+    it("rejects immediately with the default reason when signal was aborted without one", async () => {
+      const controller = new AbortController()
+      controller.abort() // platform-default reason (an AbortError-like DOMException)
+
+      const forever = new Promise<number>(() => {})
+      const rejection = await abortable(forever, controller.signal).catch(
+        e => e
+      )
+      expect(isAbortErrorLike(rejection)).toBe(true)
+    })
+
+    it("does not install an abort listener when the signal is already aborted", async () => {
+      const controller = new AbortController()
+      controller.abort()
+      const addSpy = vi.spyOn(controller.signal, "addEventListener")
+
+      await abortable(Promise.resolve(42), controller.signal).catch(() => {})
+
+      expect(addSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("listener cleanup after the wrapped promise settles", () => {
+    it("removes the abort listener after the wrapped promise resolves", async () => {
+      const controller = new AbortController()
+      const addSpy = vi.spyOn(controller.signal, "addEventListener")
+      const removeSpy = vi.spyOn(controller.signal, "removeEventListener")
+
+      const result = await abortable(Promise.resolve(7), controller.signal)
+      // The outer promise's resolve fires a few microtasks before the
+      // .finally() cleanup runs; yield to let the whole chain drain.
+      await pause(0)
+
+      expect(result).toBe(7)
+      expect(addSpy).toHaveBeenCalledTimes(1)
+      expect(removeSpy).toHaveBeenCalledTimes(1)
+      // The listener added and the listener removed must be the same function
+      const [, addedFn] = addSpy.mock.calls[0]
+      const [, removedFn] = removeSpy.mock.calls[0]
+      expect(removedFn).toBe(addedFn)
+    })
+
+    it("removes the abort listener after the wrapped promise rejects", async () => {
+      const controller = new AbortController()
+      const addSpy = vi.spyOn(controller.signal, "addEventListener")
+      const removeSpy = vi.spyOn(controller.signal, "removeEventListener")
+
+      await expect(
+        abortable(Promise.reject(new Error("boom")), controller.signal)
+      ).rejects.toThrow("boom")
+      await pause(0) // let the .finally() cleanup chain drain
+
+      expect(addSpy).toHaveBeenCalledTimes(1)
+      expect(removeSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it("aborting the signal after settlement does not throw or produce an unhandled rejection", async () => {
+      const controller = new AbortController()
+      const value = await abortable(Promise.resolve("ok"), controller.signal)
+      expect(value).toBe("ok")
+
+      // Abort after the wrapper has already settled. The listener should
+      // have been removed, and even if it hadn't, the `settled` flag in
+      // abortable prevents a late reject. Either way, this must not throw.
+      expect(() => controller.abort()).not.toThrow()
+    })
+  })
+
+  describe("baseline behavior", () => {
+    it("returns the resolved value when the wrapped promise resolves before abort", async () => {
+      const controller = new AbortController()
+      const result = await abortable(Promise.resolve(42), controller.signal)
+      expect(result).toBe(42)
+    })
+
+    it("propagates the rejection when the wrapped promise rejects before abort", async () => {
+      const controller = new AbortController()
+      await expect(
+        abortable(Promise.reject(new Error("inner")), controller.signal)
+      ).rejects.toThrow("inner")
+    })
+
+    it("rejects with an AbortError-like error when signal aborts while the wrapped promise is pending", async () => {
+      const controller = new AbortController()
+      const pending = pause(1000) // slow enough to still be pending when we abort
+
+      queueMicrotask(() => controller.abort())
+
+      const rejection = await abortable(pending, controller.signal).catch(
+        e => e
+      )
+      expect(isAbortErrorLike(rejection)).toBe(true)
+    })
+
+    it("passes through the wrapped promise unchanged when signal is undefined", async () => {
+      const result = await abortable(Promise.resolve("no-signal"), undefined)
+      expect(result).toBe("no-signal")
+
+      await expect(
+        abortable(Promise.reject(new Error("x")), undefined)
+      ).rejects.toThrow("x")
+    })
+  })
+})
+
+describe("isAbortErrorLike", () => {
+  describe("positive cases (returns true)", () => {
+    it("recognizes an AbortError instance", () => {
+      expect(isAbortErrorLike(new AbortError())).toBe(true)
+      expect(isAbortErrorLike(new AbortError("custom message"))).toBe(true)
+    })
+
+    it("recognizes a DOMException whose name is 'AbortError'", () => {
+      // This is what the platform produces for an aborted AbortSignal.reason
+      // when abort() is called without arguments.
+      const dom = new DOMException("aborted", "AbortError")
+      expect(isAbortErrorLike(dom)).toBe(true)
+    })
+
+    it("recognizes a generic Error whose name is 'AbortError'", () => {
+      // A duck-typed AbortError from some other library or ad-hoc code.
+      const err = new Error("aborted")
+      err.name = "AbortError"
+      expect(isAbortErrorLike(err)).toBe(true)
+    })
+
+    it("recognizes the reason attached to an aborted AbortSignal", () => {
+      const controller = new AbortController()
+      controller.abort() // platform-default AbortError-like reason
+      expect(isAbortErrorLike(controller.signal.reason)).toBe(true)
+    })
+  })
+
+  describe("negative cases (returns false)", () => {
+    it("rejects a plain Error (name='Error')", () => {
+      expect(isAbortErrorLike(new Error("nope"))).toBe(false)
+    })
+
+    it("rejects other built-in error types", () => {
+      expect(isAbortErrorLike(new TypeError("nope"))).toBe(false)
+      expect(isAbortErrorLike(new RangeError("nope"))).toBe(false)
+    })
+
+    it("rejects a DOMException whose name is not 'AbortError'", () => {
+      const dom = new DOMException("some other kind", "NotFoundError")
+      expect(isAbortErrorLike(dom)).toBe(false)
+    })
+
+    it("rejects a plain object that merely has name='AbortError' (duck-typing is NOT enough)", () => {
+      // Must be an Error/DOMException, not just any object with the right name.
+      expect(isAbortErrorLike({ name: "AbortError", message: "x" })).toBe(false)
+    })
+
+    it("rejects null, undefined, and primitives", () => {
+      expect(isAbortErrorLike(null)).toBe(false)
+      expect(isAbortErrorLike(undefined)).toBe(false)
+      expect(isAbortErrorLike("AbortError")).toBe(false)
+      expect(isAbortErrorLike(42)).toBe(false)
+      expect(isAbortErrorLike(false)).toBe(false)
+    })
+  })
+})

--- a/packages/automerge-repo/test/pause.test.ts
+++ b/packages/automerge-repo/test/pause.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest"
+import { pause } from "../src/helpers/pause.js"
+import { AbortError } from "../src/helpers/abortable.js"
+
+describe("pause", () => {
+  it("resolves after approximately the specified time when no signal is passed", async () => {
+    const start = Date.now()
+    await pause(40)
+    expect(Date.now() - start).toBeGreaterThanOrEqual(35) // allow small timer drift
+  })
+
+  it("resolves normally when a signal is provided but never aborts", async () => {
+    const controller = new AbortController()
+    const start = Date.now()
+    await pause(40, { signal: controller.signal })
+    expect(Date.now() - start).toBeGreaterThanOrEqual(35)
+  })
+
+  describe("signal support", () => {
+    it("rejects immediately with AbortError when the signal is already aborted", async () => {
+      const controller = new AbortController()
+      controller.abort()
+
+      const start = Date.now()
+      await expect(
+        pause(1000, { signal: controller.signal })
+      ).rejects.toBeInstanceOf(AbortError)
+      // Fast-path: reject without waiting for the 1000ms timer.
+      expect(Date.now() - start).toBeLessThan(50)
+    })
+
+    it("rejects with AbortError shortly after the signal aborts mid-pause", async () => {
+      const controller = new AbortController()
+      setTimeout(() => controller.abort(), 20)
+
+      const start = Date.now()
+      await expect(
+        pause(1000, { signal: controller.signal })
+      ).rejects.toBeInstanceOf(AbortError)
+      // Rejected near T=20 (abort time), not near T=1000 (original timeout).
+      // Proves the abort listener fired and clearTimeout prevented the late resolve.
+      const elapsed = Date.now() - start
+      expect(elapsed).toBeGreaterThanOrEqual(15)
+      expect(elapsed).toBeLessThan(200)
+    })
+
+    it("aborting after the pause already resolved does not throw or re-settle", async () => {
+      const controller = new AbortController()
+      await pause(10, { signal: controller.signal })
+      // The timer fired and resolved; the listener should have been removed.
+      // Either way, aborting now must be a harmless no-op.
+      expect(() => controller.abort()).not.toThrow()
+    })
+
+    it("supports AbortSignal.any(): aborting any source signal cancels the pause", async () => {
+      if (typeof AbortSignal.any !== "function") {
+        // Runtime without AbortSignal.any (pre-Node-20 style); skip.
+        return
+      }
+      const c1 = new AbortController()
+      const c2 = new AbortController()
+      const combined = AbortSignal.any([c1.signal, c2.signal])
+
+      setTimeout(() => c2.abort(), 20) // abort via the second source
+
+      const start = Date.now()
+      await expect(
+        pause(1000, { signal: combined })
+      ).rejects.toBeInstanceOf(AbortError)
+      expect(Date.now() - start).toBeLessThan(200)
+    })
+  })
+})

--- a/packages/automerge-repo/test/pause.test.ts
+++ b/packages/automerge-repo/test/pause.test.ts
@@ -64,9 +64,9 @@ describe("pause", () => {
       setTimeout(() => c2.abort(), 20) // abort via the second source
 
       const start = Date.now()
-      await expect(
-        pause(1000, { signal: combined })
-      ).rejects.toBeInstanceOf(AbortError)
+      await expect(pause(1000, { signal: combined })).rejects.toBeInstanceOf(
+        AbortError
+      )
       expect(Date.now() - start).toBeLessThan(200)
     })
   })

--- a/packages/automerge-repo/test/pause.test.ts
+++ b/packages/automerge-repo/test/pause.test.ts
@@ -1,52 +1,74 @@
-import { describe, it, expect } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { pause } from "../src/helpers/pause.js"
 import { AbortError } from "../src/helpers/abortable.js"
 
 describe("pause", () => {
-  it("resolves after approximately the specified time when no signal is passed", async () => {
-    const start = Date.now()
-    await pause(40)
-    expect(Date.now() - start).toBeGreaterThanOrEqual(35) // allow small timer drift
+  beforeEach(() => {
+    vi.useFakeTimers()
   })
 
-  it("resolves normally when a signal is provided but never aborts", async () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("does not resolve until the specified time has elapsed", async () => {
+    let resolved = false
+    const p = pause(40).then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(39)
+    expect(resolved).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    await p
+    expect(resolved).toBe(true)
+  })
+
+  it("resolves after the specified time when a signal is provided but never aborts", async () => {
     const controller = new AbortController()
-    const start = Date.now()
-    await pause(40, { signal: controller.signal })
-    expect(Date.now() - start).toBeGreaterThanOrEqual(35)
+    let resolved = false
+    const p = pause(40, { signal: controller.signal }).then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(40)
+    await p
+    expect(resolved).toBe(true)
   })
 
   describe("signal support", () => {
-    it("rejects immediately with AbortError when the signal is already aborted", async () => {
+    it("rejects synchronously without scheduling a timer when the signal is already aborted", async () => {
+      const before = vi.getTimerCount()
       const controller = new AbortController()
       controller.abort()
 
-      const start = Date.now()
       await expect(
         pause(1000, { signal: controller.signal })
       ).rejects.toBeInstanceOf(AbortError)
-      // Fast-path: reject without waiting for the 1000ms timer.
-      expect(Date.now() - start).toBeLessThan(50)
+      // The abort fast-path returned before setTimeout was reached.
+      expect(vi.getTimerCount()).toBe(before)
     })
 
-    it("rejects with AbortError shortly after the signal aborts mid-pause", async () => {
+    it("rejects with AbortError and clears the timer when the signal aborts mid-pause", async () => {
+      const before = vi.getTimerCount()
       const controller = new AbortController()
-      setTimeout(() => controller.abort(), 20)
+      const p = pause(1000, { signal: controller.signal })
+      expect(vi.getTimerCount()).toBe(before + 1)
 
-      const start = Date.now()
-      await expect(
-        pause(1000, { signal: controller.signal })
-      ).rejects.toBeInstanceOf(AbortError)
-      // Rejected near T=20 (abort time), not near T=1000 (original timeout).
-      // Proves the abort listener fired and clearTimeout prevented the late resolve.
-      const elapsed = Date.now() - start
-      expect(elapsed).toBeGreaterThanOrEqual(15)
-      expect(elapsed).toBeLessThan(200)
+      await vi.advanceTimersByTimeAsync(20)
+      controller.abort()
+
+      await expect(p).rejects.toBeInstanceOf(AbortError)
+      // The pending 1000ms timer was cleared by the abort listener.
+      expect(vi.getTimerCount()).toBe(before)
     })
 
     it("aborting after the pause already resolved does not throw or re-settle", async () => {
       const controller = new AbortController()
-      await pause(10, { signal: controller.signal })
+      const p = pause(10, { signal: controller.signal })
+      await vi.advanceTimersByTimeAsync(10)
+      await p
       // The timer fired and resolved; the listener should have been removed.
       // Either way, aborting now must be a harmless no-op.
       expect(() => controller.abort()).not.toThrow()
@@ -61,13 +83,11 @@ describe("pause", () => {
       const c2 = new AbortController()
       const combined = AbortSignal.any([c1.signal, c2.signal])
 
-      setTimeout(() => c2.abort(), 20) // abort via the second source
+      const p = pause(1000, { signal: combined })
+      await vi.advanceTimersByTimeAsync(20)
+      c2.abort() // abort via the second source
 
-      const start = Date.now()
-      await expect(pause(1000, { signal: combined })).rejects.toBeInstanceOf(
-        AbortError
-      )
-      expect(Date.now() - start).toBeLessThan(200)
+      await expect(p).rejects.toBeInstanceOf(AbortError)
     })
   })
 })

--- a/packages/automerge-repo/test/remoteHeads.test.ts
+++ b/packages/automerge-repo/test/remoteHeads.test.ts
@@ -15,6 +15,8 @@ import { DummyStorageAdapter } from "../src/helpers/DummyStorageAdapter.js"
 import { collectMessages } from "./helpers/collectMessages.js"
 import { TestDoc } from "./types.js"
 import { pause } from "../src/helpers/pause.js"
+import { truePromiseFactory } from "../src/helpers/truePromiseFactory.js"
+import { falsePromiseFactory } from "../src/helpers/falsePromiseFactory.js"
 
 describe("DocHandle.remoteHeads", () => {
   const TEST_ID = parseAutomergeUrl(generateAutomergeUrl()).documentId
@@ -56,13 +58,13 @@ describe("DocHandle.remoteHeads", () => {
       const alice = new Repo({
         peerId: "alice-tab-1" as PeerId,
         network: [],
-        sharePolicy: async () => true,
+        sharePolicy: truePromiseFactory,
         enableRemoteHeadsGossiping: true,
       })
       const alice2 = new Repo({
         peerId: "alice-tab-2" as PeerId,
         network: [],
-        sharePolicy: async () => true,
+        sharePolicy: truePromiseFactory,
         enableRemoteHeadsGossiping: true,
       })
       const aliceServiceWorker = new Repo({
@@ -77,7 +79,7 @@ describe("DocHandle.remoteHeads", () => {
         peerId: "sync-server" as PeerId,
         network: [],
         isEphemeral: false,
-        sharePolicy: async () => false,
+        sharePolicy: falsePromiseFactory,
         storage: new DummyStorageAdapter(),
         enableRemoteHeadsGossiping: true,
       })
@@ -92,7 +94,7 @@ describe("DocHandle.remoteHeads", () => {
       const bob = new Repo({
         peerId: "bob-tab" as PeerId,
         network: [],
-        sharePolicy: async () => true,
+        sharePolicy: truePromiseFactory,
         enableRemoteHeadsGossiping: true,
       })
 

--- a/packages/automerge-repo/test/throttle.test.ts
+++ b/packages/automerge-repo/test/throttle.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest"
+import { asyncThrottle, throttle } from "../src/helpers/throttle.js"
+import { pause } from "../src/helpers/pause.js"
+
+describe("asyncThrottle", () => {
+  it("serializes a slow async fn: two invocations never run concurrently", async () => {
+    let concurrent = 0
+    let maxConcurrent = 0
+    let callCount = 0
+
+    const fn = async () => {
+      callCount++
+      concurrent++
+      maxConcurrent = Math.max(maxConcurrent, concurrent)
+      await pause(80)
+      concurrent--
+    }
+
+    const throttled = asyncThrottle(fn, 20)
+
+    const p1 = throttled() // T=0: p1's fn scheduled to start at T=20 (DELAY)
+    await pause(40) // T≈40: p1's fn started at T=20 and is still running (until T=100)
+    const p2 = throttled() // T≈40: suspends internally on `await currentPromise` (p1's fn)
+    await Promise.all([p1, p2]) // T≈200: p1 resolves at T=100 (its fn done); p2 at T=200
+
+    expect(maxConcurrent).toBe(1)
+    expect(callCount).toBe(2)
+  })
+
+  it("coalesces rapid calls and runs fn with the latest args only", async () => {
+    const calls: number[] = []
+    const throttled = asyncThrottle(async (x: number) => {
+      calls.push(x)
+      await pause(20) // simulate real async work
+    }, 30)
+
+    throttled(1) // T=0: schedules fn at T=30 (DELAY)
+    throttled(2) // T≈0: clears previous timeout, reschedules at T=30
+    const last = throttled(3) // T≈0: clears previous, reschedules at T=30 with args=3
+    await last // T≈50: fn starts at T=30 with args=3, finishes at T=50
+
+    expect(calls.length).toBe(1) // coalesced: fn ran exactly once
+    expect(calls[0]).toBe(3) // ...with the latest args
+  })
+
+  it("returns a Promise that resolves with fn's return value", async () => {
+    const throttled = asyncThrottle(async (n: number) => n * 2, 10)
+    const result = await throttled(21) // T=0 → T≈10: fn(21) runs at T=10, returns 42
+    expect(result).toBe(42)
+  })
+
+  it("rejects the returned promise when fn throws", async () => {
+    const throttled = asyncThrottle(async () => {
+      throw new Error("boom")
+    }, 10)
+    await expect(throttled()).rejects.toThrow("boom") // T=0 → T≈10: fn throws, rejected promise propagates
+  })
+
+  it("measures the minimum gap between executions from the end of the previous run", async () => {
+    const starts: number[] = []
+    const FN_DURATION = 100
+    const DELAY = 30
+
+    const throttled = asyncThrottle(async () => {
+      starts.push(Date.now())
+      await pause(FN_DURATION)
+    }, DELAY)
+
+    const p1 = throttled() // T=0: schedules p1's fn at T=30 (DELAY)
+    // Wait past the throttle DELAY so call 1's fn is actually running
+    // (if call 2 arrives before call 1's timeout fires, call 1's promise
+    // is orphaned and the second run's fn gets called with call 2's args).
+    await pause(DELAY + 20) // T≈50: p1's fn started at T=30, still running (until T=130)
+    const p2 = throttled() // T≈50: suspends internally on `await currentPromise` (p1's fn)
+    await Promise.all([p1, p2]) // T≈260: p1 resolves at T=130; p2's fn runs T=160-260
+
+    expect(starts.length).toBe(2)
+    const gap = starts[1] - starts[0]
+    // Gap must reflect waiting for the previous fn to settle (FN_DURATION)
+    // *then* the throttle delay - not just DELAY from the first start.
+    // Allow small negative drift from timer resolution.
+    expect(gap).toBeGreaterThanOrEqual(FN_DURATION + DELAY - 10)
+  })
+
+  it("cancels a pending invocation when called again before the delay elapses", async () => {
+    // Record the `x` passed to every fn invocation that actually ran.
+    // Because push is the FIRST line of fn, if fn(1) had even started,
+    // `ranWith` would contain 1 — regardless of whether it reached the pause.
+    const ranWith: number[] = []
+    const throttled = asyncThrottle(async (x: number) => {
+      ranWith.push(x)
+      await pause(20) // simulate real async work
+    }, 50)
+
+    void throttled(1) // T=0: schedules fn(1) at T=50; pending timeout will be replaced below
+    await pause(10) // T≈10: still within the 50ms delay window, fn(1)'s timeout hasn't fired
+    await throttled(2) // T≈70: clears (1)'s timeout, reschedules; fn(2) starts at T=50, finishes at T=70
+
+    expect(ranWith).not.toContain(1) // fn(1) never ran — its pending timeout was cleared
+    expect(ranWith).toEqual([2]) // ...and fn(2) ran in its place
+  })
+})
+
+describe("throttle vs asyncThrottle: the concurrency property", () => {
+  it("plain throttle allows overlapping fn runs when fn exceeds the delay; asyncThrottle prevents them", async () => {
+    const DELAY = 30
+    const FN_DURATION = 100
+
+    const makeProbe = () => {
+      let concurrent = 0
+      let maxConcurrent = 0
+      return {
+        async fn() {
+          concurrent++
+          maxConcurrent = Math.max(maxConcurrent, concurrent)
+          await pause(FN_DURATION)
+          concurrent--
+        },
+        getMax: () => maxConcurrent,
+      }
+    }
+
+    // Plain throttle: fires fn and forgets; a second call during fn's
+    // execution schedules another fn run that overlaps the first.
+    const plainProbe = makeProbe()
+    const plainThrottled = throttle(() => {
+      void plainProbe.fn()
+    }, DELAY)
+
+    plainThrottled() // T=0: schedules fn at T=30 (DELAY)
+    await pause(50) // T≈50: fn1 started at T=30, still running (until T=130)
+    plainThrottled() // T≈50: reschedules fn at T=60 (doesn't wait for fn1); fn2 starts at T=60, ends T=160
+    await pause(FN_DURATION + DELAY + 50) // T≈230: both fn1 (T=30-130) and fn2 (T=60-160) done; they overlapped T=60-130
+
+    // Undesired behavior: plain throttle let fn runs overlap. This is the
+    // race that motivated asyncThrottle.
+    expect(plainProbe.getMax()).toBeGreaterThan(1)
+
+    // asyncThrottle: the second call awaits the first fn's promise before
+    // scheduling, so the two fn invocations never overlap.
+    const asyncProbe = makeProbe()
+    const asyncThrottled = asyncThrottle(asyncProbe.fn, DELAY)
+    // Subsection timeline below is measured from the line above (resets T=0).
+
+    const p1 = asyncThrottled() // T=0: schedules p1's fn at T=30 (DELAY)
+    await pause(50) // T≈50: p1's fn started at T=30, still running (until T=130)
+    const p2 = asyncThrottled() // T≈50: suspends on `await currentPromise` (p1's fn)
+    await Promise.all([p1, p2]) // T≈260: p1 resolves at T=130; p2's fn runs T=160-260
+
+    // Desired behavior: asyncThrottle kept max concurrent fn runs at 1,
+    // despite identical call timing to the plain-throttle case above.
+    expect(asyncProbe.getMax()).toBe(1)
+  })
+})


### PR DESCRIPTION
- Adds a new `asyncThrottle()` helper to replace the current sync `throttle()`
   - This prevents potential race between the throttle period and the previous calls of an async function
   - Added tests to demonstrate the race issues and integration tests
- strengthen `abortable()`
    - handles minor case where signal is already aborted when `abortable()` is called
    - ensure signal event listener is cleaned up when the signal is never aborted
    - add tests
- adds some consts to keep code DRY
   - `foreverPromise`; (used in Repo to prevent possible leak of new promises that never settle)
   - `noop()`
   - `truePromiseFactory()` and `falsePromiseFactory()`
- refactors the `pause()` helper to support `signal: AbortSignal` option 
    - This is helpful for future if we want to use pause() in method with abort signal.
    - And add tests
- minor fix of `import` of `UrlHeads` type in `AutomergeUrl.test.ts`