### PR TITLE
make outbound message log a debug log

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -465,8 +465,8 @@ export class Repo extends EventEmitter<RepoEvents> {
     if (this.#subductionSource) {
       const subductionSource = this.#subductionSource
       query.handle.on("ephemeral-message-outbound", ({ data }) => {
-        console.log(
-          `[repo] ephemeral outbound for ${documentId.slice(0, 8)}, ${
+        this.#log(
+          `ephemeral outbound for ${documentId.slice(0, 8)}, ${
             data.byteLength
           } bytes`
         )


### PR DESCRIPTION
this prints out so much, i'd really like to not see it unless i have debugging on for automerge-repo! if that's ok!