### PR TITLE
feat: add WeakValueCache and refactor existing #refCache and #viewCache to use it

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -18,6 +18,7 @@ import {
   isAbortErrorLike,
 } from "./helpers/abortable.js"
 import type { PathInput, InferRefType, Ref } from "./refs/types.js"
+import { WeakValueMap } from "./helpers/WeakValueMap.js"
 
 /**
  * A DocHandle is a wrapper around a single Automerge document that lets us listen for changes and
@@ -51,11 +52,13 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
   /** A dictionary mapping each peer to the last known heads we have. */
   #syncInfoByStorageId: Record<StorageId, SyncInfo> = {}
 
-  /** Cache for view handles, keyed by the stringified heads */
-  #viewCache: Map<string, DocHandle<T>> = new Map()
+  /** Cache for view handles, keyed by the stringified heads. Values are
+   * held weakly so unused views are eligible for GC. */
+  #viewCache = new WeakValueMap<string, DocHandle<T>>()
 
-  /** Cache for ref instances, keyed by serialized path */
-  #refCache: Map<string, WeakRef<Ref<any>>> = new Map()
+  /** Cache for ref instances, keyed by serialized path. Values are held
+   * weakly so unused refs are eligible for GC. */
+  #refCache = new WeakValueMap<string, Ref<any>>()
 
   /** Factory for creating Ref instances, injected by Repo to avoid circular imports */
   #refConstructor: <TDoc, TPath extends readonly PathInput[]>(
@@ -447,27 +450,15 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
       )
     }
 
-    // Create a cache key from the heads
-    const cacheKey = JSON.stringify(heads)
-
-    // Check if we have a cached handle for these heads
-    const cachedHandle = this.#viewCache.get(cacheKey)
-    if (cachedHandle) {
-      return cachedHandle
-    }
-
-    // Create a new handle with the same documentId but fixed heads
-    const handle = new DocHandle<T>(this.documentId, this.#refConstructor, {
-      heads,
-      timeoutDelay: this.#timeoutDelay,
+    return this.#viewCache.getOrCompute(JSON.stringify(heads), () => {
+      const handle = new DocHandle<T>(this.documentId, this.#refConstructor, {
+        heads,
+        timeoutDelay: this.#timeoutDelay,
+      })
+      handle.update(() => A.clone(this.#doc))
+      handle.doneLoading()
+      return handle
     })
-    handle.update(() => A.clone(this.#doc))
-    handle.doneLoading()
-
-    // Store in cache
-    this.#viewCache.set(cacheKey, handle)
-
-    return handle
   }
 
   /**
@@ -760,18 +751,9 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
   ref<TPath extends readonly PathInput[]>(
     ...segments: [...TPath]
   ): Ref<InferRefType<T, TPath>> {
-    const cacheKey = this.#pathToCacheKey(segments)
-    const existingRef = this.#refCache.get(cacheKey)?.deref()
-
-    if (existingRef) {
-      return existingRef as Ref<InferRefType<T, TPath>>
-    }
-
-    // Create new ref and cache it
-    const newRef = this.#refConstructor<T, TPath>(this, segments as [...TPath])
-    this.#refCache.set(cacheKey, new WeakRef(newRef))
-
-    return newRef as Ref<InferRefType<T, TPath>>
+    return this.#refCache.getOrCompute(this.#pathToCacheKey(segments), () =>
+      this.#refConstructor<T, TPath>(this, segments as [...TPath])
+    ) as Ref<InferRefType<T, TPath>>
   }
 
   /**

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -963,6 +963,15 @@ export class Repo extends EventEmitter<RepoEvents> {
           `WARN: removeFromCache called but handle for documentId: ${documentId} in unexpected state: ${handle.state}`
         )
       }
+      // Notes:
+      // - The parent's #viewCache uses WeakValueMap, so cached view handles
+      //   become eligible for GC as soon as nothing outside the parent holds
+      //   them.
+      // - this method does not currently detach the listeners
+      //   that DocSynchronizer and #saveFn attached to the handle, so the
+      //   parent itself may continue to be retained by those listener
+      //   closures. Treat this as "stop tracking", not "fully tear down".
+      // - TODO: If immediate handle reclamation is needed, that requires an additional step (e.g. handle.removeAllListeners())
       delete this.#handleCache[documentId]
       delete this.#progressCache[documentId]
       delete this.#saveFns[documentId]

--- a/packages/automerge-repo/src/helpers/WeakValueMap.ts
+++ b/packages/automerge-repo/src/helpers/WeakValueMap.ts
@@ -1,0 +1,68 @@
+/**
+ * Map keyed by a primitive (`number | string`) where values are held weakly.
+ * Dead entries are removed automatically via `FinalizationRegistry` once the
+ * value is GC'd.
+ *
+ * Use for pure optimization caches where:
+ *   - the key is a primitive (e.g. a stringified path, a stringified head, a
+ *     document id),
+ *   - V can be cheaply reconstructed on miss,
+ *   - "cache hit" is never observable as program state.
+ *
+ * Why not `WeakMap`? `WeakMap` keys must be `WeakKey` (object or registered
+ * symbol). It cannot be keyed on a `number` or a `string` — try
+ * `new WeakMap<string, T>()` and TypeScript rejects it. `WeakValueMap` fills
+ * exactly that gap: primitive keys, weak values, with the same automatic
+ * eviction guarantee that `WeakMap` provides for object keys.
+ *
+ * If your key *is* an object, prefer the built-in `WeakMap` instead — it ships
+ * with the language and has cleaner lifetime semantics for that shape.
+ *
+ * @example
+ *   // Cache view handles by stringified heads.
+ *   const cache = new WeakValueMap<string, DocHandle<T>>()
+ *   const handle = cache.getOrCompute(JSON.stringify(heads), () => makeView(heads))
+ */
+export class WeakValueMap<K extends number | string, V extends WeakKey> {
+  #map = new Map<K, WeakRef<V>>()
+  #registry = new FinalizationRegistry<K>(key => {
+    const ref = this.#map.get(key)
+    if (ref !== undefined && ref.deref() === undefined) {
+      this.#map.delete(key)
+    }
+  })
+
+  get(key: K): V | undefined {
+    return this.#map.get(key)?.deref()
+  }
+
+  set(key: K, value: V): this {
+    const existing = this.#map.get(key)?.deref()
+    if (existing !== undefined) {
+      // Without this, the old value's finalizer would later delete the new
+      // entry. The value object itself is the unregister token.
+      this.#registry.unregister(existing)
+    }
+    this.#map.set(key, new WeakRef(value))
+    this.#registry.register(value, key, value)
+    return this
+  }
+
+  delete(key: K): boolean {
+    const existing = this.#map.get(key)?.deref()
+    if (existing !== undefined) this.#registry.unregister(existing)
+    return this.#map.delete(key)
+  }
+
+  has(key: K): boolean {
+    return this.get(key) !== undefined
+  }
+
+  getOrCompute(key: K, compute: () => V): V {
+    const existing = this.get(key)
+    if (existing !== undefined) return existing
+    const value = compute()
+    this.set(key, value)
+    return value
+  }
+}

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -12,6 +12,7 @@ import { pause } from "../src/helpers/pause.js"
 import { DocHandle, DocHandleChangePayload } from "../src/index.js"
 import { TestDoc } from "./types.js"
 import { RefImpl } from "../src/refs/ref.js"
+import { flushGC, gcAvailable } from "./helpers/flushGC.js"
 
 describe("DocHandle", () => {
   const TEST_ID = parseAutomergeUrl(generateAutomergeUrl()).documentId
@@ -697,5 +698,69 @@ describe("DocHandle", () => {
       doc.foo = "baz"
     })
     assert.equal(handle.view(newHeads).doc().foo, "baz")
+  })
+
+  describe("weak caches", () => {
+    const itGC = gcAvailable ? it : it.skip
+
+    it("ref() returns the same instance while held", () => {
+      const handle = setup()
+      handle.change(d => (d.foo = "x"))
+      const a = handle.ref("foo")
+      const b = handle.ref("foo")
+      expect(a).toBe(b)
+    })
+
+    it("view() returns the same handle for the same heads while held", () => {
+      const handle = setup()
+      handle.change(d => (d.foo = "x"))
+      const heads = handle.heads()!
+      const a = handle.view(heads)
+      const b = handle.view(heads)
+      expect(a).toBe(b)
+    })
+
+    // Skipped: blocked by a pre-existing structural issue in RefImpl. Its
+    // #updateHandler closure captures `this` and is stored as a change
+    // listener on the DocHandle, so while the DocHandle is alive the Ref is
+    // pinned — independent of #refCache. The FinalizationRegistry in
+    // refs/ref.ts has the same shape (held value captures the target). The
+    // WeakValueMap migration of #refCache is still correct; it just cannot
+    // realize value-collection benefits until RefImpl uses weak self-refs.
+    it.skip("ref() yields a fresh instance once the prior ref is GC'd", async () => {
+      const handle = setup()
+      handle.change(d => (d.foo = "x"))
+
+      const probe = (() => {
+        const r = handle.ref("foo")
+        return new WeakRef(r)
+      })()
+
+      await flushGC()
+
+      expect(probe.deref()).toBeUndefined()
+      const fresh = handle.ref("foo")
+      expect(fresh).not.toBe(probe.deref())
+    })
+
+    itGC(
+      "view() yields a fresh handle once the prior view is GC'd",
+      async () => {
+        const handle = setup()
+        handle.change(d => (d.foo = "x"))
+        const heads = handle.heads()!
+
+        const probe = (() => {
+          const v = handle.view(heads)
+          return new WeakRef(v)
+        })()
+
+        await flushGC()
+
+        expect(probe.deref()).toBeUndefined()
+        const fresh = handle.view(heads)
+        expect(fresh).not.toBe(probe.deref())
+      }
+    )
   })
 })

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -12,7 +12,7 @@ import { pause } from "../src/helpers/pause.js"
 import { DocHandle, DocHandleChangePayload } from "../src/index.js"
 import { TestDoc } from "./types.js"
 import { RefImpl } from "../src/refs/ref.js"
-import { flushGC, gcAvailable } from "./helpers/flushGC.js"
+import { gcAvailable, waitForGC } from "./helpers/flushGC.js"
 
 describe("DocHandle", () => {
   const TEST_ID = parseAutomergeUrl(generateAutomergeUrl()).documentId
@@ -736,9 +736,7 @@ describe("DocHandle", () => {
         return new WeakRef(r)
       })()
 
-      await flushGC()
-
-      expect(probe.deref()).toBeUndefined()
+      expect(await waitForGC(probe)).toBe(true)
       const fresh = handle.ref("foo")
       expect(fresh).not.toBe(probe.deref())
     })
@@ -755,9 +753,7 @@ describe("DocHandle", () => {
           return new WeakRef(v)
         })()
 
-        await flushGC()
-
-        expect(probe.deref()).toBeUndefined()
+        expect(await waitForGC(probe)).toBe(true)
         const fresh = handle.view(heads)
         expect(fresh).not.toBe(probe.deref())
       }

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../src/Repo.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
+import { flushGC } from "./helpers/flushGC.js"
 import {
   AnyDocumentId,
   UrlHeads,
@@ -653,6 +654,43 @@ describe("Repo", () => {
         const handleCacheSize = Object.keys(repo.handles).length
         await repo.removeFromCache(badDocumentId)
         assert(Object.keys(repo.handles).length === handleCacheSize)
+      })
+
+      // Skipped: removeFromCache today does not detach the listeners that
+      // DocSynchronizer and Repo.#saveFn add to the handle. Those listener
+      // closures form a cycle (DocHandle.events → closure → DocSynchronizer
+      // → DocSynchronizer.#handle → DocHandle), and combined with internal
+      // state — pending throttle timers, the XState actor, the saveDoc
+      // promise chain — the cycle does not get reclaimed even after a long
+      // pause and many GC cycles. Making this pass would require an
+      // explicit teardown step in removeFromCache (e.g. handle.removeAll
+      // Listeners() once the synchronizer/storage subsystems are detached).
+      // That's a behavior change with potential user-visible implications,
+      // so it's deliberately out of scope here. The WeakValueMap migration
+      // of #viewCache is still correct (see the view() GC test in
+      // DocHandle.test.ts which passes).
+      it.skip("removeFromCache lets the parent + view handle become GC-eligible", async () => {
+        const { repo } = setup()
+
+        // Scope strong references inside an inner function so they don't
+        // pin the values via the test stack frame after we drop them.
+        const { parentRef, viewRef, documentId } = (() => {
+          const handle = repo.create<TestDoc>({ foo: "bar" })
+          handle.change(d => (d.foo = "baz"))
+          const view = handle.view(handle.heads()!)
+          return {
+            parentRef: new WeakRef(handle),
+            viewRef: new WeakRef(view),
+            documentId: handle.documentId,
+          }
+        })()
+
+        await repo.removeFromCache(documentId)
+        await pause(500)
+        await flushGC(10)
+
+        expect(parentRef.deref()).toBeUndefined()
+        expect(viewRef.deref()).toBeUndefined()
       })
     })
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../src/Repo.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
-import { flushGC } from "./helpers/flushGC.js"
+import { waitForGC } from "./helpers/flushGC.js"
 import {
   AnyDocumentId,
   UrlHeads,
@@ -687,10 +687,14 @@ describe("Repo", () => {
 
         await repo.removeFromCache(documentId)
         await pause(500)
-        await flushGC(10)
 
-        expect(parentRef.deref()).toBeUndefined()
-        expect(viewRef.deref()).toBeUndefined()
+        expect(
+          await waitForGC(
+            () =>
+              parentRef.deref() === undefined && viewRef.deref() === undefined,
+            5000
+          )
+        ).toBe(true)
       })
     })
 

--- a/packages/automerge-repo/test/WeakValueMap.test.ts
+++ b/packages/automerge-repo/test/WeakValueMap.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest"
+import { WeakValueMap } from "../src/helpers/WeakValueMap.js"
+import { flushGC, gcAvailable } from "./helpers/flushGC.js"
+
+const itGC = gcAvailable ? it : it.skip
+
+class Box {
+  constructor(public n: number) {}
+}
+
+describe("WeakValueMap — synchronous behavior", () => {
+  it("set/get round-trips with string keys", () => {
+    const m = new WeakValueMap<string, Box>()
+    const v = new Box(1)
+    m.set("a", v)
+    expect(m.get("a")).toBe(v)
+    expect(m.has("a")).toBe(true)
+  })
+
+  it("set/get round-trips with number keys", () => {
+    const m = new WeakValueMap<number, Box>()
+    const v = new Box(2)
+    m.set(42, v)
+    expect(m.get(42)).toBe(v)
+  })
+
+  it("get returns undefined for missing keys", () => {
+    const m = new WeakValueMap<string, Box>()
+    expect(m.get("missing")).toBeUndefined()
+    expect(m.has("missing")).toBe(false)
+  })
+
+  it("delete removes the entry", () => {
+    const m = new WeakValueMap<string, Box>()
+    const v = new Box(3)
+    m.set("a", v)
+    expect(m.delete("a")).toBe(true)
+    expect(m.get("a")).toBeUndefined()
+    expect(m.delete("a")).toBe(false)
+  })
+
+  it("set overwrites with the new value", () => {
+    const m = new WeakValueMap<string, Box>()
+    const v1 = new Box(1)
+    const v2 = new Box(2)
+    m.set("a", v1)
+    m.set("a", v2)
+    expect(m.get("a")).toBe(v2)
+  })
+
+  it("getOrCompute calls the factory only on miss", () => {
+    const m = new WeakValueMap<string, Box>()
+    let calls = 0
+    const factory = () => {
+      calls++
+      return new Box(7)
+    }
+    const a = m.getOrCompute("k", factory)
+    const b = m.getOrCompute("k", factory)
+    expect(a).toBe(b)
+    expect(calls).toBe(1)
+  })
+})
+
+describe("WeakValueMap — GC behavior", () => {
+  itGC("evicts the entry once the value is collected", async () => {
+    const m = new WeakValueMap<string, Box>()
+    let probe!: WeakRef<Box>
+
+      // Scope the strong reference to an inner block so it doesn't pin the
+      // value via the test stack frame.
+    ;(() => {
+      const v = new Box(1)
+      m.set("k", v)
+      probe = new WeakRef(v)
+    })()
+
+    await flushGC()
+
+    expect(probe.deref()).toBeUndefined()
+    expect(m.get("k")).toBeUndefined()
+    // Observable proof the entry is gone: the factory runs again.
+    let factoryCalled = false
+    const fresh = m.getOrCompute("k", () => {
+      factoryCalled = true
+      return new Box(2)
+    })
+    expect(factoryCalled).toBe(true)
+    expect(fresh).toBeInstanceOf(Box)
+  })
+
+  itGC("retains the entry while the value is still referenced", async () => {
+    const m = new WeakValueMap<string, Box>()
+    const kept = new Box(1)
+    m.set("k", kept)
+
+    await flushGC()
+
+    expect(m.get("k")).toBe(kept)
+  })
+
+  itGC("overwrite unregisters the previous value's finalizer", async () => {
+    // If set() did not unregister the previous value's token, then once
+    // v1 is collected its finalizer would delete the "k" entry — even
+    // though v2 is still alive.
+    const m = new WeakValueMap<string, Box>()
+    const v2 = new Box(2)
+
+    ;(() => {
+      const v1 = new Box(1)
+      m.set("k", v1)
+      m.set("k", v2)
+    })()
+
+    await flushGC()
+
+    expect(m.get("k")).toBe(v2)
+  })
+
+  itGC("evicts many entries when all values are dropped", async () => {
+    const m = new WeakValueMap<number, Box>()
+    const probes: WeakRef<Box>[] = []
+
+    ;(() => {
+      for (let i = 0; i < 1000; i++) {
+        const v = new Box(i)
+        m.set(i, v)
+        probes.push(new WeakRef(v))
+      }
+    })()
+
+    await flushGC()
+
+    const alive = probes.filter(r => r.deref() !== undefined).length
+    expect(alive).toBe(0)
+    // Observable proof keys are gone: factory runs for every key.
+    let factoryCalls = 0
+    for (let i = 0; i < 1000; i++) {
+      m.getOrCompute(i, () => {
+        factoryCalls++
+        return new Box(-1)
+      })
+    }
+    expect(factoryCalls).toBe(1000)
+  })
+})

--- a/packages/automerge-repo/test/WeakValueMap.test.ts
+++ b/packages/automerge-repo/test/WeakValueMap.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { WeakValueMap } from "../src/helpers/WeakValueMap.js"
-import { flushGC, gcAvailable } from "./helpers/flushGC.js"
+import { flushGC, gcAvailable, waitForGC } from "./helpers/flushGC.js"
 
 const itGC = gcAvailable ? it : it.skip
 
@@ -75,9 +75,7 @@ describe("WeakValueMap — GC behavior", () => {
       probe = new WeakRef(v)
     })()
 
-    await flushGC()
-
-    expect(probe.deref()).toBeUndefined()
+    expect(await waitForGC(probe)).toBe(true)
     expect(m.get("k")).toBeUndefined()
     // Observable proof the entry is gone: the factory runs again.
     let factoryCalled = false
@@ -94,6 +92,9 @@ describe("WeakValueMap — GC behavior", () => {
     const kept = new Box(1)
     m.set("k", kept)
 
+    // Negative assertion: the value is strongly held, so a best-effort GC
+    // should NOT collect it. waitForGC would always time out here, so use
+    // the fixed-rounds variant.
     await flushGC()
 
     expect(m.get("k")).toBe(kept)
@@ -105,15 +106,15 @@ describe("WeakValueMap — GC behavior", () => {
     // though v2 is still alive.
     const m = new WeakValueMap<string, Box>()
     const v2 = new Box(2)
-
+    let v1Probe!: WeakRef<Box>
     ;(() => {
       const v1 = new Box(1)
       m.set("k", v1)
       m.set("k", v2)
+      v1Probe = new WeakRef(v1)
     })()
 
-    await flushGC()
-
+    expect(await waitForGC(v1Probe)).toBe(true)
     expect(m.get("k")).toBe(v2)
   })
 
@@ -129,10 +130,10 @@ describe("WeakValueMap — GC behavior", () => {
       }
     })()
 
-    await flushGC()
-
-    const alive = probes.filter(r => r.deref() !== undefined).length
-    expect(alive).toBe(0)
+    // 1000 entries — give the engine a wider budget than the default 1s.
+    expect(
+      await waitForGC(() => probes.every(r => r.deref() === undefined), 5000)
+    ).toBe(true)
     // Observable proof keys are gone: factory runs for every key.
     let factoryCalls = 0
     for (let i = 0; i < 1000; i++) {

--- a/packages/automerge-repo/test/helpers/flushGC.ts
+++ b/packages/automerge-repo/test/helpers/flushGC.ts
@@ -1,0 +1,22 @@
+/**
+ * Force a few GC cycles and yield long enough for FinalizationRegistry
+ * callbacks to run. Multiple rounds because young-generation collection
+ * may not promote/finalize on the first sweep.
+ *
+ * Requires the test runner to expose `globalThis.gc` (run with --expose-gc).
+ * Use the `itGC` guard if your test should skip cleanly when unavailable.
+ */
+export async function flushGC(rounds = 3): Promise<void> {
+  if (typeof globalThis.gc !== "function") {
+    throw new Error(
+      "flushGC requires --expose-gc; configure vitest poolOptions.{forks,threads}.execArgv"
+    )
+  }
+  for (let i = 0; i < rounds; i++) {
+    globalThis.gc()
+    await new Promise(resolve => setImmediate(resolve))
+  }
+}
+
+/** Skip-when-unavailable guard for GC-dependent tests. */
+export const gcAvailable = typeof globalThis.gc === "function"

--- a/packages/automerge-repo/test/helpers/flushGC.ts
+++ b/packages/automerge-repo/test/helpers/flushGC.ts
@@ -1,20 +1,129 @@
 /**
- * Force a few GC cycles and yield long enough for FinalizationRegistry
- * callbacks to run. Multiple rounds because young-generation collection
- * may not promote/finalize on the first sweep.
+ * Test helpers for GC-dependent tests.
  *
  * Requires the test runner to expose `globalThis.gc` (run with --expose-gc).
- * Use the `itGC` guard if your test should skip cleanly when unavailable.
+ * Use {@link gcAvailable} (or the `itGC` pattern) to skip cleanly when
+ * unavailable:
+ *
+ *   const itGC = gcAvailable ? it : it.skip
+ *   itGC("...", async () => { ... })
+ *
+ * Two flavors are exported:
+ *   - {@link waitForGC} — adaptive: poll a WeakRef (or predicate) until
+ *     collection is observed or `timeoutMs` elapses. Use for *positive*
+ *     collection assertions.
+ *   - {@link flushGC} — fixed: fire `rounds` GC cycles unconditionally. Use
+ *     for *negative* assertions (something is strongly held and should still
+ *     be present after a best-effort GC).
+ *
+ * ## CI flakiness defenses
+ *
+ * GC tests are inherently engine-timing-dependent and have a reputation for
+ * being flaky. The defenses here are deliberate:
+ *
+ *   - **Adaptive polling, not fixed sleeps.** {@link waitForGC} exits as
+ *     soon as collection is observed, so a fast engine pays ~5 ms while a
+ *     loaded CI machine still gets the full timeout budget. No wall-clock
+ *     "wait N seconds and hope" anywhere in the success path.
+ *   - **Timeout is a failure budget, not a wait.** The success path never
+ *     pays the timeout. The 1 s default exists only so a genuine leak
+ *     surfaces as a deterministic failed assertion within bounded time
+ *     instead of hanging the suite.
+ *   - **Boolean return + explicit `expect(...).toBe(true)`.** A timeout
+ *     turns into a loud failed assertion, never a silent pass. Compare
+ *     `await flushGC(); expect(probe.deref()).toBeUndefined()`, where a
+ *     missed collection produces a useful error only by luck of which
+ *     assertion fires first.
+ *   - **Macrotask yield is mandatory.** V8 retains the value returned by
+ *     `WeakRef.deref()` until the end of the current Job — and microtask
+ *     boundaries (`Promise.resolve()`, `queueMicrotask`) empirically do
+ *     NOT release that pin. We use `setImmediate`. The loop in
+ *     {@link waitForGC} also orders check-then-yield-then-gc so the pin
+ *     from the previous iteration's deref is released before the next
+ *     `gc()` runs.
+ *   - **Vitest fake timers do not apply.** Fake timers mock `setTimeout` /
+ *     `setImmediate` / `Date`, but `globalThis.gc()` and
+ *     `FinalizationRegistry` callbacks are V8 internals and are not
+ *     faked. Real macrotask yields are required for finalizers to drain.
  */
-export async function flushGC(rounds = 3): Promise<void> {
-  if (typeof globalThis.gc !== "function") {
+
+const callGC = (): void => {
+  const gc = globalThis.gc
+  if (typeof gc !== "function") {
     throw new Error(
-      "flushGC requires --expose-gc; configure vitest poolOptions.{forks,threads}.execArgv"
+      "GC helpers require --expose-gc; configure vitest test.execArgv"
     )
   }
+  // Use the no-arg form. Empirically (Node 20), passing the options object
+  // — even `{ execution: "sync", type: "major" }` — leaves WeakRef targets
+  // observably alive after a setImmediate yield, while `gc()` collects them.
+  // The no-arg default is full-mark-sweep on V8/Node, which is what we want.
+  gc()
+}
+
+const yieldForFinalizers = (): Promise<void> =>
+  // setImmediate yields the macrotask queue, which drains microtasks first —
+  // FinalizationRegistry callbacks are scheduled as microtasks, so they run
+  // before the next round.
+  new Promise(resolve => setImmediate(resolve))
+
+/**
+ * Force GC cycles and yield until `target` is satisfied, or `timeoutMs`
+ * elapses. `target` may be:
+ *   - a `WeakRef`, satisfied once `.deref()` returns `undefined`
+ *   - a predicate, satisfied once it returns `true`
+ *
+ * Returns `true` if observed before the timeout, `false` on timeout. Always
+ * test the boolean explicitly so a CI miss is a loud failed assertion:
+ *
+ *   expect(await waitForGC(probe)).toBe(true)
+ *
+ * `timeoutMs` is a *failure budget*, not a wait. The loop exits as soon as
+ * collection is observed (typically 2 iterations / a few ms), so success
+ * never pays the timeout. The default 1 s exists so a genuine leak fails
+ * deterministically within bounded time instead of hanging the suite.
+ *
+ * Loop ordering matters. `WeakRef.deref()` retains the returned value until
+ * the end of the current Job (V8's kept-alive list, cleared at macrotask
+ * boundaries — microtask yields like `Promise.resolve()` are NOT enough).
+ * The order is:
+ *   1. check predicate (may deref → pins value for this Job)
+ *   2. yield (macrotask boundary releases the pin)
+ *   3. gc() (now able to collect)
+ *   4. yield (FinalizationRegistry callbacks fire)
+ * Putting gc() before the yield-after-check would re-pin via the next
+ * iteration's check before gc could collect — empirically this never
+ * converges.
+ */
+export async function waitForGC(
+  target: WeakRef<WeakKey> | (() => boolean),
+  timeoutMs = 1000
+): Promise<boolean> {
+  const isDone =
+    typeof target === "function"
+      ? target
+      : (): boolean => target.deref() === undefined
+
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (isDone()) return true
+    await yieldForFinalizers()
+    callGC()
+    await yieldForFinalizers()
+  }
+  return false
+}
+
+/**
+ * Fire a fixed number of GC cycles, yielding for finalizer callbacks between
+ * each. Use when there is no specific WeakRef to await — e.g. asserting that
+ * a strongly-held value is *not* collected. For positive collection
+ * assertions prefer {@link waitForGC}.
+ */
+export async function flushGC(rounds = 3): Promise<void> {
   for (let i = 0; i < rounds; i++) {
-    globalThis.gc()
-    await new Promise(resolve => setImmediate(resolve))
+    callGC()
+    await yieldForFinalizers()
   }
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
     // instanceof tests when going back and forth from wasm-bindgen
     environment: "happy-dom",
 
+    // Expose globalThis.gc to test workers so GC-dependent tests can opt in.
+    // Vitest 4 reads `test.execArgv` per project (cli-api: project.config.execArgv);
+    // poolOptions on its own doesn't reach project workers under `projects`.
+    execArgv: ["--expose-gc"],
+
     coverage: {
       provider: "v8",
       reporter: ["lcov", "text", "html"],


### PR DESCRIPTION
- `#refCache` previously used `Map<string, WeakRef>`, which is essentially same as `WeakValueMap` (included in PR).  But `WeakValueMap` has additional benefit of cleaning up dead string keys.  So there is no real functional change other than deleting dead string keys. (which I think is a good thing)
- `#viewCache` previously used strong refs and each entry pined a full `A.clone(doc)`. 
    - I think it was an oversight to not use a similar `Map<string, WeakRef>` for the `#viewCache` like `#refCache`
    - The functional change is that the `#viewCache` no longer prevents garbage collection if the user stops holding a strong ref to the view handle. (This is a good thing. As a user, I want garbage collection.)
     - view handles are never registered with storage or sync subsystems, and nothing holds a strong ref unless the automerge-repo user does, so the previous behavior (of holding onto the view handles strongly) meant garbage collection didn't happen without `Repo.removeFromCache()`
     - new behavior: `view()` has no side effects beyond cloning. A re-clone on cache miss is a performance hit (full doc clone) but not a correctness hit.  I think the re-clone on cache miss is acceptable in order to benefit from garbage collection when the automerge-repo users stop holding strong references.
- To keep code DRY for the 2 caches (`#refCache` and `#viewCache`), and to add benefit of cleaning up dead key strings (lazily), I implemented `WeakValueMap`.
