### PR TITLE
Clear per-peer SyncState on disconnect

### DIFF
--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -308,6 +308,7 @@ export class DocSynchronizer extends Synchronizer {
     this.#log(`removing peer ${peerId}`)
     this.#peers = this.#peers.filter(p => p !== peerId)
     delete this.#peerDocumentStatuses[peerId]
+    delete this.#syncStates[peerId]
     this.#checkDocUnavailable()
   }
 


### PR DESCRIPTION
## Summary

`DocSynchronizer.endSync(peerId)` removes the peer from `#peers` and `#peerDocumentStatuses` but leaves `#syncStates[peerId]` behind. Each entry holds a WASM-backed `Automerge.SyncState`, so on a long-running sync server with reconnecting clients you accumulate one leaked `SyncState` per (peer, document) pair for the lifetime of the process.

This adds a one-line cleanup. On reconnect, `beginSync` re-creates a fresh `SyncState` via the existing `onLoadSyncState` path, so behavior is unchanged beyond the memory freed.

```diff
     endSync(peerId: PeerId) {
       this.#log(`removing peer ${peerId}`)
       this.#peers = this.#peers.filter(p => p !== peerId)
       delete this.#peerDocumentStatuses[peerId]
+      delete this.#syncStates[peerId]
       this.#checkDocUnavailable()
     }
```

Refs automerge/automerge#903.

## Test plan

- The existing `DocSynchronizer > "still syncs with a peer after it disconnects and reconnects"` test already exercises `endSync` followed by `beginSync` on the same peer; it continues to pass.
- All 652 existing tests pass on Node 20.