### PR TITLE
Add opt-in idle eviction for handleCache (#358)

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -84,6 +84,12 @@ export class Repo extends EventEmitter<RepoEvents> {
   #saveFn: (payload: DocHandleEncodedChangePayload<any>) => void
 
   #handleCache: Record<DocumentId, DocHandle<any>> = {}
+  #lastActivity: Record<DocumentId, number> = {}
+  #evictionIntervalId: ReturnType<typeof setInterval> | null = null
+  #evictionInFlight = false
+  #touchOnHeadsChanged = ({ handle }: DocHandleEncodedChangePayload<any>) => {
+    this.#touch(handle.documentId)
+  }
 
   /** @hidden */
   synchronizer: CollectionSynchronizer
@@ -117,6 +123,8 @@ export class Repo extends EventEmitter<RepoEvents> {
     denylist = [],
     saveDebounceRate = 100,
     idFactory,
+    idleEvictionMs,
+    idleScanIntervalMs,
   }: RepoConfig = {}) {
     super()
     this.#remoteHeadsGossipingEnabled = enableRemoteHeadsGossiping
@@ -253,6 +261,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     })
 
     this.synchronizer.on("sync-state", message => {
+      this.#touch(message.documentId)
       this.#saveSyncState(message)
 
       const handle = this.#handleCache[message.documentId]
@@ -322,6 +331,17 @@ export class Repo extends EventEmitter<RepoEvents> {
         }
       )
     }
+
+    if ((idleEvictionMs ?? 0) > 0 && (idleScanIntervalMs ?? 0) > 0) {
+      const interval = setInterval(() => {
+        void this.#evictIdleHandles(idleEvictionMs!)
+      }, idleScanIntervalMs)
+      // Don't keep the event loop alive for the eviction timer.
+      if (typeof interval === "object" && "unref" in interval) {
+        interval.unref()
+      }
+      this.#evictionIntervalId = interval
+    }
   }
 
   // The `document` event is fired by the DocCollection any time we create a new document or look
@@ -333,6 +353,17 @@ export class Repo extends EventEmitter<RepoEvents> {
       if (!existingListeners.some(listener => listener === this.#saveFn)) {
         // Save when the document changes
         handle.on("heads-changed", this.#saveFn)
+      }
+    }
+
+    // Touch lastActivity on every doc change so local edits with no peers
+    // (offline writers) keep the handle alive against idle eviction.
+    if (this.#evictionIntervalId !== null) {
+      const headsListeners = handle.listeners("heads-changed")
+      if (
+        !headsListeners.some(listener => listener === this.#touchOnHeadsChanged)
+      ) {
+        handle.on("heads-changed", this.#touchOnHeadsChanged)
       }
     }
 
@@ -404,6 +435,8 @@ export class Repo extends EventEmitter<RepoEvents> {
     /** The documentId of the handle to look up or create */
     documentId: DocumentId /** If we know we're creating a new document, specify this so we can have access to it immediately */
   }) {
+    this.#touch(documentId)
+
     // If we have the handle cached, return it
     if (this.#handleCache[documentId]) return this.#handleCache[documentId]
 
@@ -415,6 +448,45 @@ export class Repo extends EventEmitter<RepoEvents> {
     )
     this.#handleCache[documentId] = handle
     return handle
+  }
+
+  #touch(documentId: DocumentId) {
+    if (this.#evictionIntervalId !== null) {
+      this.#lastActivity[documentId] = Date.now()
+    }
+  }
+
+  async #evictIdleHandles(idleMs: number) {
+    // Single-flight: skip this tick if a previous tick is still running.
+    // Without this, a stalled removeFromCache (e.g., handle stuck in
+    // REQUESTING) lets ticks stack and race over #handleCache.
+    if (this.#evictionInFlight) return
+    this.#evictionInFlight = true
+    try {
+      const cutoff = Date.now() - idleMs
+      const MAX_EVICTIONS_PER_SCAN = 100
+      let evicted = 0
+      for (const documentId of Object.keys(this.#handleCache) as DocumentId[]) {
+        if (evicted >= MAX_EVICTIONS_PER_SCAN) break
+        const lastActive = this.#lastActivity[documentId]
+        if (lastActive === undefined || lastActive > cutoff) continue
+        const docSync = this.synchronizer.docSynchronizers[documentId]
+        if (
+          docSync &&
+          this.synchronizer.peers.some(peerId => docSync.hasPeer(peerId))
+        ) {
+          continue
+        }
+        try {
+          await this.removeFromCache(documentId)
+        } catch (err) {
+          this.#log("idle-eviction failed", { documentId, err })
+        }
+        if (!this.#handleCache[documentId]) evicted++
+      }
+    } finally {
+      this.#evictionInFlight = false
+    }
   }
 
   /** Returns all the handles we have cached. */
@@ -565,6 +637,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     const { documentId, heads } = isValidAutomergeUrl(id)
       ? parseAutomergeUrl(id)
       : { documentId: interpretAsDocumentId(id), heads: undefined }
+    this.#touch(documentId)
 
     // Check handle cache first - return plain FindStep for terminal states
     if (this.#handleCache[documentId]) {
@@ -775,6 +848,8 @@ export class Repo extends EventEmitter<RepoEvents> {
    * Loads a document without waiting for ready state
    */
   async #loadDocument<T>(documentId: DocumentId): Promise<DocHandle<T>> {
+    this.#touch(documentId)
+
     // If we have the handle cached, return it
     if (this.#handleCache[documentId]) {
       return this.#handleCache[documentId]
@@ -842,6 +917,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     delete this.#handleCache[documentId]
     delete this.#progressCache[documentId]
     delete this.#saveFns[documentId]
+    delete this.#lastActivity[documentId]
     this.emit("delete-document", { documentId })
   }
 
@@ -948,7 +1024,7 @@ export class Repo extends EventEmitter<RepoEvents> {
       )
       return
     }
-    const handle = this.#getHandle({ documentId })
+    const handle = this.#handleCache[documentId]
     await handle.whenReady([READY, UNLOADED, DELETED, UNAVAILABLE])
     const doc = handle.doc()
     // because this is an internal-ish function, we'll be extra careful about undefined docs here
@@ -963,6 +1039,7 @@ export class Repo extends EventEmitter<RepoEvents> {
       delete this.#handleCache[documentId]
       delete this.#progressCache[documentId]
       delete this.#saveFns[documentId]
+      delete this.#lastActivity[documentId]
       this.synchronizer.removeDocument(documentId)
     } else {
       this.#log(
@@ -972,6 +1049,10 @@ export class Repo extends EventEmitter<RepoEvents> {
   }
 
   shutdown(): Promise<void> {
+    if (this.#evictionIntervalId !== null) {
+      clearInterval(this.#evictionIntervalId)
+      this.#evictionIntervalId = null
+    }
     this.networkSubsystem.adapters.forEach(adapter => {
       adapter.disconnect()
     })
@@ -1034,6 +1115,17 @@ export interface RepoConfig {
    * The debounce rate in milliseconds for saving documents. Defaults to 100ms.
    */
   saveDebounceRate?: number
+
+  /**
+   * Bound `handleCache` memory on long-running processes (sync servers).
+   * A handle idle for at least `idleEvictionMs` becomes eligible for
+   * eviction; handles with connected peers are never evicted. Leave unset
+   * on short-lived clients (browser tabs). Pair with `idleScanIntervalMs`.
+   */
+  idleEvictionMs?: number
+
+  /** Scan period (ms) for idle eviction. See {@link idleEvictionMs}. */
+  idleScanIntervalMs?: number
 
   // This is hidden for now because it's an experimental API, mostly here in order
   // for keyhive to be able to control the ID generation

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -656,6 +656,67 @@ describe("Repo", () => {
       })
     })
 
+    describe("idle eviction", () => {
+      it("does not evict any handles when idleEvictionMs/idleScanIntervalMs are unset", async () => {
+        const { repo } = setup()
+        const handle = repo.create<TestDoc>()
+        await pause(50)
+        assert(repo.handles[handle.documentId])
+        await repo.shutdown()
+      })
+
+      it("evicts an idle handle once idleEvictionMs has elapsed", async () => {
+        const repo = new Repo({
+          idleEvictionMs: 30,
+          idleScanIntervalMs: 10,
+        })
+        const handle = repo.create<TestDoc>()
+        assert(repo.handles[handle.documentId])
+        // Wait long enough for the handle to idle past idleEvictionMs and
+        // for at least one scan tick to fire.
+        await pause(80)
+        assert.equal(repo.handles[handle.documentId], undefined)
+        await repo.shutdown()
+      })
+
+      it("does not evict a handle that find() touched within idleEvictionMs", async () => {
+        const repo = new Repo({
+          idleEvictionMs: 80,
+          idleScanIntervalMs: 10,
+        })
+        const handle = repo.create<TestDoc>()
+        await pause(50)
+        await repo.find<TestDoc>(handle.url)
+        await pause(50)
+        assert(repo.handles[handle.documentId])
+        await pause(80)
+        assert.equal(repo.handles[handle.documentId], undefined)
+        await repo.shutdown()
+      })
+
+      it("does not evict a handle that has at least one active peer", async () => {
+        const repo = new Repo({
+          idleEvictionMs: 30,
+          idleScanIntervalMs: 10,
+        })
+        const handle = repo.create<TestDoc>()
+        // Pretend a peer is actively syncing this doc. The eviction scan must
+        // skip handles with peers regardless of idleness.
+        repo.synchronizer.addPeer("fake-peer" as PeerId)
+        await pause(80)
+        assert(repo.handles[handle.documentId])
+        await repo.shutdown()
+      })
+
+      it("does not enable activity tracking when eviction is disabled", () => {
+        const { repo } = setup()
+        const handle = repo.create<TestDoc>()
+        // No touchOnHeadsChanged listener should be attached when eviction is off.
+        // setup() registers exactly one heads-changed listener (the save fn).
+        assert.equal(handle.listenerCount("heads-changed"), 1)
+      })
+    })
+
     describe("registerHandleWithSubsystems", () => {
       it("registers document with synchronizer when creating a new document", async () => {
         const { repo } = setup()

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -2,7 +2,7 @@ import { next as A, Heads } from "@automerge/automerge"
 import { MessageChannelNetworkAdapter } from "../../automerge-repo-network-messagechannel/src/index.js"
 import assert from "assert"
 import * as Uuid from "uuid"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   encodeHeads,
   getHeadsFromUrl,
@@ -658,54 +658,98 @@ describe("Repo", () => {
 
     describe("idle eviction", () => {
       it("does not evict any handles when idleEvictionMs/idleScanIntervalMs are unset", async () => {
+        vi.useFakeTimers()
         const { repo } = setup()
-        const handle = repo.create<TestDoc>()
-        await pause(50)
-        assert(repo.handles[handle.documentId])
-        await repo.shutdown()
+        try {
+          const handle = repo.create<TestDoc>()
+          await vi.advanceTimersByTimeAsync(100)
+          assert(repo.handles[handle.documentId])
+        } finally {
+          try {
+            await repo.shutdown()
+          } finally {
+            vi.useRealTimers()
+          }
+        }
       })
 
       it("evicts an idle handle once idleEvictionMs has elapsed", async () => {
+        vi.useFakeTimers()
+        const idleEvictionMs = 30
+        const idleScanIntervalMs = 10
         const repo = new Repo({
-          idleEvictionMs: 30,
-          idleScanIntervalMs: 10,
+          idleEvictionMs,
+          idleScanIntervalMs,
         })
-        const handle = repo.create<TestDoc>()
-        assert(repo.handles[handle.documentId])
-        // Wait long enough for the handle to idle past idleEvictionMs and
-        // for at least one scan tick to fire.
-        await pause(80)
-        assert.equal(repo.handles[handle.documentId], undefined)
-        await repo.shutdown()
+        try {
+          const handle = repo.create<TestDoc>()
+          assert(repo.handles[handle.documentId])
+
+          await vi.advanceTimersByTimeAsync(idleEvictionMs)
+          assert.equal(repo.handles[handle.documentId], undefined)
+        } finally {
+          try {
+            await repo.shutdown()
+          } finally {
+            vi.useRealTimers()
+          }
+        }
       })
 
       it("does not evict a handle that find() touched within idleEvictionMs", async () => {
+        vi.useFakeTimers()
+        const idleEvictionMs = 80
+        const idleScanIntervalMs = 10
+        const almostIdleMs = idleEvictionMs - idleScanIntervalMs
         const repo = new Repo({
-          idleEvictionMs: 80,
-          idleScanIntervalMs: 10,
+          idleEvictionMs,
+          idleScanIntervalMs,
         })
-        const handle = repo.create<TestDoc>()
-        await pause(50)
-        await repo.find<TestDoc>(handle.url)
-        await pause(50)
-        assert(repo.handles[handle.documentId])
-        await pause(80)
-        assert.equal(repo.handles[handle.documentId], undefined)
-        await repo.shutdown()
+        try {
+          const handle = repo.create<TestDoc>()
+
+          await vi.advanceTimersByTimeAsync(almostIdleMs)
+          await repo.find<TestDoc>(handle.url)
+
+          await vi.advanceTimersByTimeAsync(almostIdleMs)
+          assert(repo.handles[handle.documentId])
+
+          await vi.advanceTimersByTimeAsync(idleScanIntervalMs)
+          assert.equal(repo.handles[handle.documentId], undefined)
+        } finally {
+          try {
+            await repo.shutdown()
+          } finally {
+            vi.useRealTimers()
+          }
+        }
       })
 
       it("does not evict a handle that has at least one active peer", async () => {
+        vi.useFakeTimers()
+        const idleEvictionMs = 30
+        const idleScanIntervalMs = 10
         const repo = new Repo({
-          idleEvictionMs: 30,
-          idleScanIntervalMs: 10,
+          idleEvictionMs,
+          idleScanIntervalMs,
         })
-        const handle = repo.create<TestDoc>()
-        // Pretend a peer is actively syncing this doc. The eviction scan must
-        // skip handles with peers regardless of idleness.
-        repo.synchronizer.addPeer("fake-peer" as PeerId)
-        await pause(80)
-        assert(repo.handles[handle.documentId])
-        await repo.shutdown()
+        try {
+          const handle = repo.create<TestDoc>()
+          const peerId = "fake-peer" as PeerId
+          const peerOpened = eventPromise(repo.synchronizer, "open-doc")
+
+          repo.synchronizer.addPeer(peerId)
+          await peerOpened
+
+          await vi.advanceTimersByTimeAsync(idleEvictionMs + idleScanIntervalMs)
+          assert(repo.handles[handle.documentId])
+        } finally {
+          try {
+            await repo.shutdown()
+          } finally {
+            vi.useRealTimers()
+          }
+        }
       })
 
       it("does not enable activity tracking when eviction is disabled", () => {


### PR DESCRIPTION
## Summary

Fixes #358.

`Repo#handleCache` grows without bound: every doc that gets opened stays in memory until the process exits. On a long-running sync server with many docs and reconnecting clients, that's a memory leak in practice.

Adds two opt-in `RepoConfig` options:

- `idleEvictionMs`: handle is eligible for eviction after this many ms with no activity.
- `idleScanIntervalMs`: period of the eviction scan.

Both unset (the default) disables eviction entirely. No listeners are attached, no timestamps recorded, no `setInterval` scheduled. Existing consumers pay nothing.

When enabled, activity is tracked on four signals:

- `#getHandle` access (`create` / imports / cache misses)
- cached `find` / `findWithProgress` / `findClassic` access
- synchronizer `sync-state` events (incoming peer traffic)
- `DocHandle` `heads-changed` events (covers offline local writes)

The scan walks `#handleCache`, skips handles touched within `idleEvictionMs`, skips handles that still have at least one peer, and calls the existing public `removeFromCache()` for the rest. `removeFromCache` already takes care of `synchronizer.removeDocument`, `progressCache`, and `saveFns` cleanup.

Notable details:

- **Single-flight**: a tick is skipped if the previous one is still running, so a slow `removeFromCache` (e.g. a handle stuck in `REQUESTING`) can't stack ticks and race over `#handleCache`.
- **Per-tick cap (100 successful evictions)** bounds evictions per scan.
- `setInterval(...).unref()` so the timer never blocks process exit.
- `shutdown()` clears the interval.

A doc that's held externally but quiet for longer than `idleEvictionMs` and has no peers will be evicted and re-loaded from storage on next access.

## Why a heuristic rather than `WeakRef` + `FinalizationRegistry`

The thread on #358 discusses an `InternalDocHandle` + `DocHandle` split using `WeakRef` and `FinalizationRegistry`. This PR takes a simpler route on purpose:

- Stays inside the existing public API (`removeFromCache`).
- Deterministic to test, no GC timing dependence.
- Opt-in, so the risk surface for existing consumers is zero.
- Trivially removable if a more sophisticated approach lands later.

## Test plan

Five new tests in `Repo.test.ts > local only > idle eviction`:

- `does not evict any handles when idleEvictionMs/idleScanIntervalMs are unset`: confirms the default no-op path.
- `evicts an idle handle once idleEvictionMs has elapsed`: basic happy path.
- `treats a cached find as activity`: confirms cached handle access refreshes idleness.
- `does not evict a handle that has at least one active peer`: confirms the peers-skip gate.
- `does not enable activity tracking when eviction is disabled`: confirms no `heads-changed` listener is attached when off.

Local verification:

- `pnpm vitest run packages/automerge-repo/test/Repo.test.ts`
- `pnpm -F @automerge/automerge-repo build`
- `pnpm prettier --check packages/automerge-repo/src/Repo.ts packages/automerge-repo/test/Repo.test.ts`
