### PR TITLE
fix: drop sync messages for documents evicted mid-receive

### DIFF
--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -138,6 +138,19 @@ export class CollectionSynchronizer extends Synchronizer {
     const handle = await this.repo.find(documentId, {
       allowableStates: ["ready", "unavailable", "requesting"],
     })
+
+    // Race guard: removeFromCache may have unloaded the handle during the
+    // await above. Without this, fetchDocSynchronizer would install a fresh
+    // DocSynchronizer capturing an UNLOADED handle, queuing the message in
+    // #pendingSyncMessages forever — the peer is silently cut off from the
+    // doc until restart. Drop the message; the peer's next attempt will
+    // create a fresh handle.
+    if (handle.isUnloaded() || this.repo.handles[documentId] !== handle) {
+      log(`dropping sync message for evicted document ${documentId}`)
+      delete this.#docSetUp[documentId]
+      return
+    }
+
     const docSynchronizer = this.#fetchDocSynchronizer(handle)
 
     docSynchronizer.receiveMessage(message)

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert"
-import { beforeEach, describe, it } from "vitest"
+import { beforeEach, describe, it, vi } from "vitest"
+import { next as Automerge } from "@automerge/automerge"
 import { PeerId, Repo, SyncMessage } from "../src/index.js"
 import { CollectionSynchronizer } from "../src/synchronizer/CollectionSynchronizer.js"
 
@@ -98,4 +99,63 @@ describe("CollectionSynchronizer", () => {
       // removing document again should not throw an error
       synchronizer.removeDocument(handle.documentId)
     }))
+
+  describe("eviction race", () => {
+    // If removeFromCache runs during the await window inside
+    // CollectionSynchronizer.receiveMessage, the receive's continuation
+    // previously installed a fresh DocSynchronizer capturing an UNLOADED
+    // handle, queuing the message in #pendingSyncMessages forever — the
+    // peer is silently cut off from that doc until restart.
+    //
+    // The race window is between repo.find() reading the handle from the
+    // cache and receiveMessage's continuation calling fetchDocSynchronizer.
+    // We force the same outcome deterministically by patching repo.find to
+    // return the original handle after it has been unloaded.
+    it("drops sync messages for handles that have been unloaded mid-receive", async () => {
+      const repo = new Repo({})
+      const handle = repo.create<{ foo: string }>({ foo: "bar" })
+      await handle.whenReady()
+      const documentId = handle.documentId
+
+      // Build a sync message while the doc is still loaded
+      const [, syncData] = Automerge.generateSyncMessage(
+        handle.doc()!,
+        Automerge.initSyncState()
+      )
+      if (!syncData) throw new Error("expected sync message")
+      const syncMessage: SyncMessage = {
+        type: "sync",
+        senderId: "remote-peer" as PeerId,
+        targetId: repo.networkSubsystem.peerId,
+        documentId,
+        data: syncData,
+      }
+
+      // Patch repo.find to return the original handle even after eviction —
+      // this simulates the race outcome where receive's await find() had
+      // already grabbed the handle before removeFromCache unloaded it.
+      const originalFind = repo.find.bind(repo)
+      vi.spyOn(repo, "find").mockImplementation(async (id, options) => {
+        if (typeof id === "string" && id === documentId) {
+          return handle as never
+        }
+        return originalFind(id, options)
+      })
+
+      // Evict the doc — unloads the handle, clears it from the cache,
+      // removes its DocSynchronizer.
+      await repo.removeFromCache(documentId)
+      assert(handle.isUnloaded(), "handle should be unloaded after eviction")
+
+      // Receive a message — the patched find returns the unloaded handle,
+      // simulating the race. The guard should drop the message.
+      await repo.synchronizer.receiveMessage(syncMessage)
+
+      assert.strictEqual(
+        repo.synchronizer.docSynchronizers[documentId],
+        undefined,
+        "no DocSynchronizer should have been installed for the evicted document"
+      )
+    })
+  })
 })

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -137,7 +137,7 @@ describe("CollectionSynchronizer", () => {
       const originalFind = repo.find.bind(repo)
       vi.spyOn(repo, "find").mockImplementation(async (id, options) => {
         if (typeof id === "string" && id === documentId) {
-          return handle as never
+          return handle as unknown as ReturnType<typeof repo.find>
         }
         return originalFind(id, options)
       })


### PR DESCRIPTION
This resolves a race condition we're experiencing problems with randomly. PR #618 also resolves this race (but a different approach).  If 618 takes time to review/merge, maybe this PR can be reviewed/merged sooner as a stop gap?

CollectionSynchronizer.receiveMessage has an await on repo.find() that runs after the per-document cache lookup but before the synchronous fetchDocSynchronizer call. If removeFromCache (e.g. from a downstream LRU evictor) runs during this microtask window, the continuation captures an UNLOADED handle and installs a fresh DocSynchronizer with it. Subsequent sync messages get queued in #pendingSyncMessages and never processed — the peer is silently cut off from that document until restart.

Add a race guard after the find() await: if the handle has been unloaded or no longer matches the cached entry, drop the message and return. The peer's next attempt will create a fresh handle.

This is a stopgap targeting the legacy async receiveMessage path; the larger xstate-removal refactor in flight (#618) removes the await window structurally and obviates this guard. Lands cleanly on either.