### PR TITLE
fix(websocket): drop sends to non-OPEN sockets instead of throwing

### DIFF
--- a/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
@@ -179,8 +179,6 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
     if (this.socket.readyState !== WebSocket.OPEN) {
       // CONNECTING / CLOSING / CLOSED. Drop silently — sync state and
       // reconnect logic will replay once the socket is OPEN again.
-      // Throwing here previously surfaced as an uncaught exception
-      // through automerge-repo's event machinery (see issue #297).
       this.#log(
         `Tried to send on a non-OPEN socket (readyState=${this.socket.readyState}); dropping.`
       )

--- a/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
@@ -176,8 +176,16 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
       this.#log("Tried to send on a disconnected socket.")
       return
     }
-    if (this.socket.readyState !== WebSocket.OPEN)
-      throw new Error(`Websocket not ready (${this.socket.readyState})`)
+    if (this.socket.readyState !== WebSocket.OPEN) {
+      // CONNECTING / CLOSING / CLOSED. Drop silently — sync state and
+      // reconnect logic will replay once the socket is OPEN again.
+      // Throwing here previously surfaced as an uncaught exception
+      // through automerge-repo's event machinery (see issue #297).
+      this.#log(
+        `Tried to send on a non-OPEN socket (readyState=${this.socket.readyState}); dropping.`
+      )
+      return
+    }
 
     const encoded = cbor.encode(message)
     this.socket.send(toArrayBuffer(encoded))

--- a/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
@@ -116,6 +116,18 @@ export class WebSocketServerAdapter extends NetworkAdapter {
       return
     }
 
+    if (socket.readyState !== WebSocket.OPEN) {
+      // Peer's socket is CONNECTING / CLOSING / CLOSED. Drop silently —
+      // the underlying `ws.send()` would throw, and the throw escapes
+      // through automerge-repo's event machinery as an uncaught
+      // exception that crashes the process. Once the peer reconnects
+      // and rejoins, normal sync state resumes.
+      log(
+        `Tried to send to peer ${message.targetId} with non-OPEN socket (readyState=${socket.readyState}); dropping.`
+      )
+      return
+    }
+
     const encoded = encode(message)
     const arrayBuf = toArrayBuffer(encoded)
 

--- a/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
@@ -118,10 +118,7 @@ export class WebSocketServerAdapter extends NetworkAdapter {
 
     if (socket.readyState !== WebSocket.OPEN) {
       // Peer's socket is CONNECTING / CLOSING / CLOSED. Drop silently —
-      // the underlying `ws.send()` would throw, and the throw escapes
-      // through automerge-repo's event machinery as an uncaught
-      // exception that crashes the process. Once the peer reconnects
-      // and rejoins, normal sync state resumes.
+      // once the peer reconnects and rejoins, normal sync state resumes.
       log(
         `Tried to send to peer ${message.targetId} with non-OPEN socket (readyState=${socket.readyState}); dropping.`
       )

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -174,7 +174,13 @@ describe("Websocket adapters", () => {
       assert.throws(sendNoData, /zero/)
     })
 
-    it("should throw an error if asked to send before ready", async () => {
+    it("should silently drop sends before the socket is ready", async () => {
+      // Earlier versions of the adapter threw a "Websocket not ready"
+      // error here. That throw surfaced as an uncaught exception via
+      // automerge-repo's event machinery, crashing the host process
+      // (see issue #297). The current contract is to drop the message
+      // silently; sync state and reconnect logic will replay once the
+      // socket is OPEN.
       const port = await getPort()
 
       const serverUrl = `ws://localhost:${port}`
@@ -208,7 +214,7 @@ describe("Websocket adapters", () => {
           targetId: serverPeerId,
         })
       }
-      assert.throws(sendMessage, /not ready/)
+      assert.doesNotThrow(sendMessage)
 
       // once the server is ready, we can send
       await eventPromise(browser, "peer-candidate")
@@ -278,6 +284,48 @@ describe("Websocket adapters", () => {
       await browserRepo.networkSubsystem.whenReady()
 
       assert.deepStrictEqual(browserRepo.peers, ["server" as PeerId])
+    })
+
+    it("should not throw when send() is called on a non-OPEN socket", async () => {
+      const {
+        serverAdapter,
+        server,
+        serverUrl,
+        clients: [browser],
+      } = await setup()
+
+      const _serverRepo = new Repo({
+        network: [serverAdapter],
+        peerId: serverPeerId,
+      })
+      const browserRepo = new Repo({
+        network: [browser],
+        peerId: browserPeerId,
+      })
+
+      await browserRepo.networkSubsystem.whenReady()
+
+      // Close the underlying socket out from under the adapter. The next
+      // send() (e.g. the automatic "leave" on disconnect()) should not
+      // throw — previously this surfaced as an uncaught exception via
+      // automerge-repo's event machinery.
+      assert.ok(browser.socket)
+      browser.socket.close()
+      while (browser.socket && browser.socket.readyState !== WebSocket.CLOSED) {
+        await pause(5)
+      }
+
+      assert.doesNotThrow(() => {
+        browser.send({
+          type: "sync",
+          senderId: browserPeerId,
+          targetId: serverPeerId,
+          documentId,
+          data: new Uint8Array([1]),
+        })
+      })
+
+      server.close()
     })
   })
 
@@ -452,6 +500,46 @@ describe("Websocket adapters", () => {
         targetId: "browser",
         selectedProtocolVersion: "1",
       })
+    })
+
+    it("should not throw when send() targets a peer whose socket is non-OPEN", async () => {
+      const { serverSocket, server, serverUrl } = await setupServer()
+      const serverAdapter = new WebSocketServerAdapter(serverSocket)
+      serverAdapter.connect(serverPeerId, {
+        storageId: undefined,
+        isEphemeral: true,
+      })
+
+      const browserSocket = new WebSocket(serverUrl)
+      await once(browserSocket, "open")
+      browserSocket.send(
+        CBOR.encode({
+          type: "join",
+          senderId: browserPeerId,
+          supportedProtocolVersions: ["1"],
+        })
+      )
+      await messageOrTimeout(browserSocket)
+
+      // Close the underlying socket out from under the server adapter
+      // without giving it a chance to clean up its sockets map. The next
+      // send() to that peer must not throw — previously the underlying
+      // ws.send threw and the exception escaped uncaught.
+      browserSocket.terminate()
+      await pause(50)
+
+      assert.doesNotThrow(() => {
+        serverAdapter.send({
+          type: "sync",
+          senderId: serverPeerId,
+          targetId: browserPeerId,
+          documentId,
+          data: new Uint8Array([1]),
+        })
+      })
+
+      serverSocket.close()
+      server.close()
     })
 
     it("should ignore messages from a socket replaced by a same-peer-ID reconnect", async () => {


### PR DESCRIPTION
Closes #297 and addresses a closely-related production crash mode.

## What

Both `WebSocketClientAdapter` and `WebSocketServerAdapter` previously called `socket.send()` without a readyState gate. When the socket was CONNECTING (issue #297), CLOSING, or CLOSED, the send threw — and the throw escaped through automerge-repo's xstate-driven event machinery as an uncaught exception with no async frame to catch it, crashing the host process.

Reproduced consistently in a hybrid sync-server spike (automerge-repo `Repo` + custom Postgres `StorageAdapter` inside a Node server) any time a client disconnected mid-sync — tab close, network blip, page nav.

## Fix

Both adapters now drop sends to non-OPEN sockets silently and log via the existing `debug` channel. The library's existing sync state and reconnect logic replays once the socket is OPEN again, so the only observable change is "no crash."

## Tests

- Updated `should throw an error if asked to send before ready` → `should silently drop sends before the socket is ready` (the throw behavior was the bug, not the spec).
- Added `should not throw when send() is called on a non-OPEN socket` for the client adapter.
- Added `should not throw when send() targets a peer whose socket is non-OPEN` for the server adapter.

Full suite (`pnpm test --run`): **690 passed, 1 skipped, 0 failed**. Prettier clean.