### PR TITLE
fix: `repo.create({})` is never persisted to storage

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -47,6 +47,8 @@ import { RefImpl } from "./refs/ref.js"
 import { foreverPromise } from "./helpers/foreverPromise.js"
 import { noop } from "./helpers/noop.js"
 import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
+import { isPlainObject } from "./helpers/isPlainObject.js"
+import { hasAtLeastOneKey } from "./helpers/has-at-least-one-key.js"
 
 export type FindProgressWithMethods<T> = FindProgress<T> & {
   untilReady: (allowableStates: string[]) => Promise<DocHandle<T>>
@@ -465,7 +467,9 @@ export class Repo extends EventEmitter<RepoEvents> {
    */
   create<T>(initialValue?: T): DocHandle<T> {
     let initialDoc: Automerge.Doc<T>
-    if (initialValue) {
+
+    // If the initial value is an empty object, use the empty change initialisation path instead of the from path
+    if (isPlainObject(initialValue) && hasAtLeastOneKey(initialValue)) {
       initialDoc = Automerge.from(initialValue)
     } else {
       initialDoc = Automerge.emptyChange(Automerge.init())

--- a/packages/automerge-repo/src/helpers/has-at-least-one-key.ts
+++ b/packages/automerge-repo/src/helpers/has-at-least-one-key.ts
@@ -1,0 +1,17 @@
+/**
+ * Test if object has at least one key
+ *
+ * @remarks
+ * Faster than `Object.keys(obj).length > 0` for large object
+ * - No Allocation: It doesn't create a massive array in memory.
+ * - Short-Circuiting: If the object has 10,000 keys, Object.keys() will visit all 10,000. This function stops at the 1st key.
+ *
+ * Like `Object.keys()`, only own enumerable properties are considered, so behaviour is identical to `Object.keys(obj).length > 0`.
+ */
+export const hasAtLeastOneKey = (obj: Record<string, unknown>): boolean => {
+  for (const _ in obj) {
+    //https://caniuse.com/mdn-javascript_builtins_object_hasown
+    if (Object.hasOwn(obj, _)) return true
+  }
+  return false
+}

--- a/packages/automerge-repo/src/helpers/isPlainObject.ts
+++ b/packages/automerge-repo/src/helpers/isPlainObject.ts
@@ -1,0 +1,11 @@
+/**
+ * Checks if a value is a plain object.
+ *
+ * @param value - The value to check.
+ * @returns `true` if the value is a plain object, `false` otherwise.
+ */
+export function isPlainObject(
+  value: unknown
+): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -2,7 +2,7 @@ import { next as A, Heads } from "@automerge/automerge"
 import { MessageChannelNetworkAdapter } from "../../automerge-repo-network-messagechannel/src/index.js"
 import assert from "assert"
 import * as Uuid from "uuid"
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   encodeHeads,
   getHeadsFromUrl,
@@ -1977,6 +1977,58 @@ describe("Repo", () => {
 
       const openDocs = Object.keys(server.metrics().documents).length
       assert.deepEqual(openDocs, 0)
+    })
+  })
+
+  describe("storage persistence", () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    const storedKeysFor = (
+      storage: DummyStorageAdapter,
+      handle: DocHandle<any>
+    ) => storage.keys().filter(key => key.includes(handle.documentId))
+
+    it("should persist created handle with an empty object as the initial value", async () => {
+      const storage = new DummyStorageAdapter()
+      const repo = new Repo({ storage })
+
+      const handle = repo.create({})
+
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(handle.doc()).toEqual({})
+      expect(storedKeysFor(storage, handle)).toHaveLength(1)
+    })
+
+    it("should persist created handle when no initial value is provided", async () => {
+      const storage = new DummyStorageAdapter()
+      const repo = new Repo({ storage })
+
+      const handle = repo.create()
+
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(handle.doc()).toEqual({})
+      expect(storedKeysFor(storage, handle)).toHaveLength(1)
+    })
+
+    it("should persist created handle when a non-empty initial value is provided", async () => {
+      const storage = new DummyStorageAdapter()
+      const repo = new Repo({ storage })
+      const initialValue = { foo: "bar" }
+
+      const handle = repo.create(initialValue)
+
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(handle.doc()).toEqual(initialValue)
+      expect(storedKeysFor(storage, handle)).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
### What was broken

`Repo.create()` should persist new documents via the configured `StorageAdapter`, but calling it with an empty object (`repo.create({})`) silently skipped persistence.

The old check used JS truthiness:

```ts
if (initialValue) {
  initialDoc = Automerge.from(initialValue)
} else {
  initialDoc = Automerge.emptyChange(Automerge.init())
}
```

`{}` is truthy, so it took the `Automerge.from(initialValue)` branch. But `Automerge.from({})` records no changes, leaving the document with no heads — and the storage subsystem only writes documents that have changes. The no-argument path worked because `Automerge.emptyChange(Automerge.init())` explicitly creates an empty change.

### The fix

Use `Automerge.from` only when the input is a plain object with at least one own key; otherwise fall through to the working empty-change path:

```ts
if (isPlainObject(initialValue) && hasAtLeastOneKey(initialValue)) {
  initialDoc = Automerge.from(initialValue)
} else {
  initialDoc = Automerge.emptyChange(Automerge.init())
}
```

Two helpers were added:

- `isPlainObject(value)` — rules out `null`, arrays, and primitives.
- `hasAtLeastOneKey(obj)` — short-circuits on the first own key, avoiding the `Object.keys(obj).length` allocation.

### Tests

New `storage persistence` suite in `Repo.test.ts` uses `DummyStorageAdapter` + `vi.useFakeTimers()` to assert exactly one storage key is written for:

1. `repo.create({})`
2. `repo.create()`
3. `repo.create({ foo: "bar" })`