### PR TITLE
chore: add test for race that was fixed in PR618 and strengthen related tests 

### DIFF
--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -572,7 +572,7 @@ describe("Websocket adapters", () => {
         const handle = silentRepo.create()
         handle.update(() => A.clone(doc))
         const { documentId } = parseAutomergeUrl(handle.url)
-        await pause(150)
+        await silentRepo.flush([documentId])
         return {
           url: handle.url,
           doc,

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -18,7 +18,7 @@ import * as CBOR from "cbor-x"
 import { once } from "events"
 import http from "http"
 import { getPortPromise as getAvailablePort } from "portfinder"
-import { describe, it } from "vitest"
+import { afterEach, describe, it, vi } from "vitest"
 import WebSocket from "ws"
 import { WebSocketClientAdapter } from "../src/WebSocketClientAdapter.js"
 import { WebSocketServerAdapter } from "../src/WebSocketServerAdapter.js"
@@ -91,25 +91,36 @@ describe("Websocket adapters", () => {
     })
 
     it("should connect even when server is not initially available", async () => {
-      const port = await getPort() //?
-      const retryInterval = 100
+      // Fake only setInterval so the adapter's retry tick is under our
+      // control. Leave setTimeout real because the underlying `ws` library
+      // and Node's net stack rely on it for connection lifecycle.
+      vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] })
+      try {
+        const port = await getPort()
+        const retryInterval = 100
 
-      const browserAdapter = await setupClient({ port, retryInterval })
+        const browserAdapter = await setupClient({ port, retryInterval })
+        const _browserRepo = new Repo({
+          network: [browserAdapter],
+          peerId: browserPeerId,
+        })
 
-      const _browserRepo = new Repo({
-        network: [browserAdapter],
-        peerId: browserPeerId,
-      })
+        // Bring up the server, then fire one retry tick to drive the
+        // adapter's reconnect. Without fake timers the adapter would wait
+        // a full retryInterval of wall-clock time per attempt; here we
+        // skip straight to the next tick.
+        const { serverAdapter } = await setupServer({ port, retryInterval })
+        const _serverRepo = new Repo({
+          network: [serverAdapter],
+          peerId: serverPeerId,
+        })
 
-      await pause(500)
-
-      const { serverAdapter } = await setupServer({ port, retryInterval })
-      const serverRepo = new Repo({
-        network: [serverAdapter],
-        peerId: serverPeerId,
-      })
-
-      await eventPromise(browserAdapter, "peer-candidate")
+        const peerCandidate = eventPromise(browserAdapter, "peer-candidate")
+        await vi.advanceTimersByTimeAsync(retryInterval)
+        await peerCandidate
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it("should reconnect after being disconnected", async () => {

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -10,6 +10,7 @@ import { headsAreSame } from "./helpers/headsAreSame.js"
 import type { AutomergeUrl, DocumentId, PeerId, UrlHeads } from "./types.js"
 import { StorageId } from "./storage/types.js"
 import type { PathInput, InferRefType, Ref } from "./refs/types.js"
+import { foreverPromise } from "./helpers/foreverPromise.js"
 
 /**
  * A DocHandle is a wrapper around a single Automerge document that lets us listen for changes and
@@ -175,7 +176,7 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
       return
     }
     // No path to other states from a handed-out handle.
-    return new Promise(() => {})
+    return foreverPromise
   }
 
   /**

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -42,7 +42,7 @@ import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
 import { isPlainObject } from "./helpers/isPlainObject.js"
 import { hasAtLeastOneKey } from "./helpers/has-at-least-one-key.js"
 
-export type { DocumentProgress, QueryState } from "./DocumentQuery.js"
+export type { DocumentProgress } from "./DocumentQuery.js"
 export { DocumentQuery } from "./DocumentQuery.js"
 
 function randomPeerId() {

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -2,6 +2,7 @@ import assert from "assert"
 import { beforeEach, describe, it } from "vitest"
 import { next as Automerge } from "@automerge/automerge"
 import { generateAutomergeUrl, parseAutomergeUrl } from "../src/AutomergeUrl.js"
+import { Repo } from "../src/Repo.js"
 import {
   CollectionSynchronizer,
   AutomergeSyncConfig,
@@ -142,5 +143,120 @@ describe("CollectionSynchronizer", () => {
 
     // Removing document again should not throw an error
     synchronizer.detach(query.documentId)
+  })
+
+  describe("eviction race (closed by synchronous receiveMessage)", () => {
+    // On the legacy code path, CollectionSynchronizer.receiveMessage awaited
+    // repo.find() and a concurrent removeFromCache could leave the receive
+    // continuation holding an UNLOADED handle — it then installed a fresh
+    // DocSynchronizer capturing that handle, queuing the sync message in
+    // #pendingSyncMessages forever. The peer was silently cut off from the
+    // document until restart.
+    //
+    // On this surface, receiveMessage returns void (no awaits) and
+    // ensureQuery is idempotent, so no microtask interleaving is possible
+    // between receiveMessage's body and removeFromCache's body. These tests
+    // verify the post-conditions for both orderings of the legacy race.
+
+    it("detach then receive: ensureQuery resurrects the doc with a fresh DocSynchronizer", async () => {
+      const repo = new Repo({})
+      const handle = repo.create<TestDoc>({ foo: "bar" })
+      const documentId = handle.documentId
+
+      const [, syncData] = Automerge.generateSyncMessage(
+        handle.doc(),
+        Automerge.initSyncState()
+      )
+      if (!syncData) throw new Error("expected sync message")
+      const syncMessage: SyncMessage = {
+        type: "sync",
+        senderId: "remote-peer" as PeerId,
+        targetId: repo.networkSubsystem.peerId,
+        documentId,
+        data: syncData,
+      }
+
+      await repo.removeFromCache(documentId)
+      assert(
+        repo.synchronizer.docSynchronizers[documentId] === undefined,
+        "DocSynchronizer should be detached after removeFromCache"
+      )
+
+      repo.synchronizer.receiveMessage(syncMessage)
+
+      assert(
+        repo.synchronizer.docSynchronizers[documentId] !== undefined,
+        "ensureQuery should have installed a fresh DocSynchronizer"
+      )
+      assert(
+        repo.handles[documentId] !== undefined,
+        "the doc should be reachable via repo.handles after resurrection"
+      )
+    })
+
+    it("receive then detach: state is fully cleaned up", async () => {
+      const repo = new Repo({})
+      const handle = repo.create<TestDoc>({ foo: "bar" })
+      const documentId = handle.documentId
+
+      const [, syncData] = Automerge.generateSyncMessage(
+        handle.doc(),
+        Automerge.initSyncState()
+      )
+      if (!syncData) throw new Error("expected sync message")
+      const syncMessage: SyncMessage = {
+        type: "sync",
+        senderId: "remote-peer" as PeerId,
+        targetId: repo.networkSubsystem.peerId,
+        documentId,
+        data: syncData,
+      }
+
+      repo.synchronizer.receiveMessage(syncMessage)
+      await repo.removeFromCache(documentId)
+
+      assert(
+        repo.synchronizer.docSynchronizers[documentId] === undefined,
+        "detach should have removed the DocSynchronizer"
+      )
+    })
+
+    it("interleaved removeFromCache and receiveMessage in the same tick leaves consistent state", async () => {
+      const repo = new Repo({})
+      const handle = repo.create<TestDoc>({ foo: "bar" })
+      const documentId = handle.documentId
+
+      const [, syncData] = Automerge.generateSyncMessage(
+        handle.doc(),
+        Automerge.initSyncState()
+      )
+      if (!syncData) throw new Error("expected sync message")
+      const syncMessage: SyncMessage = {
+        type: "sync",
+        senderId: "remote-peer" as PeerId,
+        targetId: repo.networkSubsystem.peerId,
+        documentId,
+        data: syncData,
+      }
+
+      // On the legacy code path this ordering would race. Here both bodies
+      // are synchronous so the order is fully determined: removeFromCache
+      // runs first (its async body has no awaits), then receiveMessage
+      // resurrects the doc via ensureQuery.
+      const removePromise = repo.removeFromCache(documentId)
+      repo.synchronizer.receiveMessage(syncMessage)
+      await removePromise
+
+      // No "broken" state: if a DocSynchronizer is present, its document
+      // must be reachable via repo.handles. The legacy bug created an
+      // entry in docSynchronizers without a corresponding live entry.
+      const docSync = repo.synchronizer.docSynchronizers[documentId]
+      if (docSync !== undefined) {
+        assert(
+          repo.handles[documentId] !== undefined,
+          "DocSynchronizer exists but the doc isn't in repo.handles — stale state"
+        )
+      }
+    })
   })
 })

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -93,7 +93,7 @@ describe("CollectionSynchronizer", () => {
         reject(new Error("Should not have sent a message"))
       })
       synchronizer.addPeer(alice)
-      setTimeout(done)
+      queueMicrotask(done)
     }))
 
   it("should not synchronize a document which is excluded from the share policy", () =>
@@ -115,7 +115,7 @@ describe("CollectionSynchronizer", () => {
         reject(new Error("Should not have sent a message"))
       })
       synchronizer.attach(query)
-      setTimeout(done)
+      queueMicrotask(done)
     }))
 
   it("removes document", async () => {

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -247,7 +247,7 @@ describe("DocHandle", () => {
         reject(new Error("shouldn't have changed"))
       })
       handle.update(d => {
-        setTimeout(done, 0)
+        queueMicrotask(done)
         return d
       })
     }))
@@ -307,7 +307,7 @@ describe("DocHandle", () => {
       })
       handle.change(_doc => {
         // do nothing
-        setTimeout(done, 0)
+        queueMicrotask(done)
       })
     }))
 

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -221,14 +221,14 @@ describe("DocSynchronizer", () => {
     // Add bob — alice sends an initial request (both have no data)
     aliceDocSynchronizer.addPeer(bob, Promise.resolve(undefined))
     // Wait for peer activation (Promise.all needs 2+ microtask ticks)
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
 
     // Receive bob's message — alice now knows bob wants the doc
     aliceDocSynchronizer.receiveMessage({ ...bobMsg, senderId: bob })
 
     // Add charlie (unknown peer) — should get a request
     aliceDocSynchronizer.addPeer(charlie, Promise.resolve(undefined))
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
 
     const charlieMessage = messages.find(m => m.targetId === charlie)
     const bobMessages = messages.filter(m => m.targetId === bob)
@@ -288,8 +288,8 @@ describe("DocSynchronizer", () => {
     docSynchronizer.addPeer(alice, Promise.resolve(undefined))
 
     // Wait for the second activation to complete.
-    await new Promise(r => setTimeout(r, 0))
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
+    await new Promise(setImmediate)
 
     // Capture sync-state events before resolving the stale promise.
     const syncStatesBefore: any[] = []
@@ -298,7 +298,7 @@ describe("DocSynchronizer", () => {
     // Resolve the first activation. Should be silently discarded — no
     // sync-state event for the stale activation.
     resolveFirst(undefined)
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
 
     assert.equal(
       syncStatesBefore.length,
@@ -356,12 +356,12 @@ describe("DocSynchronizer", () => {
     aliceSync.addPeer(bob, Promise.resolve(undefined))
     aliceSync.addPeer(charlie, Promise.resolve(undefined))
     aliceSync.addPeer("drew" as PeerId, Promise.resolve(undefined))
-    await new Promise(r => setTimeout(r, 0))
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
+    await new Promise(setImmediate)
 
     aliceSync.receiveMessage({ ...bobMsg, senderId: bob })
     aliceSync.receiveMessage({ ...drewReq, senderId: "drew" as PeerId })
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
 
     // At this point alice has heard from bob (a supplier) but hasn't received
     // bob's data yet, and hasn't heard from charlie. She must NOT have told
@@ -377,7 +377,7 @@ describe("DocSynchronizer", () => {
 
     // Now charlie advertises too — still no unavailable.
     aliceSync.receiveMessage({ ...charlieMsg, senderId: charlie })
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
     const stillEarly = aliceMessages.find(
       m => m.type === "doc-unavailable" && m.targetId === "drew"
     )
@@ -419,8 +419,8 @@ describe("DocSynchronizer", () => {
     docSync.addPeer(bob, Promise.resolve(undefined), {
       messages: [{ ...syncMsg, senderId: bob } as any],
     })
-    await new Promise(r => setTimeout(r, 0))
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
+    await new Promise(setImmediate)
 
     const unavailable = messages.find(
       m => m.type === "doc-unavailable" && m.targetId === bob
@@ -462,8 +462,8 @@ describe("DocSynchronizer", () => {
     docSync.addPeer(bob, Promise.resolve(undefined), {
       messages: [{ ...bobMsg, senderId: bob } as any],
     })
-    await new Promise(r => setTimeout(r, 0))
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
+    await new Promise(setImmediate)
     assert.ok(
       messages.find(m => m.type === "doc-unavailable" && m.targetId === bob),
       "should have sent doc-unavailable while denied"
@@ -472,8 +472,8 @@ describe("DocSynchronizer", () => {
     // Flip access on, then re-evaluate. Bob should be re-engaged with sync.
     allowAccess = true
     docSync.reevaluateSharePolicy()
-    await new Promise(r => setTimeout(r, 0))
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
+    await new Promise(setImmediate)
 
     const syncToBob = messages.find(
       m => m.type === "sync" && m.targetId === bob
@@ -489,7 +489,7 @@ describe("DocSynchronizer", () => {
 
     docSync.addPeer(alice, Promise.resolve(undefined))
     docSync.addPeer(bob, Promise.resolve(undefined))
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
 
     const received: any[] = []
     handle.on("ephemeral-message", payload => received.push(payload))
@@ -510,7 +510,7 @@ describe("DocSynchronizer", () => {
     docSync.receiveMessage({ ...ephemeral, senderId: alice })
     // Second arrival from bob (same charlie ephemeral, mesh duplicate)
     docSync.receiveMessage({ ...ephemeral, senderId: alice })
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
 
     assert.equal(received.length, 1, "should only emit ephemeral-message once")
   })
@@ -549,11 +549,11 @@ describe("DocSynchronizer", () => {
     // DocSynchronizer sends doc-unavailable to bob.
     docSync.addPeer(bob, Promise.resolve(undefined))
     // Wait for peer activation (Promise.all needs 2+ microtask ticks)
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
     docSync.receiveMessage({ ...reqMsg, senderId: bob })
 
     // Wait for #evaluate to process the message and send doc-unavailable
-    await new Promise(r => setTimeout(r, 0))
+    await new Promise(setImmediate)
 
     const unavailableMsg = messages.find(m => m.type === "doc-unavailable")
     assert.ok(unavailableMsg, "should have sent doc-unavailable")

--- a/packages/automerge-repo/test/DocumentQuery.test.ts
+++ b/packages/automerge-repo/test/DocumentQuery.test.ts
@@ -362,7 +362,7 @@ describe("DocumentQuery", () => {
 
       query.handle.update(() => v2)
       // Allow microtasks to flush.
-      await new Promise(r => setTimeout(r, 0))
+      await Promise.resolve()
       expect(states).toContain("ready")
     })
   })

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -892,7 +892,7 @@ describe("Repo", () => {
             }
             blockedSaves.add(blockedSave)
           })
-          await pause(0)
+          await Promise.resolve()
           // otherwise all the save promises resolve together
           // which prevents testing flushing a single docID
           return originalSave(...args)
@@ -1080,7 +1080,7 @@ describe("Repo", () => {
       const deliver = (
         to: DummyNetworkAdapter,
         message: Parameters<DummyNetworkAdapter["receive"]>[0]
-      ) => pause(0).then(() => to.receive(message))
+      ) => Promise.resolve().then(() => to.receive(message))
 
       // Model a half-lost first connection. Bob's request reaches Alice, but
       // Alice's response is dropped. This leaves Alice with sync state that
@@ -1112,7 +1112,7 @@ describe("Repo", () => {
         alice.networkSubsystem.whenReady(),
         bob.networkSubsystem.whenReady(),
       ])
-      await pause(0)
+      await Promise.resolve()
 
       const aliceHandle = alice.create<TestDoc>({ foo: "bar" })
       const bobFind = bob.find<TestDoc>(aliceHandle.url)
@@ -1145,7 +1145,7 @@ describe("Repo", () => {
       const deliver = (
         to: DummyNetworkAdapter,
         message: Parameters<DummyNetworkAdapter["receive"]>[0]
-      ) => pause(0).then(() => to.receive(message))
+      ) => Promise.resolve().then(() => to.receive(message))
 
       // Pair 1 is the original connection. Bob can send requests to Alice,
       // but Alice's responses are lost, so Bob's public find() cannot finish
@@ -1184,7 +1184,7 @@ describe("Repo", () => {
         alice.networkSubsystem.whenReady(),
         bob.networkSubsystem.whenReady(),
       ])
-      await pause(0)
+      await Promise.resolve()
 
       const aliceHandle = alice.create<TestDoc>({ foo: "bar" })
       const bobFind = bob.find<TestDoc>(aliceHandle.url)
@@ -1216,7 +1216,7 @@ describe("Repo", () => {
       const deliver = (
         to: DummyNetworkAdapter,
         message: Parameters<DummyNetworkAdapter["receive"]>[0]
-      ) => pause(0).then(() => to.receive(message))
+      ) => Promise.resolve().then(() => to.receive(message))
 
       const aliceToBob1 = new DummyNetworkAdapter({
         startReady: true,
@@ -1250,7 +1250,7 @@ describe("Repo", () => {
         alice.networkSubsystem.whenReady(),
         bob.networkSubsystem.whenReady(),
       ])
-      await pause(0)
+      await Promise.resolve()
 
       aliceToBob1.peerCandidate(bob.peerId)
       bobToAlice1.peerCandidate(alice.peerId)


### PR DESCRIPTION
- Adds test to assert the `receiveMessage` / `removeFromCache` race is closed
    - This bug was resolved by PR #618, but there was no unit test to demonstrate it resolved it
    - Adding the test guards against this type of race occurring in future
- Minor: Refactors `DocHandle.ts` to use `foreverPromise` rather than re-create a promise that never resolves (which was slow memory leak)
- Minor: Removes unused `import` in `Repo.ts`
- Strengthen tests in `Websocket.test.ts` to use `fake` timers (and keeps real clock tests /w reason why).  (This reduces risk of flaky test and has side benefit of reducing time from ~500ms to 25ms)
- Replace `setTimeout(0)`/`pause(0)` with more idiomiatic JS microtask flush patterns. No functional changes

Note: This supersedes #624