### PR TITLE
refactor: refactor caches to improve garbage collection and prevent memory leaks

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
+++ b/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
@@ -9,11 +9,23 @@ import { pause } from "../../automerge-repo/src/helpers/pause.js"
 
 describe("BroadcastChannel", () => {
   const setup: SetupFn = async () => {
-    const a = new BroadcastChannelNetworkAdapter()
-    const b = new BroadcastChannelNetworkAdapter()
-    const c = new BroadcastChannelNetworkAdapter()
+    // Isolate each test on its own channel. A shared channel lets stale
+    // adapters from another test in the same process answer "arrive" with
+    // "welcome", which fires extra peer-candidate events for the same
+    // peerIds and resets per-peer sync state mid-test.
+    const channelName = `broadcast-${Math.random().toString(36).slice(2)}`
+    const a = new BroadcastChannelNetworkAdapter({ channelName })
+    const b = new BroadcastChannelNetworkAdapter({ channelName })
+    const c = new BroadcastChannelNetworkAdapter({ channelName })
 
-    return { adapters: [a, b, c] }
+    return {
+      adapters: [a, b, c],
+      teardown: () => {
+        a.disconnect()
+        b.disconnect()
+        c.disconnect()
+      },
+    }
   }
 
   runNetworkAdapterTests(setup)

--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -399,18 +399,17 @@ describe("useDocuments", () => {
       render(<Wrapped />, { wrapper })
 
       // Make a change while document is loading
-      handleA.change(doc => (doc.counter = 1))
-
-      // Wait for load
       await act(async () => {
-        await Promise.resolve()
+        handleA.change(doc => (doc.counter = 1))
       })
 
       // Should have latest state
-      const [docs] = onState.mock.lastCall || []
-      expect(docs.get(handleA.url)).toEqual({
-        foo: "A",
-        counter: 1,
+      await waitFor(() => {
+        const [docs] = onState.mock.lastCall || []
+        expect(docs.get(handleA.url)).toEqual({
+          foo: "A",
+          counter: 1,
+        })
       })
     })
 

--- a/packages/automerge-repo/README.md
+++ b/packages/automerge-repo/README.md
@@ -251,6 +251,56 @@ And you're finished! You can test that your sync server is opening the same docu
 different browsers (e.g. Chrome and Firefox). (Note that with our current trivial implementation
 you'll need to manually copy the `rootDocId` value between the browsers.)
 
+## Memory lifetime — consumer responsibilities
+
+`Repo` follows consumer lifetime decisions: if you hold a strong reference to a `DocHandle`, the repo keeps it alive; if you drop the reference and the handle becomes garbage-collectable, the repo automatically releases the associated coordination state (synchronizer entry, sync info).
+
+### The contract
+
+- **Holding a strong reference keeps the document loaded.** Storage backing, sync state, and the synchronizer entry stay alive as long as your reference does.
+- **Dropping the reference releases everything.** Once garbage collection reclaims the handle, the repo's internal storage and the per-document synchronizer entry are cleaned up automatically. No call to `repo.removeFromCache(id)` is required.
+- **A consumer-side `WeakMap<DocHandle, ...>` for derived state works as expected.** The repo no longer pins the handle, so weak-map entries are released when you drop your reference.
+
+**Opt-in modules with their own teardown.** The contract above covers the `Repo` / `DocHandle` reference relationship. Some optional modules layer their own long-lived state on top of a handle — most notably [`Presence`](src/presence/Presence.ts), which schedules heartbeat and peer-pruning intervals in the host timer queue. The timer queue is an external GC root that keeps the `Presence` (and its handle) alive until cleared, so dropping references is **not** enough for those: call `presence.stop()` deterministically (typically in a `pagehide` / unmount path) before releasing. See the relevant module's docs for the specifics.
+
+### Flush unsaved changes before dropping
+
+Pending throttled saves keep the handle alive briefly via the timer queue, so they always reach storage. But if you need a deterministic point at which all writes are persisted, `await repo.flush(documentId)` first:
+
+```ts
+await repo.flush(handle.documentId) // ensure pending changes hit storage
+handle = null // drop the reference; GC will follow when ready
+```
+
+### `removeFromCache` is for explicit teardown
+
+`repo.removeFromCache(documentId)` is still available. Its semantics changed from "force-clean the entry" to "force-clean _now_ instead of waiting for GC." Use it when you need synchronous teardown (e.g. shutting down a subsystem with a known doc list); for typical reference-dropping patterns it is no longer needed.
+
+### Consumer-managed LRU (sync servers, long-running processes)
+
+`Repo` does not include a built-in LRU or grace-period cache. The right level for these policies is the consumer: you know your access pattern, your eviction criterion (time, count, memory pressure), and your tolerance for re-loading on the next access.
+
+A consumer LRU is just a strong-reference map under your own policy. When a handle should be evicted, drop the reference — the repo follows:
+
+```ts
+class HandleLRU<T> {
+  #strong = new Map<DocumentId, DocHandle<T>>() // strong refs, your LRU policy
+  // ... your own eviction logic (time, count, memory) ...
+
+  evict(documentId: DocumentId) {
+    this.#strong.delete(documentId)
+    // No removeFromCache call needed: dropping the strong reference is enough.
+    // The repo releases coordination state when GC reclaims the handle.
+  }
+}
+```
+
+### Behavior change vs. previous versions
+
+In earlier versions, `Repo` strongly retained every handle it created for the lifetime of the `Repo`. Consumers needed `removeFromCache(id)` for every doc they wanted to release. Code that relied on that retention (e.g. assuming a previously-`find()`-ed handle would still be in the cache without holding the reference yourself) needs review.
+
+For most application code the change is transparent — you were already holding handles where you needed them. The change affects code that _implicitly_ relied on the repo as a permanent cache.
+
 ## Acknowledgements
 
 Originally authored by Peter van Hardenberg.

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -11,6 +11,7 @@ import type { AutomergeUrl, DocumentId, PeerId, UrlHeads } from "./types.js"
 import { StorageId } from "./storage/types.js"
 import type { PathInput, InferRefType, Ref } from "./refs/types.js"
 import { foreverPromise } from "./helpers/foreverPromise.js"
+import { WeakValueMap } from "./helpers/WeakValueMap.js"
 
 /**
  * A DocHandle is a wrapper around a single Automerge document that lets us listen for changes and
@@ -31,11 +32,13 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
 
   #doc: A.Doc<T>
 
-  /** Cache for view handles, keyed by the stringified heads */
-  #viewCache: Map<string, DocHandle<T>> = new Map()
+  /** Cache for view handles, keyed by the stringified heads. Values are
+   * held weakly so unused views are eligible for GC. */
+  #viewCache = new WeakValueMap<string, DocHandle<T>>()
 
-  /** Cache for ref instances, keyed by serialized path */
-  #refCache = new Map<string, WeakRef<Ref<any>>>()
+  /** Cache for ref instances, keyed by serialized path. Values are held
+   * weakly so unused refs are eligible for GC. */
+  #refCache = new WeakValueMap<string, Ref<any>>()
 
   #deleted = false
 
@@ -246,29 +249,17 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
    * @returns DocHandle<T> at the time of `heads`
    */
   view(heads: UrlHeads): DocHandle<T> {
-    // Create a cache key from the heads
-    const cacheKey = JSON.stringify(heads)
-
-    // Check if we have a cached handle for these heads
-    const cachedHandle = this.#viewCache.get(cacheKey)
-    if (cachedHandle) {
-      return cachedHandle
-    }
-
-    // Create a new handle with the same documentId but fixed heads
-    const handle = new DocHandle<T>(
-      this.documentId,
-      this.#refConstructor,
-      {},
-      this.#syncInfoLookup
-    )
-    handle.#doc = A.view(this.#doc, decodeHeads(heads))
-    handle.#fixedHeads = heads
-
-    // Store in cache
-    this.#viewCache.set(cacheKey, handle)
-
-    return handle
+    return this.#viewCache.getOrCompute(JSON.stringify(heads), () => {
+      const handle = new DocHandle<T>(
+        this.documentId,
+        this.#refConstructor,
+        {},
+        this.#syncInfoLookup
+      )
+      handle.#doc = A.view(this.#doc, decodeHeads(heads))
+      handle.#fixedHeads = heads
+      return handle
+    })
   }
 
   /**
@@ -519,18 +510,9 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
   ref<TPath extends readonly PathInput[]>(
     ...segments: [...TPath]
   ): Ref<InferRefType<T, TPath>> {
-    const cacheKey = this.#pathToCacheKey(segments)
-    const existingRef = this.#refCache.get(cacheKey)?.deref()
-
-    if (existingRef) {
-      return existingRef as Ref<InferRefType<T, TPath>>
-    }
-
-    // Create new ref and cache it
-    const newRef = this.#refConstructor<T, TPath>(this, segments as [...TPath])
-    this.#refCache.set(cacheKey, new WeakRef(newRef))
-
-    return newRef as Ref<InferRefType<T, TPath>>
+    return this.#refCache.getOrCompute(this.#pathToCacheKey(segments), () =>
+      this.#refConstructor<T, TPath>(this, segments as [...TPath])
+    ) as Ref<InferRefType<T, TPath>>
   }
 
   /**

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -41,6 +41,7 @@ import { RefImpl } from "./refs/ref.js"
 import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
 import { isPlainObject } from "./helpers/isPlainObject.js"
 import { hasAtLeastOneKey } from "./helpers/has-at-least-one-key.js"
+import { testInternals } from "./testInternals.js"
 import { WeakValueMap } from "./helpers/WeakValueMap.js"
 
 export type { DocumentProgress } from "./DocumentQuery.js"
@@ -78,6 +79,16 @@ export class Repo extends EventEmitter<RepoEvents> {
   //   handle weakly and self-evicts dead entries via FinalizationRegistry.
   #queriesByHandle = new WeakMap<DocHandle<any>, DocumentQuery<any>>()
   #queryHandleByDocumentId = new WeakValueMap<DocumentId, DocHandle<any>>()
+
+  // When the consumer's last strong reference to a handle goes away
+  // and the handle is collected, the registry callback runs cleanup
+  // for coordination state that doesn't self-clean. Both targets are
+  // idempotent: `removeFromCache(id)` can run before GC and call
+  // these explicitly, and the registry firing afterwards is a no-op.
+  #handleCleanupRegistry = new FinalizationRegistry<DocumentId>(documentId => {
+    this.synchronizer.detach(documentId)
+    this.#syncStateTracker.delete(documentId)
+  })
 
   /** @hidden */
   synchronizer: CollectionSynchronizer
@@ -311,10 +322,18 @@ export class Repo extends EventEmitter<RepoEvents> {
     return this.#queriesByHandle.get(handle) as DocumentQuery<T> | undefined
   }
 
-  /** Register a freshly-created query in both stores. */
+  /** Register a freshly-created query in both stores and arrange for
+   *  coordination-state cleanup when the consumer drops the handle. */
   #registerQuery(query: DocumentQuery<unknown>): void {
     this.#queriesByHandle.set(query.handle, query)
     this.#queryHandleByDocumentId.set(query.documentId, query.handle)
+    // Unregister token is the handle itself, used by #unregisterQuery
+    // on the explicit-removal path.
+    this.#handleCleanupRegistry.register(
+      query.handle,
+      query.documentId,
+      query.handle
+    )
   }
 
   /** Explicit-removal path. Both stores auto-clean when the handle is
@@ -322,7 +341,14 @@ export class Repo extends EventEmitter<RepoEvents> {
    *  eagerly. */
   #unregisterQuery(documentId: DocumentId): void {
     const handle = this.#queryHandleByDocumentId.get(documentId)
-    if (handle) this.#queriesByHandle.delete(handle)
+    if (handle) {
+      this.#queriesByHandle.delete(handle)
+      // Stop the FinalizationRegistry callback from firing later for
+      // this doc. If the handle is already collected (we got
+      // undefined), the callback may already be queued — its work
+      // is idempotent so a late run is harmless.
+      this.#handleCleanupRegistry.unregister(handle)
+    }
     this.#queryHandleByDocumentId.delete(documentId)
   }
 
@@ -680,11 +706,13 @@ export class Repo extends EventEmitter<RepoEvents> {
     } else {
       return this.storageSubsystem.id()
     }
-  }
+  };
 
   /** Generator yielding save promises for currently-ready docs only.
    *  Single-pass over the documentId index; no intermediate arrays. */
-  *#saveTasks(documents?: Iterable<DocumentId>): IterableIterator<Promise<void>> {
+  *#saveTasks(
+    documents?: Iterable<DocumentId>
+  ): IterableIterator<Promise<void>> {
     const ids = documents ?? this.#queryHandleByDocumentId.keys()
     for (const id of ids) {
       const state = this.#getQuery(id)?.peek()
@@ -735,6 +763,19 @@ export class Repo extends EventEmitter<RepoEvents> {
 
   shareConfigChanged() {
     this.synchronizer.reevaluateDocumentShare()
+  }
+
+  /** Test-only escape hatch. The {@link testInternals} symbol is exported
+   *  from a module not part of the public entrypoint, so this method is
+   *  unreachable from external code. Used by tests to assert on internal
+   *  cleanup state (e.g. that `#syncStateTracker` no longer has an entry
+   *  for a doc whose handle was GC'd). */
+  static [testInternals](repo: Repo) {
+    return {
+      syncStateTracker: repo.#syncStateTracker,
+      queryHandleByDocumentId: repo.#queryHandleByDocumentId,
+      queriesByHandle: repo.#queriesByHandle,
+    }
   }
 }
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -65,7 +65,19 @@ export class Repo extends EventEmitter<RepoEvents> {
   /** @hidden */
   storageSubsystem?: StorageSubsystem
 
-  #queries: Record<DocumentId, DocumentQuery<any>> = {}
+  // Document query storage:
+  // - Split is what enables GC: primary keyed by handle so it can be a
+  //   WeakMap; a single documentId-keyed map couldn't be weak (primitive
+  //   keys) and would pin every query for the repo's lifetime.
+  // - `#queriesByHandle`: keyed weakly by `DocHandle`. The query holds a
+  //   strong ref back to the handle, but per spec that cycle is internal
+  //   to the entry and doesn't pin — so dropping the handle GCs both.
+  // - `#queryHandleByDocumentId`: secondary index for documentId-based
+  //   lookups (sync messages, removeFromCache). Holds the handle weakly.
+  //   TODO: switch to `WeakValueMap<DocumentId, DocHandle<any>>` when
+  //   that helper lands — same shape, with active cleanup.
+  #queriesByHandle = new WeakMap<DocHandle<any>, DocumentQuery<any>>()
+  #queryHandleByDocumentId: Record<DocumentId, WeakRef<DocHandle<any>>> = {}
 
   /** @hidden */
   synchronizer: CollectionSynchronizer
@@ -227,7 +239,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     })
 
     this.synchronizer.on("sync-state", message => {
-      const handle = this.#queries[message.documentId]?.handle
+      const handle = this.#getQuery(message.documentId)?.handle
       if (!handle) return
 
       const peerMeta = this.peerMetadataByPeerId[message.peerId]
@@ -276,7 +288,7 @@ export class Repo extends EventEmitter<RepoEvents> {
       this.#remoteHeadsSubscriptions.on(
         "remote-heads-changed",
         ({ documentId, storageId, remoteHeads, timestamp }) => {
-          const handle = this.#queries[documentId]?.handle
+          const handle = this.#getQuery(documentId)?.handle
           if (!handle) return
           this.#syncStateTracker.handleRemoteHeadsChanged(
             documentId,
@@ -287,6 +299,41 @@ export class Repo extends EventEmitter<RepoEvents> {
           )
         }
       )
+    }
+  }
+
+  /** Look up a query by documentId. Returns undefined if the document
+   *  was never registered, or was registered but its DocHandle has been
+   *  garbage-collected since (no live consumer reference remains). */
+  #getQuery<T>(documentId: DocumentId): DocumentQuery<T> | undefined {
+    const handle = this.#queryHandleByDocumentId[documentId]?.deref()
+    if (!handle) return undefined
+    return this.#queriesByHandle.get(handle) as DocumentQuery<T> | undefined
+  }
+
+  /** Register a freshly-created query in both stores. */
+  #registerQuery(query: DocumentQuery<unknown>): void {
+    this.#queriesByHandle.set(query.handle, query)
+    this.#queryHandleByDocumentId[query.documentId] = new WeakRef(query.handle)
+  }
+
+  /** Explicit-removal path. The WeakMap entry auto-cleans when the
+   *  handle is GC'd; this is used by `delete` and `removeFromCache`
+   *  to remove eagerly. */
+  #unregisterQuery(documentId: DocumentId): void {
+    const handle = this.#queryHandleByDocumentId[documentId]?.deref()
+    if (handle) this.#queriesByHandle.delete(handle)
+    delete this.#queryHandleByDocumentId[documentId]
+  }
+
+  /** Iterate currently-alive `(documentId, query)` pairs. Skips entries
+   *  whose handle has been collected. */
+  *#aliveQueries(): IterableIterator<[DocumentId, DocumentQuery<any>]> {
+    for (const id of Object.keys(
+      this.#queryHandleByDocumentId
+    ) as DocumentId[]) {
+      const query = this.#getQuery(id)
+      if (query) yield [id, query]
     }
   }
 
@@ -304,7 +351,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     documentId: DocumentId,
     initialDoc?: Automerge.Doc<unknown>
   ): DocumentQuery<unknown> {
-    const existing = this.#queries[documentId]
+    const existing = this.#getQuery(documentId)
     if (existing) {
       return existing
     }
@@ -319,7 +366,7 @@ export class Repo extends EventEmitter<RepoEvents> {
       handle.update(() => initialDoc)
     }
     const query = new DocumentQuery(handle, this.#sources)
-    this.#queries[documentId] = query
+    this.#registerQuery(query)
 
     // Attach all sources. Each source calls sourcePending/sourceUnavailable
     // as appropriate and sets up its own listeners. When initialDoc is
@@ -356,9 +403,9 @@ export class Repo extends EventEmitter<RepoEvents> {
   /** Returns all the handles we have cached. */
   get handles(): Record<DocumentId, DocHandle<any>> {
     const result: Record<DocumentId, DocHandle<any>> = {}
-    for (const [id, query] of Object.entries(this.#queries)) {
+    for (const [id, query] of this.#aliveQueries()) {
       if (query.handle) {
-        result[id as DocumentId] = query.handle
+        result[id] = query.handle
       }
     }
     return result
@@ -499,10 +546,10 @@ export class Repo extends EventEmitter<RepoEvents> {
 
     // ensureQuery creates the query, handle, sets up all sources, and
     // registers with the sync layer (no-ops if already added).
-    if (!this.#queries[documentId]) {
-      this.#ensureQuery(documentId)
+    let query = this.#getQuery<T>(documentId)
+    if (!query) {
+      query = this.#ensureQuery(documentId) as DocumentQuery<T>
     }
-    const query = this.#queries[documentId] as DocumentQuery<T>
 
     if (!heads) return query
     return progressAtHeads(query, heads)
@@ -544,14 +591,14 @@ export class Repo extends EventEmitter<RepoEvents> {
   delete(id: AnyDocumentId) {
     const documentId = interpretAsDocumentId(id)
 
-    const query = this.#queries[documentId]
+    const query = this.#getQuery(documentId)
     if (query?.handle) {
       query.handle.emit("delete", { handle: query.handle })
     }
     if (query) {
       query.fail(new Error(`Document ${documentId} was deleted`))
     }
-    delete this.#queries[documentId]
+    this.#unregisterQuery(documentId)
 
     for (const source of this.#sources.values()) {
       source.detach(documentId)
@@ -599,7 +646,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     const docId = args?.docId
     if (docId != null) {
       // Check if we already have a handle for this document
-      const existing = this.#queries[docId]?.handle as DocHandle<T> | null
+      const existing = this.#getQuery(docId)?.handle as DocHandle<T> | null
       if (existing) {
         existing.update(doc => Automerge.loadIncremental(doc, binary))
         return existing
@@ -650,10 +697,11 @@ export class Repo extends EventEmitter<RepoEvents> {
       return
     }
 
-    const ids = documents ?? (Object.keys(this.#queries) as DocumentId[])
+    const ids =
+      documents ?? (Object.keys(this.#queryHandleByDocumentId) as DocumentId[])
     await Promise.all(
       ids.map(async id => {
-        const state = this.#queries[id]?.peek()
+        const state = this.#getQuery(id)?.peek()
         if (state?.state === "ready") {
           await this.storageSubsystem!.saveDoc(id, state.handle.doc())
         }
@@ -670,7 +718,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     for (const source of this.#sources.values()) {
       source.detach(documentId)
     }
-    delete this.#queries[documentId]
+    this.#unregisterQuery(documentId)
     this.#syncStateTracker.delete(documentId)
   }
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -82,11 +82,16 @@ export class Repo extends EventEmitter<RepoEvents> {
 
   // When the consumer's last strong reference to a handle goes away
   // and the handle is collected, the registry callback runs cleanup
-  // for coordination state that doesn't self-clean. Both targets are
-  // idempotent: `removeFromCache(id)` can run before GC and call
-  // these explicitly, and the registry firing afterwards is a no-op.
+  // for coordination state that doesn't self-clean. This mirrors the
+  // explicit `removeFromCache(id)` path so consumers see the same
+  // outcome whether they trigger eviction by dropping the handle or
+  // by calling the API. All targets are idempotent — if
+  // `removeFromCache(id)` runs first, the registry firing afterwards
+  // is a no-op.
   #handleCleanupRegistry = new FinalizationRegistry<DocumentId>(documentId => {
-    this.synchronizer.detach(documentId)
+    for (const source of this.#sources.values()) {
+      source.detach(documentId)
+    }
     this.#syncStateTracker.delete(documentId)
   })
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -41,6 +41,7 @@ import { RefImpl } from "./refs/ref.js"
 import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
 import { isPlainObject } from "./helpers/isPlainObject.js"
 import { hasAtLeastOneKey } from "./helpers/has-at-least-one-key.js"
+import { WeakValueMap } from "./helpers/WeakValueMap.js"
 
 export type { DocumentProgress } from "./DocumentQuery.js"
 export { DocumentQuery } from "./DocumentQuery.js"
@@ -73,11 +74,10 @@ export class Repo extends EventEmitter<RepoEvents> {
   //   strong ref back to the handle, but per spec that cycle is internal
   //   to the entry and doesn't pin — so dropping the handle GCs both.
   // - `#queryHandleByDocumentId`: secondary index for documentId-based
-  //   lookups (sync messages, removeFromCache). Holds the handle weakly.
-  //   TODO: switch to `WeakValueMap<DocumentId, DocHandle<any>>` when
-  //   that helper lands — same shape, with active cleanup.
+  //   lookups (sync messages, removeFromCache). WeakValueMap holds the
+  //   handle weakly and self-evicts dead entries via FinalizationRegistry.
   #queriesByHandle = new WeakMap<DocHandle<any>, DocumentQuery<any>>()
-  #queryHandleByDocumentId: Record<DocumentId, WeakRef<DocHandle<any>>> = {}
+  #queryHandleByDocumentId = new WeakValueMap<DocumentId, DocHandle<any>>()
 
   /** @hidden */
   synchronizer: CollectionSynchronizer
@@ -306,7 +306,7 @@ export class Repo extends EventEmitter<RepoEvents> {
    *  was never registered, or was registered but its DocHandle has been
    *  garbage-collected since (no live consumer reference remains). */
   #getQuery<T>(documentId: DocumentId): DocumentQuery<T> | undefined {
-    const handle = this.#queryHandleByDocumentId[documentId]?.deref()
+    const handle = this.#queryHandleByDocumentId.get(documentId)
     if (!handle) return undefined
     return this.#queriesByHandle.get(handle) as DocumentQuery<T> | undefined
   }
@@ -314,25 +314,23 @@ export class Repo extends EventEmitter<RepoEvents> {
   /** Register a freshly-created query in both stores. */
   #registerQuery(query: DocumentQuery<unknown>): void {
     this.#queriesByHandle.set(query.handle, query)
-    this.#queryHandleByDocumentId[query.documentId] = new WeakRef(query.handle)
+    this.#queryHandleByDocumentId.set(query.documentId, query.handle)
   }
 
-  /** Explicit-removal path. The WeakMap entry auto-cleans when the
-   *  handle is GC'd; this is used by `delete` and `removeFromCache`
-   *  to remove eagerly. */
+  /** Explicit-removal path. Both stores auto-clean when the handle is
+   *  GC'd; this is used by `delete` and `removeFromCache` to remove
+   *  eagerly. */
   #unregisterQuery(documentId: DocumentId): void {
-    const handle = this.#queryHandleByDocumentId[documentId]?.deref()
+    const handle = this.#queryHandleByDocumentId.get(documentId)
     if (handle) this.#queriesByHandle.delete(handle)
-    delete this.#queryHandleByDocumentId[documentId]
+    this.#queryHandleByDocumentId.delete(documentId)
   }
 
   /** Iterate currently-alive `(documentId, query)` pairs. Skips entries
    *  whose handle has been collected. */
   *#aliveQueries(): IterableIterator<[DocumentId, DocumentQuery<any>]> {
-    for (const id of Object.keys(
-      this.#queryHandleByDocumentId
-    ) as DocumentId[]) {
-      const query = this.#getQuery(id)
+    for (const [id, handle] of this.#queryHandleByDocumentId) {
+      const query = this.#queriesByHandle.get(handle)
       if (query) yield [id, query]
     }
   }
@@ -404,9 +402,7 @@ export class Repo extends EventEmitter<RepoEvents> {
   get handles(): Record<DocumentId, DocHandle<any>> {
     const result: Record<DocumentId, DocHandle<any>> = {}
     for (const [id, query] of this.#aliveQueries()) {
-      if (query.handle) {
-        result[id] = query.handle
-      }
+      result[id] = query.handle
     }
     return result
   }
@@ -686,27 +682,33 @@ export class Repo extends EventEmitter<RepoEvents> {
     }
   }
 
+  /** Generator yielding save promises for currently-ready docs only.
+   *  Single-pass over the documentId index; no intermediate arrays. */
+  *#saveTasks(documents?: Iterable<DocumentId>): IterableIterator<Promise<void>> {
+    const ids = documents ?? this.#queryHandleByDocumentId.keys()
+    for (const id of ids) {
+      const state = this.#getQuery(id)?.peek()
+      if (state?.state === "ready") {
+        yield this.storageSubsystem!.saveDoc(id, state.handle.doc())
+      }
+    }
+  }
+
   /**
    * Writes Documents to a disk.
    * @hidden this API is experimental and may change.
    * @param documents - if provided, only writes the specified documents.
    * @returns Promise<void>
    */
-  async flush(documents?: DocumentId[]): Promise<void> {
+  async flush(documents?: Iterable<DocumentId>): Promise<void> {
     if (!this.storageSubsystem) {
       return
     }
 
-    const ids =
-      documents ?? (Object.keys(this.#queryHandleByDocumentId) as DocumentId[])
-    await Promise.all(
-      ids.map(async id => {
-        const state = this.#getQuery(id)?.peek()
-        if (state?.state === "ready") {
-          await this.storageSubsystem!.saveDoc(id, state.handle.doc())
-        }
-      })
-    )
+    // Yield save promises one-at-a-time to Promise.all so we never
+    // materialize the ids array or an intermediate promise array, and
+    // skip non-ready docs without wrapping them in an async no-op.
+    await Promise.all(this.#saveTasks(documents))
   }
 
   /**

--- a/packages/automerge-repo/src/helpers/DummyNetworkAdapter.ts
+++ b/packages/automerge-repo/src/helpers/DummyNetworkAdapter.ts
@@ -66,16 +66,25 @@ export class DummyNetworkAdapter extends NetworkAdapter {
     this.emit("message", message)
   }
 
-  static createConnectedPair({ latency = 10 }: { latency?: number } = {}) {
+  static createConnectedPair({ latency = 0 }: { latency?: number } = {}) {
+    // Default to microtask delivery. `setTimeout`-based delivery (any
+    // `latency > 0`) is subject to event-loop starvation under concurrent
+    // test load, which produces flaky round-trip-heavy tests. Callers that
+    // actually want to simulate latency can still pass a positive value.
+    const deliver =
+      latency === 0
+        ? (adapter: DummyNetworkAdapter, message: Message) =>
+            Promise.resolve().then(() => adapter.receive(message))
+        : (adapter: DummyNetworkAdapter, message: Message) =>
+            pause(latency).then(() => adapter.receive(message))
+
     const adapter1: DummyNetworkAdapter = new DummyNetworkAdapter({
       startReady: true,
-      sendMessage: (message: Message) =>
-        pause(latency).then(() => adapter2.receive(message)),
+      sendMessage: (message: Message) => deliver(adapter2, message),
     })
     const adapter2: DummyNetworkAdapter = new DummyNetworkAdapter({
       startReady: true,
-      sendMessage: (message: Message) =>
-        pause(latency).then(() => adapter1.receive(message)),
+      sendMessage: (message: Message) => deliver(adapter1, message),
     })
 
     return [adapter1, adapter2]

--- a/packages/automerge-repo/src/helpers/WeakValueMap.ts
+++ b/packages/automerge-repo/src/helpers/WeakValueMap.ts
@@ -1,0 +1,68 @@
+/**
+ * Map keyed by a primitive (`number | string`) where values are held weakly.
+ * Dead entries are removed automatically via `FinalizationRegistry` once the
+ * value is GC'd.
+ *
+ * Use for pure optimization caches where:
+ *   - the key is a primitive (e.g. a stringified path, a stringified head, a
+ *     document id),
+ *   - V can be cheaply reconstructed on miss,
+ *   - "cache hit" is never observable as program state.
+ *
+ * Why not `WeakMap`? `WeakMap` keys must be `WeakKey` (object or registered
+ * symbol). It cannot be keyed on a `number` or a `string` — try
+ * `new WeakMap<string, T>()` and TypeScript rejects it. `WeakValueMap` fills
+ * exactly that gap: primitive keys, weak values, with the same automatic
+ * eviction guarantee that `WeakMap` provides for object keys.
+ *
+ * If your key *is* an object, prefer the built-in `WeakMap` instead — it ships
+ * with the language and has cleaner lifetime semantics for that shape.
+ *
+ * @example
+ *   // Cache view handles by stringified heads.
+ *   const cache = new WeakValueMap<string, DocHandle<T>>()
+ *   const handle = cache.getOrCompute(JSON.stringify(heads), () => makeView(heads))
+ */
+export class WeakValueMap<K extends number | string, V extends WeakKey> {
+  #map = new Map<K, WeakRef<V>>()
+  #registry = new FinalizationRegistry<K>(key => {
+    const ref = this.#map.get(key)
+    if (ref !== undefined && ref.deref() === undefined) {
+      this.#map.delete(key)
+    }
+  })
+
+  get(key: K): V | undefined {
+    return this.#map.get(key)?.deref()
+  }
+
+  set(key: K, value: V): this {
+    const existing = this.#map.get(key)?.deref()
+    if (existing !== undefined) {
+      // Without this, the old value's finalizer would later delete the new
+      // entry. The value object itself is the unregister token.
+      this.#registry.unregister(existing)
+    }
+    this.#map.set(key, new WeakRef(value))
+    this.#registry.register(value, key, value)
+    return this
+  }
+
+  delete(key: K): boolean {
+    const existing = this.#map.get(key)?.deref()
+    if (existing !== undefined) this.#registry.unregister(existing)
+    return this.#map.delete(key)
+  }
+
+  has(key: K): boolean {
+    return this.get(key) !== undefined
+  }
+
+  getOrCompute(key: K, compute: () => V): V {
+    const existing = this.get(key)
+    if (existing !== undefined) return existing
+    const value = compute()
+    this.set(key, value)
+    return value
+  }
+}

--- a/packages/automerge-repo/src/helpers/WeakValueMap.ts
+++ b/packages/automerge-repo/src/helpers/WeakValueMap.ts
@@ -65,4 +65,32 @@ export class WeakValueMap<K extends number | string, V extends WeakKey> {
     this.set(key, value)
     return value
   }
+
+  // Iteration matches `Map`'s shape (`entries`, `keys`, `values`,
+  // `[Symbol.iterator]`). Dead entries are silently skipped — there's
+  // no way to observe one, and the only way for a value to be in the
+  // underlying map is to be alive at the moment we yield it.
+  //
+  // No `size` — it would lie. The count can change between calls
+  // without any mutation, just from GC, so any single read would be
+  // immediately stale.
+
+  *entries(): IterableIterator<[K, V]> {
+    for (const [key, ref] of this.#map) {
+      const value = ref.deref()
+      if (value !== undefined) yield [key, value]
+    }
+  }
+
+  [Symbol.iterator](): IterableIterator<[K, V]> {
+    return this.entries()
+  }
+
+  *keys(): IterableIterator<K> {
+    for (const [k] of this.entries()) yield k
+  }
+
+  *values(): IterableIterator<V> {
+    for (const [, v] of this.entries()) yield v
+  }
 }

--- a/packages/automerge-repo/src/presence/Presence.ts
+++ b/packages/automerge-repo/src/presence/Presence.ts
@@ -184,6 +184,8 @@ export class Presence<
    * {@link https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event | "visibilitychange"}
    * to stop sending and receiving updates when not active.
    *
+   * @remarks here?
+   * 
    * **You must call `stop()` to release a `Presence` instance.** Dropping the
    * reference is not enough: the heartbeat / pruning `setInterval` timers
    * scheduled in {@link start} are registered with the host timer queue,

--- a/packages/automerge-repo/src/presence/Presence.ts
+++ b/packages/automerge-repo/src/presence/Presence.ts
@@ -183,6 +183,19 @@ export class Presence<
    * or
    * {@link https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event | "visibilitychange"}
    * to stop sending and receiving updates when not active.
+   *
+   * **You must call `stop()` to release a `Presence` instance.** Dropping the
+   * reference is not enough: the heartbeat / pruning `setInterval` timers
+   * scheduled in {@link start} are registered with the host timer queue,
+   * which is an external GC root. As long as those intervals are running,
+   * the timer callbacks (which capture `this`) keep this `Presence` alive,
+   * which in turn keeps its `DocHandle` alive via `this.#handle`.
+   *
+   * In a browser this is usually a non-issue because `Presence` is tied to
+   * a long-lived page; pair `stop()` with `pagehide` / `visibilitychange`
+   * for clean teardown. In a longer-running JS process that creates and
+   * tears down many `Presence` instances over time, forgetting `stop()`
+   * leaks per-instance state and pins the associated handle.
    */
   stop() {
     if (!this.#running) {

--- a/packages/automerge-repo/src/refs/ref.ts
+++ b/packages/automerge-repo/src/refs/ref.ts
@@ -72,6 +72,9 @@ export class RefImpl<
    * field-side reference to the original arrow function so it can be
    * GC'd.
    *
+   * 
+   * @remarks
+   * 
    * Optional. If you drop both the handle and the Ref together, the
    * natural internal cycle handles cleanup. Call `dispose()` only
    * when you want to release a Ref while keeping the handle alive —

--- a/packages/automerge-repo/src/refs/ref.ts
+++ b/packages/automerge-repo/src/refs/ref.ts
@@ -2,6 +2,7 @@ import * as Automerge from "@automerge/automerge/slim"
 import type { Doc, Prop, Heads } from "@automerge/automerge/slim"
 import type { DocHandle, DocHandleChangePayload } from "../DocHandle.js"
 import { encodeHeads, decodeHeads } from "../AutomergeUrl.js"
+import { noop } from "../helpers/noop.js"
 import type {
   Segment,
   PathSegment,
@@ -21,14 +22,10 @@ import type { CursorMarker } from "./types.js"
 import { stringifyRefUrl } from "./parser.js"
 import { MutableText } from "./mutable-text.js"
 
-/**
- * FinalizationRegistry for automatic cleanup of Ref instances.
- * This ensures subscriptions are cleaned up when Refs are garbage collected,
- * even if dispose() is never called.
- */
-const refCleanupRegistry = new FinalizationRegistry<() => void>(cleanup =>
-  cleanup()
-)
+// Refs and their handles form an internal cycle (handle → events →
+// listener → this → docHandle → handle) that's collected as a unit
+// when both are dropped — no FinalizationRegistry needed. For
+// releasing a Ref while keeping the handle alive, use `dispose()`.
 
 /**
  * Internal implementation of the Ref interface.
@@ -67,13 +64,31 @@ export class RefImpl<
       this.#updateProps(currentDoc)
     }
     this.docHandle.on("change", this.#updateHandler)
-
-    // Register for automatic cleanup when this Ref is garbage collected
-    refCleanupRegistry.register(this, () => this.#cleanup(), this)
   }
 
-  #cleanup(): void {
+  /**
+   * Detach this Ref from its `DocHandle`: remove the internal
+   * `"change"` listener and any `onChange` callbacks, and release the
+   * field-side reference to the original arrow function so it can be
+   * GC'd.
+   *
+   * Optional. If you drop both the handle and the Ref together, the
+   * natural internal cycle handles cleanup. Call `dispose()` only
+   * when you want to release a Ref while keeping the handle alive —
+   * e.g. you've created Refs for many positions and want to release
+   * them without dropping the handle.
+   *
+   * After `dispose()`, `value()` may return stale results for paths
+   * containing array indices that shift (cached `segment.prop`
+   * indices are no longer refreshed on `change`), and `onChange`
+   * callbacks no longer fire.
+   */
+  dispose(): void {
     this.docHandle.off("change", this.#updateHandler)
+    // After .off() has removed the handler from the handle's
+    // EventEmitter, drop the field-side reference too so the original
+    // arrow function (which captured `this`) can be GC'd.
+    this.#updateHandler = noop
     for (const callback of this.#onChangeCallbacks) {
       this.docHandle.off("change", callback)
     }

--- a/packages/automerge-repo/src/refs/types.ts
+++ b/packages/automerge-repo/src/refs/types.ts
@@ -379,6 +379,9 @@ export interface Ref<TValue = unknown> {
    * Detach this Ref from its `DocHandle`: remove the internal `change`
    * listener and any `onChange` callbacks.
    *
+   * 
+   * @remarks
+   *   
    * Optional. If you drop both the handle and the Ref together, the
    * natural internal cycle (`handle → events → listener → this →
    * docHandle → handle`) is collected as a unit. Call `dispose()` only

--- a/packages/automerge-repo/src/refs/types.ts
+++ b/packages/automerge-repo/src/refs/types.ts
@@ -376,6 +376,22 @@ export interface Ref<TValue = unknown> {
   ): () => void
 
   /**
+   * Detach this Ref from its `DocHandle`: remove the internal `change`
+   * listener and any `onChange` callbacks.
+   *
+   * Optional. If you drop both the handle and the Ref together, the
+   * natural internal cycle (`handle → events → listener → this →
+   * docHandle → handle`) is collected as a unit. Call `dispose()` only
+   * when you want to release the listener while keeping the handle
+   * alive for other uses.
+   *
+   * After `dispose()`, `value()` may return stale results for
+   * array-shifting paths (cached `segment.prop` indices are no longer
+   * refreshed) and `onChange` callbacks no longer fire.
+   */
+  dispose(): void
+
+  /**
    * Check if this ref is equal to another ref.
    * Two refs are equal if they have the same URL (document, path, and heads).
    */

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -1,7 +1,6 @@
 import { next as A } from "@automerge/automerge/slim"
 import debug from "debug"
 import { EventEmitter } from "eventemitter3"
-import { DocHandle } from "../DocHandle.js"
 import { parseAutomergeUrl } from "../AutomergeUrl.js"
 import {
   DocMessage,
@@ -99,7 +98,7 @@ export class CollectionSynchronizer
   attach(query: DocumentQuery<unknown>): void {
     if (this.#docSynchronizers[query.documentId]) return
 
-    const docSync = this.#initDocSynchronizer(query.handle, query)
+    const docSync = this.#initDocSynchronizer(query)
     this.#docSynchronizers[query.documentId] = docSync
 
     for (const peerId of this.#peers) {
@@ -218,12 +217,8 @@ export class CollectionSynchronizer
 
   // PRIVATE
 
-  #initDocSynchronizer(
-    handle: DocHandle<unknown>,
-    query: DocumentQuery<unknown>
-  ): DocSynchronizer {
+  #initDocSynchronizer(query: DocumentQuery<unknown>): DocSynchronizer {
     const docSync = new DocSynchronizer({
-      handle,
       query,
       networkReady: this.#networkReady,
       shareConfig: this.#config.shareConfig,

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -88,32 +88,73 @@ interface DocSynchronizerEvents {
  *    requests to other peers — avoid duplicate work.
  * 5. New peer after unavailable → re-request (if share policy allows).
  * 6. Handle updates from other sources → send sync to interested peers.
+ *
+ * ## Lifetime / GC contract
+ *
+ * The synchronizer never pins its handle. The reverse holds:
+ *
+ * - `#query` is a {@link WeakRef}. The handle is reached via
+ *   {@link DocumentQuery.handle}, so dropping the handle on the consumer
+ *   side lets the WeakMap entry in Repo collect both query and handle as
+ *   a unit.
+ * - Listeners attached to the handle (`"change"`,
+ *   `"ephemeral-message-outbound"`) capture only `this`. They live inside
+ *   the handle's `EventEmitter`, so the only reference direction is
+ *   `handle → events → closure → this` — they don't pin the handle. When
+ *   the handle dies, listeners die with it.
+ * - {@link DocumentId} is cached at construction (`#documentId`) so that
+ *   message routing, log messages, and event payloads don't require a
+ *   handle deref. The `get documentId()` accessor stays stable through
+ *   collection.
+ * - Hot paths ({@link #evaluate}, {@link #updateAvailability},
+ *   {@link #receiveSyncMessage}, {@link #receiveEphemeralMessage},
+ *   {@link metrics}) deref the WeakRef at the top and bail if dead. The
+ *   synchronizer goes inert after consumer drop.
+ *
+ * The one subtle case: a pending {@link asyncThrottle} timer is held
+ * strongly by the host timer queue and pins `this` for up to
+ * `syncDebounceRate` milliseconds after the handle is gone. The handle
+ * is *not* on that chain, so its GC is not blocked — the synchronizer
+ * just outlives the handle briefly. When the timer fires, `#evaluate`
+ * derefs the dead query and bails, and the asyncThrottle `finally`
+ * block clears its state.
+ *
+ * Reclaiming the DocSynchronizer itself requires
+ * {@link CollectionSynchronizer} to remove the entry from
+ * `docSynchronizers[id]`. Today that's the explicit `removeFromCache(id)`
+ * path; a planned `FinalizationRegistry` on the handle will make it
+ * automatic as part of handle collection.
  */
 export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
   #log: debug.Debugger
   syncDebounceRate = 100
 
   #peers: Map<PeerId, PeerState> = new Map()
-  #handle: DocHandle<unknown>
-  #query: DocumentQuery<unknown>
+  // documentId is cached at construction so accessors and event payloads
+  // don't need to deref the query. Stable for the lifetime of the
+  // DocSynchronizer (handles never change their documentId).
+  #documentId: DocumentId
+  // #query held weakly: consumer drops handle → WeakMap entry in Repo
+  // collects key+value together → this WeakRef goes dead. The
+  // synchronizer no longer pins the handle through the query.
+  #query: WeakRef<DocumentQuery<unknown>>
   #shareConfig: ShareConfig
   #seenEphemeralMessages = new HashRing(1000)
   #networkReady: boolean = false
 
   constructor({
-    handle,
     query,
     networkReady,
     shareConfig,
   }: {
-    handle: DocHandle<unknown>
     query: DocumentQuery<unknown>
     networkReady: Promise<void>
     shareConfig: ShareConfig
   }) {
     super()
-    this.#handle = handle
-    this.#query = query
+    const handle = query.handle
+    this.#documentId = handle.documentId
+    this.#query = new WeakRef(query)
     this.#shareConfig = shareConfig
     query.sourcePending("automerge-sync")
 
@@ -159,12 +200,21 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
       .catch(() => {})
   }
 
-  get query(): DocumentQuery<unknown> {
-    return this.#query
+  /** Returns the query if it's still alive (consumer is still holding
+   *  the handle, or some other strong path to the query exists), or
+   *  undefined if the handle has been collected. */
+  get query(): DocumentQuery<unknown> | undefined {
+    return this.#query.deref()
+  }
+
+  /** Returns the handle if it's still alive, or undefined if the consumer
+   *  has dropped it. Derefs through the weak query. */
+  get handle(): DocHandle<unknown> | undefined {
+    return this.#query.deref()?.handle
   }
 
   get documentId(): DocumentId {
-    return this.#handle.documentId
+    return this.#documentId
   }
 
   // PUBLIC API
@@ -218,8 +268,9 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
 
     // If we don't have data yet, a new peer might provide it — re-mark
     // the sync source as pending to prevent premature unavailability.
-    if (this.#query.peek().state !== "ready") {
-      this.#query.sourcePending("automerge-sync")
+    const query = this.#query.deref()
+    if (query && query.peek().state !== "ready") {
+      query.sourcePending("automerge-sync")
     }
 
     Promise.all([syncState, this.#resolveSharePolicy(peerId)])
@@ -308,9 +359,10 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
   }
 
   metrics(): { peers: PeerId[]; size: { numOps: number; numChanges: number } } {
+    const handle = this.handle
     return {
       peers: Array.from(this.#peers.keys()),
-      size: A.stats(this.#handle.doc()),
+      size: handle ? A.stats(handle.doc()) : { numOps: 0, numChanges: 0 },
     }
   }
 
@@ -338,7 +390,14 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
    * 3. Whether to send doc-unavailable to wanting peers
    */
   #evaluate(): void {
-    const doc = this.#handle.doc()
+    // Deref the weak query and obtain the handle through it. If the consumer
+    // has dropped the handle, the synchronizer goes inert — there's no doc
+    // to inspect and nowhere to publish availability.
+    const query = this.#query.deref()
+    const handle = query?.handle
+    if (!query || !handle) return
+
+    const doc = handle.doc()
     const weHaveData = A.getHeads(doc).length > 0
     const supplierExists = this.#anyActivePeerOfType("has")
 
@@ -365,7 +424,7 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
       if (
         !weHaveData &&
         peer.status.type === "unknown" &&
-        this.#query.shouldDeferAvailability("automerge-sync")
+        query.shouldDeferAvailability("automerge-sync")
       ) {
         continue
       }
@@ -396,7 +455,7 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
     // Only fires when the query has settled to unavailable/failed
     // and we have no data. The "unavailable-notified" status ensures each
     // peer is only told once.
-    const queryState = this.#query.peek()
+    const queryState = query.peek()
     if (
       !weHaveData &&
       (queryState.state === "unavailable" || queryState.state === "failed")
@@ -406,7 +465,7 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
           this.#setPeerStatus(peerId, { type: "unavailable-notified" })
           this.emit("message", {
             type: "doc-unavailable",
-            documentId: this.#handle.documentId,
+            documentId: this.documentId,
             targetId: peerId,
           } as MessageContents<DocumentUnavailableMessage>)
         }
@@ -457,42 +516,46 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
   #updateAvailability(): void {
     if (!this.#networkReady) return
 
+    const query = this.#query.deref()
+    const handle = query?.handle
+    if (!query || !handle) return
+
     if (this.#peers.size === 0) {
-      this.#query.sourceUnavailable("automerge-sync")
+      query.sourceUnavailable("automerge-sync")
       return
     }
 
     // If any peer's share policy is still being evaluated, we don't yet
     // know the full set of peers — stay pending.
     if (this.#anyPeerWithSharePolicy("loading")) {
-      this.#query.sourcePending("automerge-sync")
+      query.sourcePending("automerge-sync")
       return
     }
 
     // If any non-denied peer is still unknown, we might get data — stay pending.
     if (this.#anyActivePeerOfType("unknown")) {
-      this.#query.sourcePending("automerge-sync")
+      query.sourcePending("automerge-sync")
       return
     }
 
     // If at least one `has` peer's advertised heads are already present
     // in our doc, we have a complete copy from a supplier — ready, even
     // if other suppliers have additional heads we haven't reached yet.
-    if (this.#hasCaughtUpToAnySupplier(this.#handle.doc())) {
-      this.#query.sourceReady("automerge-sync")
+    if (this.#hasCaughtUpToAnySupplier(handle.doc())) {
+      query.sourceReady("automerge-sync")
       return
     }
 
     // There's at least one `has` peer but we haven't caught up to any of
     // them yet — stay pending.
     if (this.#anyActivePeerOfType("has")) {
-      this.#query.sourcePending("automerge-sync")
+      query.sourcePending("automerge-sync")
       return
     }
 
     // No peer ever advertised the doc — all are unavailable / wants /
     // denied.
-    this.#query.sourceUnavailable("automerge-sync")
+    query.sourceUnavailable("automerge-sync")
   }
 
   // STATE MUTATION HELPERS
@@ -529,7 +592,7 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
     this.emit("sync-state", {
       peerId,
       syncState: state,
-      documentId: this.#handle.documentId,
+      documentId: this.documentId,
     })
 
     peer.sharePolicyState = sharePolicyState
@@ -623,7 +686,7 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
     const end = performance.now()
     this.emit("metrics", {
       type: "generate-sync-message",
-      documentId: this.#handle.documentId,
+      documentId: this.documentId,
       durationMillis: end - start,
       forPeer: peerId,
     })
@@ -632,7 +695,7 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
     this.emit("sync-state", {
       peerId,
       syncState: newSyncState,
-      documentId: this.#handle.documentId,
+      documentId: this.documentId,
     })
 
     if (!message) return
@@ -646,7 +709,7 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
       this.emit("message", {
         type: "request",
         targetId: peerId,
-        documentId: this.#handle.documentId,
+        documentId: this.documentId,
         data: message,
       } as RequestMessage)
     } else {
@@ -654,20 +717,20 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
         type: "sync",
         targetId: peerId,
         data: message,
-        documentId: this.#handle.documentId,
+        documentId: this.documentId,
       } as SyncMessage)
     }
   }
 
   #receiveSyncMessage(message: SyncMessage | RequestMessage): void {
-    if (message.documentId !== this.#handle.documentId)
+    if (message.documentId !== this.documentId)
       throw new Error(`channelId doesn't match documentId`)
 
     const peer = this.#peers.get(message.senderId)
     if (!peer) {
       throw new Error(
         `No peer state for ${message.senderId} on document ` +
-          `${this.#handle.documentId}. This indicates a logic error: ` +
+          `${this.documentId}. This indicates a logic error: ` +
           `addPeer must be called before receiving messages from a peer.`
       )
     }
@@ -705,13 +768,18 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
     if (peer.sharePolicyState === "denied") {
       this.emit("message", {
         type: "doc-unavailable",
-        documentId: this.#handle.documentId,
+        documentId: this.documentId,
         targetId: message.senderId,
       } as MessageContents<DocumentUnavailableMessage>)
       return
     }
 
-    this.#handle.update(doc => {
+    // Consumer may have dropped the handle since this message was received —
+    // there's nothing to update in that case.
+    const handle = this.handle
+    if (!handle) return
+
+    handle.update(doc => {
       const start = performance.now()
       const [newDoc, newSyncState] = A.receiveSyncMessage(
         doc,
@@ -721,7 +789,7 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
       const end = performance.now()
       this.emit("metrics", {
         type: "receive-sync-message",
-        documentId: this.#handle.documentId,
+        documentId: this.documentId,
         durationMillis: end - start,
         fromPeer: message.senderId,
         ...A.stats(doc),
@@ -731,7 +799,7 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
       this.emit("sync-state", {
         peerId: message.senderId,
         syncState: newSyncState,
-        documentId: this.#handle.documentId,
+        documentId: this.documentId,
       })
 
       // Mark this peer dirty so #evaluate sends a response.
@@ -765,14 +833,14 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
     const message: MessageContents<EphemeralMessage> = {
       type: "ephemeral",
       targetId: peerId,
-      documentId: this.#handle.documentId,
+      documentId: this.documentId,
       data,
     }
     this.emit("message", message)
   }
 
   #receiveEphemeralMessage(message: EphemeralMessage): void {
-    if (message.documentId !== this.#handle.documentId)
+    if (message.documentId !== this.documentId)
       throw new Error(`channelId doesn't match documentId`)
 
     const { senderId, sessionId, count, data } = message
@@ -783,9 +851,15 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
     // Only emit and forward it once per unique sender/session/count.
     if (!isNewMessage) return
 
+    // Consumer may have dropped the handle — there's no local listener to
+    // deliver to, so skip emit (and mesh forwarding, since the synchronizer
+    // is effectively inert when the handle is gone).
+    const handle = this.handle
+    if (!handle) return
+
     const contents = decode(new Uint8Array(data))
-    this.#handle.emit("ephemeral-message", {
-      handle: this.#handle,
+    handle.emit("ephemeral-message", {
+      handle,
       senderId,
       message: contents,
     })

--- a/packages/automerge-repo/src/testInternals.ts
+++ b/packages/automerge-repo/src/testInternals.ts
@@ -1,0 +1,26 @@
+/**
+ * Test-only escape hatch. This module is NOT re-exported from
+ * `src/index.ts`, so external consumers can't reach the symbol — they'd
+ * have to deep-import via the source path, which is not part of the
+ * supported public API.
+ *
+ * Tests that need to assert on internal `#`-private state import
+ * `testInternals` from here and invoke a class's static method
+ * `[testInternals](instance)` to obtain a view of that state.
+ *
+ * @example
+ *   // In src/Repo.ts
+ *   import { testInternals } from "./testInternals.js"
+ *
+ *   class Repo {
+ *     static [testInternals](repo: Repo) {
+ *       return { syncStateTracker: repo.#syncStateTracker }
+ *     }
+ *   }
+ *
+ *   // In a test
+ *   import { testInternals } from "../src/testInternals.js"
+ *   const internals = Repo[testInternals](repo)
+ *   expect(internals.syncStateTracker.get(id)).toBeUndefined()
+ */
+export const testInternals = Symbol("automerge-repo:testInternals")

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -11,6 +11,7 @@ import { eventPromise } from "../src/helpers/eventPromise.js"
 import { DocHandle, DocHandleChangePayload } from "../src/index.js"
 import { TestDoc } from "./types.js"
 import { RefImpl } from "../src/refs/ref.js"
+import { flushGC, gcAvailable } from "./helpers/flushGC.js"
 
 describe("DocHandle", () => {
   const TEST_ID = parseAutomergeUrl(generateAutomergeUrl()).documentId
@@ -619,5 +620,69 @@ describe("DocHandle", () => {
     assert.ok(newHeads, "should have new heads")
     const viewDoc = A.view(handle.doc(), A.getHeads(handle.doc()))
     assert.ok(viewDoc)
+  })
+
+  describe("weak caches", () => {
+    const itGC = gcAvailable ? it : it.skip
+
+    it("ref() returns the same instance while held", () => {
+      const handle = setup()
+      handle.change(d => (d.foo = "x"))
+      const a = handle.ref("foo")
+      const b = handle.ref("foo")
+      expect(a).toBe(b)
+    })
+
+    it("view() returns the same handle for the same heads while held", () => {
+      const handle = setup()
+      handle.change(d => (d.foo = "x"))
+      const heads = handle.heads()!
+      const a = handle.view(heads)
+      const b = handle.view(heads)
+      expect(a).toBe(b)
+    })
+
+    // Skipped: blocked by a pre-existing structural issue in RefImpl. Its
+    // #updateHandler closure captures `this` and is stored as a change
+    // listener on the DocHandle, so while the DocHandle is alive the Ref is
+    // pinned — independent of #refCache. The FinalizationRegistry in
+    // refs/ref.ts has the same shape (held value captures the target). The
+    // WeakValueMap migration of #refCache is still correct; it just cannot
+    // realize value-collection benefits until RefImpl uses weak self-refs.
+    it.skip("ref() yields a fresh instance once the prior ref is GC'd", async () => {
+      const handle = setup()
+      handle.change(d => (d.foo = "x"))
+
+      const probe = (() => {
+        const r = handle.ref("foo")
+        return new WeakRef(r)
+      })()
+
+      await flushGC()
+
+      expect(probe.deref()).toBeUndefined()
+      const fresh = handle.ref("foo")
+      expect(fresh).not.toBe(probe.deref())
+    })
+
+    itGC(
+      "view() yields a fresh handle once the prior view is GC'd",
+      async () => {
+        const handle = setup()
+        handle.change(d => (d.foo = "x"))
+        const heads = handle.heads()!
+
+        const probe = (() => {
+          const v = handle.view(heads)
+          return new WeakRef(v)
+        })()
+
+        await flushGC()
+
+        expect(probe.deref()).toBeUndefined()
+        const fresh = handle.view(heads)
+        expect(fresh).not.toBe(probe.deref())
+      }
+    )
   })
 })

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -11,7 +11,7 @@ import { eventPromise } from "../src/helpers/eventPromise.js"
 import { DocHandle, DocHandleChangePayload } from "../src/index.js"
 import { TestDoc } from "./types.js"
 import { RefImpl } from "../src/refs/ref.js"
-import { flushGC, gcAvailable } from "./helpers/flushGC.js"
+import { gcAvailable, waitForGC } from "./helpers/flushGC.js"
 
 describe("DocHandle", () => {
   const TEST_ID = parseAutomergeUrl(generateAutomergeUrl()).documentId
@@ -658,9 +658,7 @@ describe("DocHandle", () => {
         return new WeakRef(r)
       })()
 
-      await flushGC()
-
-      expect(probe.deref()).toBeUndefined()
+      expect(await waitForGC(probe)).toBe(true)
       const fresh = handle.ref("foo")
       expect(fresh).not.toBe(probe.deref())
     })
@@ -677,9 +675,7 @@ describe("DocHandle", () => {
           return new WeakRef(v)
         })()
 
-        await flushGC()
-
-        expect(probe.deref()).toBeUndefined()
+        expect(await waitForGC(probe)).toBe(true)
         const fresh = handle.view(heads)
         expect(fresh).not.toBe(probe.deref())
       }

--- a/packages/automerge-repo/test/Repo.handleCleanup.test.ts
+++ b/packages/automerge-repo/test/Repo.handleCleanup.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from "vitest"
+import { Repo } from "../src/Repo.js"
+import { testInternals } from "../src/testInternals.js"
+import { DummyStorageAdapter } from "../src/helpers/DummyStorageAdapter.js"
+import { DummyNetworkAdapter } from "../src/helpers/DummyNetworkAdapter.js"
+import { flushGC, gcAvailable, waitForGC } from "./helpers/flushGC.js"
+import type { DocumentId } from "../src/types.js"
+
+const itGC = gcAvailable ? it : it.skip
+
+interface TestDoc {
+  foo: string
+}
+
+/**
+ * Test design — fake timers for the throttle phase, real timers for GC.
+ *
+ * `StorageSource.attach` registers a `heads-changed → asyncThrottle(saveFn,
+ * saveDebounceRate)` listener on the handle. The throttle's `setTimeout`
+ * retains the saveFn closure (which captures `{handle, doc}`), so a pending
+ * timer pins the handle — orthogonal to the §3 coordination cleanup we're
+ * actually testing. Wall-clock dependence on `saveDebounceRate` is the
+ * exact thing fake timers eliminate.
+ *
+ * Each itGC test:
+ *   1. `vi.useFakeTimers()` — capture the throttle's `setTimeout`.
+ *   2. Schedule the work (`repo.create` → emits heads-changed → throttle
+ *      schedules a fake-timer setTimeout).
+ *   3. `vi.advanceTimersByTimeAsync(...)` — fire the throttle's setTimeout,
+ *      releasing the closure that pinned the handle.
+ *   4. `vi.useRealTimers()` — switch back. The existing GC helpers use
+ *      real `setImmediate` for the macrotask yields that drain
+ *      `FinalizationRegistry` callbacks; fake timers would interfere.
+ *   5. `waitForGC(...)` with a combined predicate (handle is collected
+ *      AND the cleanup callback has run).
+ *
+ * The `try / finally` around fake-timer activation ensures real timers
+ * are restored even if an assertion throws.
+ */
+
+const SAVE_THROTTLE_MS = 100
+
+const setup = () => {
+  const storage = new DummyStorageAdapter()
+  const network = new DummyNetworkAdapter({ startReady: true })
+  // Use the default `saveDebounceRate` (100ms). With fake timers in
+  // effect, the value never converts to wall-clock — we just advance
+  // fake time by `SAVE_THROTTLE_MS * 2` to fire the throttle once.
+  const repo = new Repo({ storage, network: [network] })
+  return { repo, storage, network }
+}
+
+describe("Repo handle cleanup (FinalizationRegistry)", () => {
+  itGC(
+    "removes the synchronizer entry when the consumer drops the handle",
+    async () => {
+      let probe!: WeakRef<object>
+      let documentId!: DocumentId
+      let repo!: Repo
+
+      vi.useFakeTimers()
+      try {
+        repo = setup().repo
+        // Scope the strong ref inside an IIFE so it doesn't survive on
+        // the test stack frame after we drop it.
+        ;(() => {
+          const handle = repo.create<TestDoc>({ foo: "bar" })
+          documentId = handle.documentId
+          probe = new WeakRef(handle)
+        })()
+
+        // Sanity: the synchronizer registered the document.
+        expect(repo.synchronizer.docSynchronizers[documentId]).toBeDefined()
+
+        // Persist via the explicit path; this bypasses the throttle so
+        // storage has the data regardless of when the throttle fires.
+        await repo.flush()
+
+        // Fire the StorageSource asyncThrottle's pending setTimeout —
+        // drops the saveFn closure that retained the handle.
+        await vi.advanceTimersByTimeAsync(SAVE_THROTTLE_MS * 2)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      // Combined predicate: (a) handle is GC-collected, (b) the
+      // FinalizationRegistry callback has fired and run
+      // `synchronizer.detach(id)`. The callback runs as a microtask
+      // shortly after collection — combined predicate accepts whatever
+      // macrotask-yield count is needed for finalizers to drain.
+      expect(
+        await waitForGC(
+          () =>
+            probe.deref() === undefined &&
+            repo.synchronizer.docSynchronizers[documentId] === undefined
+        )
+      ).toBe(true)
+
+      expect(repo.handles[documentId]).toBeUndefined()
+    }
+  )
+
+  itGC(
+    "keeps the synchronizer entry while the consumer still holds the handle",
+    async () => {
+      let handle!: ReturnType<Repo["create"]>
+      let repo!: Repo
+
+      vi.useFakeTimers()
+      try {
+        repo = setup().repo
+        handle = repo.create<TestDoc>({ foo: "bar" })
+        await repo.flush()
+        await vi.advanceTimersByTimeAsync(SAVE_THROTTLE_MS * 2)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      // Strong ref still in scope — best-effort GC should NOT collect it.
+      await flushGC()
+
+      expect(
+        repo.synchronizer.docSynchronizers[handle.documentId]
+      ).toBeDefined()
+      expect(repo.handles[handle.documentId]).toBe(handle)
+    }
+  )
+
+  itGC(
+    "find() after drop returns a fresh handle (resurrection from storage)",
+    async () => {
+      let probe!: WeakRef<object>
+      let documentId!: DocumentId
+      let repo!: Repo
+
+      vi.useFakeTimers()
+      try {
+        repo = setup().repo
+        ;(() => {
+          const original = repo.create<TestDoc>({ foo: "bar" })
+          documentId = original.documentId
+          probe = new WeakRef(original)
+        })()
+
+        await repo.flush()
+        await vi.advanceTimersByTimeAsync(SAVE_THROTTLE_MS * 2)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      expect(await waitForGC(probe)).toBe(true)
+      expect(repo.handles[documentId]).toBeUndefined()
+
+      // Re-find the same id. Should produce a brand-new handle that
+      // re-loads from storage. (Same documentId, different handle
+      // instance — proves the cache miss path went through ensureQuery.)
+      const fresh = await repo.find<TestDoc>(documentId)
+      expect(fresh).toBeDefined()
+      expect(fresh.documentId).toBe(documentId)
+      expect(fresh.doc()).toMatchObject({ foo: "bar" })
+    }
+  )
+
+  it("removeFromCache eagerly clears coordination state", async () => {
+    // No GC required for this case — the explicit-removal path runs
+    // `#unregisterQuery` + `syncStateTracker.delete` synchronously, and
+    // the throttle pin is irrelevant to whether `removeFromCache`
+    // succeeds. Real timers throughout.
+    const { repo } = setup()
+    const handle = repo.create<TestDoc>({ foo: "bar" })
+    const documentId = handle.documentId
+    await repo.flush()
+
+    expect(repo.synchronizer.docSynchronizers[documentId]).toBeDefined()
+
+    await repo.removeFromCache(documentId)
+
+    expect(repo.synchronizer.docSynchronizers[documentId]).toBeUndefined()
+    expect(repo.handles[documentId]).toBeUndefined()
+  })
+
+  itGC(
+    "removeFromCache unregisters the registry: later handle GC is a no-op",
+    async () => {
+      let probe!: WeakRef<object>
+      let documentId!: DocumentId
+      let repo!: Repo
+
+      vi.useFakeTimers()
+      try {
+        repo = setup().repo
+        ;(() => {
+          const handle = repo.create<TestDoc>({ foo: "bar" })
+          documentId = handle.documentId
+          probe = new WeakRef(handle)
+        })()
+
+        await repo.flush()
+        await vi.advanceTimersByTimeAsync(SAVE_THROTTLE_MS * 2)
+        await repo.removeFromCache(documentId)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      // The registry entry was already unregistered by removeFromCache,
+      // so the callback shouldn't fire — but if it did, it would be a
+      // no-op (synchronizer.detach + syncStateTracker.delete are
+      // idempotent). Either way the state is correct.
+      expect(await waitForGC(probe)).toBe(true)
+      expect(repo.synchronizer.docSynchronizers[documentId]).toBeUndefined()
+      expect(repo.handles[documentId]).toBeUndefined()
+    }
+  )
+
+  it("testInternals symbol exposes the syncStateTracker", () => {
+    // Static-method form: Repo[testInternals](instance) — verifies that
+    // the symbol-keyed escape hatch is reachable from a test, the
+    // returned object has the expected shape, and the syncStateTracker
+    // is the live instance (not a snapshot).
+    const { repo } = setup()
+    const internals = Repo[testInternals](repo)
+    expect(internals.syncStateTracker).toBe(
+      Repo[testInternals](repo).syncStateTracker
+    )
+    expect(internals.queryHandleByDocumentId).toBeDefined()
+    expect(internals.queriesByHandle).toBeDefined()
+  })
+})

--- a/packages/automerge-repo/test/Repo.handleCleanup.test.ts
+++ b/packages/automerge-repo/test/Repo.handleCleanup.test.ts
@@ -18,9 +18,9 @@ interface TestDoc {
  * `StorageSource.attach` registers a `heads-changed → asyncThrottle(saveFn,
  * saveDebounceRate)` listener on the handle. The throttle's `setTimeout`
  * retains the saveFn closure (which captures `{handle, doc}`), so a pending
- * timer pins the handle — orthogonal to the §3 coordination cleanup we're
- * actually testing. Wall-clock dependence on `saveDebounceRate` is the
- * exact thing fake timers eliminate.
+ * timer pins the handle — orthogonal to the FinalizationRegistry cleanup
+ * we're actually testing. Wall-clock dependence on `saveDebounceRate` is
+ * the exact thing fake timers eliminate.
  *
  * Each itGC test:
  *   1. `vi.useFakeTimers()` — capture the throttle's `setTimeout`.
@@ -225,4 +225,252 @@ describe("Repo handle cleanup (FinalizationRegistry)", () => {
     expect(internals.queryHandleByDocumentId).toBeDefined()
     expect(internals.queriesByHandle).toBeDefined()
   })
+})
+
+/**
+ * Pinning behaviors that consumers may inadvertently rely on (or be
+ * surprised by). Each test is a regression guard for an observable
+ * design property — the asyncThrottle save timer, `Repo.handles`
+ * snapshot semantics, and the subscriber → query → handle reference
+ * chain.
+ */
+describe("Repo handle cleanup — cross-cutting behaviors", () => {
+  itGC(
+    "pending throttle setTimeout pins the handle until it fires",
+    /**
+     * Why this matters
+     * ----------------
+     * `StorageSource`'s `heads-changed → asyncThrottle(saveFn, ...)` schedules
+     * a `setTimeout` whose callback retains `{handle, doc}` through closure.
+     * Until the timer fires, the handle is reachable from the host timer
+     * queue → callback → args → handle.
+     *
+     * Implications for consumers:
+     *   - Changes via `handle.change()` will reach storage even if the
+     *     consumer drops the handle immediately afterward — the throttle's
+     *     pin guarantees the saveFn runs before GC can collect the handle.
+     *   - But the handle is NOT immediately collectable: it lingers until
+     *     the throttle setTimeout fires (default `saveDebounceRate = 100ms`).
+     *     `repo.flush(id)` saves directly via the storage subsystem, but
+     *     does NOT cancel a pending throttle; consumers wanting prompt
+     *     reclamation must wait for the throttle to settle after flushing.
+     *
+     * Regression guard: if someone changes the throttle to capture
+     * references differently — e.g. a stable wrapper that doesn't release
+     * its closure on settle — this test catches the new leak.
+     *
+     * Sequence
+     * --------
+     *   1. Create a doc and call `change()` — schedules a throttle
+     *      `setTimeout` whose callback retains `{handle, doc}`.
+     *   2. Drop the handle (IIFE scope); capture `WeakRef` as `probe`.
+     *   3. `flushGC()` (fixed rounds, negative assertion) — should NOT
+     *      collect: the throttle's pending setTimeout pins the handle.
+     *   4. `vi.advanceTimersByTimeAsync(...)` fires the throttle. The
+     *      callback runs (no-op since `flush()` already saved), the
+     *      closure releases, the handle becomes collectable.
+     *   5. `waitForGC(probe)` — collects.
+     *
+     * Implementation note — partial fake timers
+     * -----------------------------------------
+     * We pass `toFake: ['setTimeout', 'clearTimeout']` so that the throttle
+     * setTimeout is captured by the fake queue but `setImmediate` stays
+     * real. `flushGC` / `waitForGC` need real `setImmediate` for their
+     * macrotask yields; faking it would block their forward progress.
+     */
+    async () => {
+      let probe!: WeakRef<object>
+      let repo!: Repo
+
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] })
+      try {
+        repo = setup().repo
+        ;(() => {
+          const handle = repo.create<TestDoc>({ foo: "bar" })
+          handle.change(d => (d.foo = "baz"))
+          probe = new WeakRef(handle)
+        })()
+
+        // Do NOT advance fake time — the throttle setTimeout sits in the
+        // fake queue, its callback retaining the handle via closure.
+        await flushGC()
+        expect(probe.deref()).toBeDefined()
+
+        // Fire the throttle; the callback releases the closure.
+        await vi.advanceTimersByTimeAsync(SAVE_THROTTLE_MS * 2)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      expect(await waitForGC(probe)).toBe(true)
+    }
+  )
+
+  itGC(
+    "Repo.handles snapshot pins; a later snapshot reflects drops",
+    /**
+     * Why this matters
+     * ----------------
+     * `Repo.handles` is a getter that returns a fresh
+     * `Record<DocumentId, DocHandle>` each call — a snapshot, not a live
+     * view. The Record strongly references its values, so:
+     *   - A consumer iterating the snapshot stays correct (no mid-iteration
+     *     mutation).
+     *   - Holding the snapshot prevents the underlying handles from being
+     *     GC-collected, even after the consumer drops its own references.
+     *   - A subsequent call to `repo.handles` returns a new snapshot that
+     *     reflects current liveness (entries are absent for collected
+     *     handles, via the WeakValueMap's `entries()` iterator skipping
+     *     dead entries).
+     *
+     * Regression guard:
+     *   - If someone changes the getter to return a live `Map` view (would
+     *     break snapshot semantics — callers iterating would see mid-call
+     *     mutations from concurrent GC).
+     *   - If someone weakens the Record's values (would change observable
+     *     lifetime semantics: holding a snapshot would no longer pin).
+     *
+     * Useful for sync-server diagnostics that snapshot `repo.handles` for
+     * metrics — the snapshot needs to be self-consistent for the duration
+     * the operator holds it.
+     *
+     * Sequence
+     * --------
+     *   1. Create a doc; capture `WeakRef` as `probe`.
+     *   2. `const snapshot = repo.handles` — Record with strong ref to handle.
+     *   3. Drop the original handle reference (IIFE scope).
+     *   4. `flushGC()` (negative) — should NOT collect: the snapshot pins it.
+     *   5. Drop the snapshot reference.
+     *   6. `waitForGC(probe)` — collects.
+     *   7. `repo.handles` returns a fresh Record without the documentId.
+     */
+    async () => {
+      let probe!: WeakRef<object>
+      let documentId!: DocumentId
+      let repo!: Repo
+      let snapshot: Record<DocumentId, unknown> | undefined
+
+      vi.useFakeTimers()
+      try {
+        repo = setup().repo
+        ;(() => {
+          const handle = repo.create<TestDoc>({ foo: "bar" })
+          documentId = handle.documentId
+          probe = new WeakRef(handle)
+        })()
+
+        await repo.flush()
+        await vi.advanceTimersByTimeAsync(SAVE_THROTTLE_MS * 2)
+
+        // Capture a snapshot — the Record strongly references the handle.
+        snapshot = repo.handles
+      } finally {
+        vi.useRealTimers()
+      }
+
+      // Snapshot pins the handle; flushGC should NOT collect.
+      await flushGC()
+      expect(probe.deref()).toBeDefined()
+      expect(snapshot![documentId]).toBeDefined()
+
+      // Release the snapshot — no other strong refs remain.
+      snapshot = undefined
+
+      // Combined predicate: handle GC'd AND fresh snapshot no longer
+      // includes the documentId (verifies the WeakValueMap iterator
+      // skips the dead entry).
+      expect(
+        await waitForGC(
+          () =>
+            probe.deref() === undefined &&
+            repo.handles[documentId] === undefined
+        )
+      ).toBe(true)
+    }
+  )
+
+  itGC(
+    "a query subscriber pins both the query and its handle",
+    /**
+     * Why this matters
+     * ----------------
+     * `DocumentQuery.subscribe(callback)` adds `callback` to the query's
+     * internal `#subscribers` set and returns an `unsubscribe` function
+     * that closes over `this` (the query) and `callback`. So whoever
+     * holds the `unsubscribe` reference also (transitively) holds the
+     * query — and `DocumentQuery.#handle` is a strong field, so the
+     * query holds the handle too.
+     *
+     * Reference chain while `unsubscribe` is held:
+     *   unsubscribe → query → query.#handle → handle
+     *
+     * This is the structural reason the design does NOT need a "collected"
+     * `QueryState` variant: a `DocumentQuery` cannot outlive its handle.
+     * Any path that keeps the query reachable also keeps the handle
+     * reachable. The asymmetry doesn't exist.
+     *
+     * Implications for consumers:
+     *   - Reactive UIs that `subscribe` and forget to `unsubscribe` will
+     *     keep the handle alive. Intentional. Drop the unsubscribe to
+     *     allow reclamation.
+     *
+     * Regression guard: if someone weakens `DocumentQuery.#handle` to a
+     * `WeakRef` in the future, the chain breaks and this test fails —
+     * forcing the design discussion (do we want a "collected" QueryState
+     * variant?) back into scope before the change can land.
+     *
+     * Sequence
+     * --------
+     *   1. Create a doc; capture `WeakRef` as `probe`.
+     *   2. Get the query via `Repo[testInternals]`. Call `query.subscribe`
+     *      with a no-op callback; keep the returned `unsubscribe`.
+     *   3. Drop the handle reference (IIFE scope).
+     *   4. `flushGC()` (negative) — should NOT collect: `unsubscribe` pins
+     *      query, query pins handle.
+     *   5. Drop the `unsubscribe` reference.
+     *   6. `waitForGC(probe)` — collects.
+     */
+    async () => {
+      let probe!: WeakRef<object>
+      let repo!: Repo
+      let unsubscribe: (() => void) | undefined
+
+      vi.useFakeTimers()
+      try {
+        repo = setup().repo
+        ;(() => {
+          const handle = repo.create<TestDoc>({ foo: "bar" })
+          probe = new WeakRef(handle)
+
+          const internals = Repo[testInternals](repo)
+          const query = internals.queriesByHandle.get(handle)
+          if (!query) throw new Error("query missing for freshly-created doc")
+          unsubscribe = query.subscribe(() => {})
+        })()
+
+        await repo.flush()
+        await vi.advanceTimersByTimeAsync(SAVE_THROTTLE_MS * 2)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      // Confirm the unsubscribe function is what we expect — and the
+      // act of reading it keeps the static-analyzer happy. The
+      // load-bearing thing for the test is that the variable still
+      // strongly references the closure across the flushGC below.
+      expect(typeof unsubscribe).toBe("function")
+
+      // Subscriber chain pins the handle.
+      await flushGC()
+      expect(probe.deref()).toBeDefined()
+
+      // Drop the unsubscribe reference. Not calling unsubscribe() is
+      // sufficient — the closure-captured query is what pins. Calling
+      // it would only remove the callback from the subscriber set; the
+      // closure still holds the query until the variable releases.
+      unsubscribe = undefined
+
+      expect(await waitForGC(probe)).toBe(true)
+    }
+  )
 })

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -14,7 +14,7 @@ import {
 import { DocMetrics, Repo, ShareConfig } from "../src/Repo.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
-import { flushGC } from "./helpers/flushGC.js"
+import { waitForGC } from "./helpers/flushGC.js"
 import {
   AnyDocumentId,
   UrlHeads,
@@ -709,10 +709,14 @@ describe("Repo", () => {
 
         await repo.removeFromCache(documentId)
         await pause(500)
-        await flushGC(10)
 
-        expect(parentRef.deref()).toBeUndefined()
-        expect(viewRef.deref()).toBeUndefined()
+        expect(
+          await waitForGC(
+            () =>
+              parentRef.deref() === undefined && viewRef.deref() === undefined,
+            5000
+          )
+        ).toBe(true)
       })
     })
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -14,6 +14,7 @@ import {
 import { DocMetrics, Repo, ShareConfig } from "../src/Repo.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
+import { flushGC } from "./helpers/flushGC.js"
 import {
   AnyDocumentId,
   UrlHeads,
@@ -675,6 +676,43 @@ describe("Repo", () => {
         const handleCacheSize = Object.keys(repo.handles).length
         await repo.removeFromCache(badDocumentId)
         assert(Object.keys(repo.handles).length === handleCacheSize)
+      })
+
+      // Skipped: removeFromCache today does not detach the listeners that
+      // DocSynchronizer and Repo.#saveFn add to the handle. Those listener
+      // closures form a cycle (DocHandle.events → closure → DocSynchronizer
+      // → DocSynchronizer.#handle → DocHandle), and combined with internal
+      // state — pending throttle timers, the XState actor, the saveDoc
+      // promise chain — the cycle does not get reclaimed even after a long
+      // pause and many GC cycles. Making this pass would require an
+      // explicit teardown step in removeFromCache (e.g. handle.removeAll
+      // Listeners() once the synchronizer/storage subsystems are detached).
+      // That's a behavior change with potential user-visible implications,
+      // so it's deliberately out of scope here. The WeakValueMap migration
+      // of #viewCache is still correct (see the view() GC test in
+      // DocHandle.test.ts which passes).
+      it.skip("removeFromCache lets the parent + view handle become GC-eligible", async () => {
+        const { repo } = setup()
+
+        // Scope strong references inside an inner function so they don't
+        // pin the values via the test stack frame after we drop them.
+        const { parentRef, viewRef, documentId } = (() => {
+          const handle = repo.create<TestDoc>({ foo: "bar" })
+          handle.change(d => (d.foo = "baz"))
+          const view = handle.view(handle.heads()!)
+          return {
+            parentRef: new WeakRef(handle),
+            viewRef: new WeakRef(view),
+            documentId: handle.documentId,
+          }
+        })()
+
+        await repo.removeFromCache(documentId)
+        await pause(500)
+        await flushGC(10)
+
+        expect(parentRef.deref()).toBeUndefined()
+        expect(viewRef.deref()).toBeUndefined()
       })
     })
 

--- a/packages/automerge-repo/test/WeakValueMap.test.ts
+++ b/packages/automerge-repo/test/WeakValueMap.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest"
+import { WeakValueMap } from "../src/helpers/WeakValueMap.js"
+import { flushGC, gcAvailable } from "./helpers/flushGC.js"
+
+const itGC = gcAvailable ? it : it.skip
+
+class Box {
+  constructor(public n: number) {}
+}
+
+describe("WeakValueMap — synchronous behavior", () => {
+  it("set/get round-trips with string keys", () => {
+    const m = new WeakValueMap<string, Box>()
+    const v = new Box(1)
+    m.set("a", v)
+    expect(m.get("a")).toBe(v)
+    expect(m.has("a")).toBe(true)
+  })
+
+  it("set/get round-trips with number keys", () => {
+    const m = new WeakValueMap<number, Box>()
+    const v = new Box(2)
+    m.set(42, v)
+    expect(m.get(42)).toBe(v)
+  })
+
+  it("get returns undefined for missing keys", () => {
+    const m = new WeakValueMap<string, Box>()
+    expect(m.get("missing")).toBeUndefined()
+    expect(m.has("missing")).toBe(false)
+  })
+
+  it("delete removes the entry", () => {
+    const m = new WeakValueMap<string, Box>()
+    const v = new Box(3)
+    m.set("a", v)
+    expect(m.delete("a")).toBe(true)
+    expect(m.get("a")).toBeUndefined()
+    expect(m.delete("a")).toBe(false)
+  })
+
+  it("set overwrites with the new value", () => {
+    const m = new WeakValueMap<string, Box>()
+    const v1 = new Box(1)
+    const v2 = new Box(2)
+    m.set("a", v1)
+    m.set("a", v2)
+    expect(m.get("a")).toBe(v2)
+  })
+
+  it("getOrCompute calls the factory only on miss", () => {
+    const m = new WeakValueMap<string, Box>()
+    let calls = 0
+    const factory = () => {
+      calls++
+      return new Box(7)
+    }
+    const a = m.getOrCompute("k", factory)
+    const b = m.getOrCompute("k", factory)
+    expect(a).toBe(b)
+    expect(calls).toBe(1)
+  })
+})
+
+describe("WeakValueMap — GC behavior", () => {
+  itGC("evicts the entry once the value is collected", async () => {
+    const m = new WeakValueMap<string, Box>()
+    let probe!: WeakRef<Box>
+
+      // Scope the strong reference to an inner block so it doesn't pin the
+      // value via the test stack frame.
+    ;(() => {
+      const v = new Box(1)
+      m.set("k", v)
+      probe = new WeakRef(v)
+    })()
+
+    await flushGC()
+
+    expect(probe.deref()).toBeUndefined()
+    expect(m.get("k")).toBeUndefined()
+    // Observable proof the entry is gone: the factory runs again.
+    let factoryCalled = false
+    const fresh = m.getOrCompute("k", () => {
+      factoryCalled = true
+      return new Box(2)
+    })
+    expect(factoryCalled).toBe(true)
+    expect(fresh).toBeInstanceOf(Box)
+  })
+
+  itGC("retains the entry while the value is still referenced", async () => {
+    const m = new WeakValueMap<string, Box>()
+    const kept = new Box(1)
+    m.set("k", kept)
+
+    await flushGC()
+
+    expect(m.get("k")).toBe(kept)
+  })
+
+  itGC("overwrite unregisters the previous value's finalizer", async () => {
+    // If set() did not unregister the previous value's token, then once
+    // v1 is collected its finalizer would delete the "k" entry — even
+    // though v2 is still alive.
+    const m = new WeakValueMap<string, Box>()
+    const v2 = new Box(2)
+
+    ;(() => {
+      const v1 = new Box(1)
+      m.set("k", v1)
+      m.set("k", v2)
+    })()
+
+    await flushGC()
+
+    expect(m.get("k")).toBe(v2)
+  })
+
+  itGC("evicts many entries when all values are dropped", async () => {
+    const m = new WeakValueMap<number, Box>()
+    const probes: WeakRef<Box>[] = []
+
+    ;(() => {
+      for (let i = 0; i < 1000; i++) {
+        const v = new Box(i)
+        m.set(i, v)
+        probes.push(new WeakRef(v))
+      }
+    })()
+
+    await flushGC()
+
+    const alive = probes.filter(r => r.deref() !== undefined).length
+    expect(alive).toBe(0)
+    // Observable proof keys are gone: factory runs for every key.
+    let factoryCalls = 0
+    for (let i = 0; i < 1000; i++) {
+      m.getOrCompute(i, () => {
+        factoryCalls++
+        return new Box(-1)
+      })
+    }
+    expect(factoryCalls).toBe(1000)
+  })
+})

--- a/packages/automerge-repo/test/WeakValueMap.test.ts
+++ b/packages/automerge-repo/test/WeakValueMap.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { WeakValueMap } from "../src/helpers/WeakValueMap.js"
-import { flushGC, gcAvailable } from "./helpers/flushGC.js"
+import { flushGC, gcAvailable, waitForGC } from "./helpers/flushGC.js"
 
 const itGC = gcAvailable ? it : it.skip
 
@@ -75,9 +75,7 @@ describe("WeakValueMap — GC behavior", () => {
       probe = new WeakRef(v)
     })()
 
-    await flushGC()
-
-    expect(probe.deref()).toBeUndefined()
+    expect(await waitForGC(probe)).toBe(true)
     expect(m.get("k")).toBeUndefined()
     // Observable proof the entry is gone: the factory runs again.
     let factoryCalled = false
@@ -94,6 +92,9 @@ describe("WeakValueMap — GC behavior", () => {
     const kept = new Box(1)
     m.set("k", kept)
 
+    // Negative assertion: the value is strongly held, so a best-effort GC
+    // should NOT collect it. waitForGC would always time out here, so use
+    // the fixed-rounds variant.
     await flushGC()
 
     expect(m.get("k")).toBe(kept)
@@ -105,15 +106,15 @@ describe("WeakValueMap — GC behavior", () => {
     // though v2 is still alive.
     const m = new WeakValueMap<string, Box>()
     const v2 = new Box(2)
-
+    let v1Probe!: WeakRef<Box>
     ;(() => {
       const v1 = new Box(1)
       m.set("k", v1)
       m.set("k", v2)
+      v1Probe = new WeakRef(v1)
     })()
 
-    await flushGC()
-
+    expect(await waitForGC(v1Probe)).toBe(true)
     expect(m.get("k")).toBe(v2)
   })
 
@@ -129,10 +130,10 @@ describe("WeakValueMap — GC behavior", () => {
       }
     })()
 
-    await flushGC()
-
-    const alive = probes.filter(r => r.deref() !== undefined).length
-    expect(alive).toBe(0)
+    // 1000 entries — give the engine a wider budget than the default 1s.
+    expect(
+      await waitForGC(() => probes.every(r => r.deref() === undefined), 5000)
+    ).toBe(true)
     // Observable proof keys are gone: factory runs for every key.
     let factoryCalls = 0
     for (let i = 0; i < 1000; i++) {

--- a/packages/automerge-repo/test/WeakValueMap.test.ts
+++ b/packages/automerge-repo/test/WeakValueMap.test.ts
@@ -60,6 +60,58 @@ describe("WeakValueMap — synchronous behavior", () => {
     expect(a).toBe(b)
     expect(calls).toBe(1)
   })
+
+  it("entries yields [key, value] for each entry", () => {
+    const m = new WeakValueMap<string, Box>()
+    const a = new Box(1)
+    const b = new Box(2)
+    m.set("a", a)
+    m.set("b", b)
+
+    const entries = Array.from(m.entries())
+    expect(entries).toHaveLength(2)
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        ["a", a],
+        ["b", b],
+      ])
+    )
+  })
+
+  it("keys yields the key for each entry", () => {
+    const m = new WeakValueMap<string, Box>()
+    m.set("a", new Box(1))
+    m.set("b", new Box(2))
+    expect([...m.keys()].sort()).toEqual(["a", "b"])
+  })
+
+  it("values yields the value for each entry", () => {
+    const m = new WeakValueMap<string, Box>()
+    const a = new Box(1)
+    const b = new Box(2)
+    m.set("a", a)
+    m.set("b", b)
+    const values = [...m.values()]
+    expect(values).toHaveLength(2)
+    expect(values).toEqual(expect.arrayContaining([a, b]))
+  })
+
+  it("is iterable via Symbol.iterator and yields [key, value]", () => {
+    const m = new WeakValueMap<string, Box>()
+    const a = new Box(1)
+    m.set("a", a)
+    const collected: [string, Box][] = []
+    for (const entry of m) collected.push(entry)
+    expect(collected).toEqual([["a", a]])
+  })
+
+  it("iteration reflects deletions", () => {
+    const m = new WeakValueMap<string, Box>()
+    m.set("a", new Box(1))
+    m.set("b", new Box(2))
+    m.delete("a")
+    expect([...m.keys()]).toEqual(["b"])
+  })
 })
 
 describe("WeakValueMap — GC behavior", () => {

--- a/packages/automerge-repo/test/helpers/flushGC.ts
+++ b/packages/automerge-repo/test/helpers/flushGC.ts
@@ -1,0 +1,22 @@
+/**
+ * Force a few GC cycles and yield long enough for FinalizationRegistry
+ * callbacks to run. Multiple rounds because young-generation collection
+ * may not promote/finalize on the first sweep.
+ *
+ * Requires the test runner to expose `globalThis.gc` (run with --expose-gc).
+ * Use the `itGC` guard if your test should skip cleanly when unavailable.
+ */
+export async function flushGC(rounds = 3): Promise<void> {
+  if (typeof globalThis.gc !== "function") {
+    throw new Error(
+      "flushGC requires --expose-gc; configure vitest poolOptions.{forks,threads}.execArgv"
+    )
+  }
+  for (let i = 0; i < rounds; i++) {
+    globalThis.gc()
+    await new Promise(resolve => setImmediate(resolve))
+  }
+}
+
+/** Skip-when-unavailable guard for GC-dependent tests. */
+export const gcAvailable = typeof globalThis.gc === "function"

--- a/packages/automerge-repo/test/helpers/flushGC.ts
+++ b/packages/automerge-repo/test/helpers/flushGC.ts
@@ -1,20 +1,129 @@
 /**
- * Force a few GC cycles and yield long enough for FinalizationRegistry
- * callbacks to run. Multiple rounds because young-generation collection
- * may not promote/finalize on the first sweep.
+ * Test helpers for GC-dependent tests.
  *
  * Requires the test runner to expose `globalThis.gc` (run with --expose-gc).
- * Use the `itGC` guard if your test should skip cleanly when unavailable.
+ * Use {@link gcAvailable} (or the `itGC` pattern) to skip cleanly when
+ * unavailable:
+ *
+ *   const itGC = gcAvailable ? it : it.skip
+ *   itGC("...", async () => { ... })
+ *
+ * Two flavors are exported:
+ *   - {@link waitForGC} — adaptive: poll a WeakRef (or predicate) until
+ *     collection is observed or `timeoutMs` elapses. Use for *positive*
+ *     collection assertions.
+ *   - {@link flushGC} — fixed: fire `rounds` GC cycles unconditionally. Use
+ *     for *negative* assertions (something is strongly held and should still
+ *     be present after a best-effort GC).
+ *
+ * ## CI flakiness defenses
+ *
+ * GC tests are inherently engine-timing-dependent and have a reputation for
+ * being flaky. The defenses here are deliberate:
+ *
+ *   - **Adaptive polling, not fixed sleeps.** {@link waitForGC} exits as
+ *     soon as collection is observed, so a fast engine pays ~5 ms while a
+ *     loaded CI machine still gets the full timeout budget. No wall-clock
+ *     "wait N seconds and hope" anywhere in the success path.
+ *   - **Timeout is a failure budget, not a wait.** The success path never
+ *     pays the timeout. The 1 s default exists only so a genuine leak
+ *     surfaces as a deterministic failed assertion within bounded time
+ *     instead of hanging the suite.
+ *   - **Boolean return + explicit `expect(...).toBe(true)`.** A timeout
+ *     turns into a loud failed assertion, never a silent pass. Compare
+ *     `await flushGC(); expect(probe.deref()).toBeUndefined()`, where a
+ *     missed collection produces a useful error only by luck of which
+ *     assertion fires first.
+ *   - **Macrotask yield is mandatory.** V8 retains the value returned by
+ *     `WeakRef.deref()` until the end of the current Job — and microtask
+ *     boundaries (`Promise.resolve()`, `queueMicrotask`) empirically do
+ *     NOT release that pin. We use `setImmediate`. The loop in
+ *     {@link waitForGC} also orders check-then-yield-then-gc so the pin
+ *     from the previous iteration's deref is released before the next
+ *     `gc()` runs.
+ *   - **Vitest fake timers do not apply.** Fake timers mock `setTimeout` /
+ *     `setImmediate` / `Date`, but `globalThis.gc()` and
+ *     `FinalizationRegistry` callbacks are V8 internals and are not
+ *     faked. Real macrotask yields are required for finalizers to drain.
  */
-export async function flushGC(rounds = 3): Promise<void> {
-  if (typeof globalThis.gc !== "function") {
+
+const callGC = (): void => {
+  const gc = globalThis.gc
+  if (typeof gc !== "function") {
     throw new Error(
-      "flushGC requires --expose-gc; configure vitest poolOptions.{forks,threads}.execArgv"
+      "GC helpers require --expose-gc; configure vitest test.execArgv"
     )
   }
+  // Use the no-arg form. Empirically (Node 20), passing the options object
+  // — even `{ execution: "sync", type: "major" }` — leaves WeakRef targets
+  // observably alive after a setImmediate yield, while `gc()` collects them.
+  // The no-arg default is full-mark-sweep on V8/Node, which is what we want.
+  gc()
+}
+
+const yieldForFinalizers = (): Promise<void> =>
+  // setImmediate yields the macrotask queue, which drains microtasks first —
+  // FinalizationRegistry callbacks are scheduled as microtasks, so they run
+  // before the next round.
+  new Promise(resolve => setImmediate(resolve))
+
+/**
+ * Force GC cycles and yield until `target` is satisfied, or `timeoutMs`
+ * elapses. `target` may be:
+ *   - a `WeakRef`, satisfied once `.deref()` returns `undefined`
+ *   - a predicate, satisfied once it returns `true`
+ *
+ * Returns `true` if observed before the timeout, `false` on timeout. Always
+ * test the boolean explicitly so a CI miss is a loud failed assertion:
+ *
+ *   expect(await waitForGC(probe)).toBe(true)
+ *
+ * `timeoutMs` is a *failure budget*, not a wait. The loop exits as soon as
+ * collection is observed (typically 2 iterations / a few ms), so success
+ * never pays the timeout. The default 1 s exists so a genuine leak fails
+ * deterministically within bounded time instead of hanging the suite.
+ *
+ * Loop ordering matters. `WeakRef.deref()` retains the returned value until
+ * the end of the current Job (V8's kept-alive list, cleared at macrotask
+ * boundaries — microtask yields like `Promise.resolve()` are NOT enough).
+ * The order is:
+ *   1. check predicate (may deref → pins value for this Job)
+ *   2. yield (macrotask boundary releases the pin)
+ *   3. gc() (now able to collect)
+ *   4. yield (FinalizationRegistry callbacks fire)
+ * Putting gc() before the yield-after-check would re-pin via the next
+ * iteration's check before gc could collect — empirically this never
+ * converges.
+ */
+export async function waitForGC(
+  target: WeakRef<WeakKey> | (() => boolean),
+  timeoutMs = 1000
+): Promise<boolean> {
+  const isDone =
+    typeof target === "function"
+      ? target
+      : (): boolean => target.deref() === undefined
+
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (isDone()) return true
+    await yieldForFinalizers()
+    callGC()
+    await yieldForFinalizers()
+  }
+  return false
+}
+
+/**
+ * Fire a fixed number of GC cycles, yielding for finalizer callbacks between
+ * each. Use when there is no specific WeakRef to await — e.g. asserting that
+ * a strongly-held value is *not* collected. For positive collection
+ * assertions prefer {@link waitForGC}.
+ */
+export async function flushGC(rounds = 3): Promise<void> {
   for (let i = 0; i < rounds; i++) {
-    globalThis.gc()
-    await new Promise(resolve => setImmediate(resolve))
+    callGC()
+    await yieldForFinalizers()
   }
 }
 

--- a/packages/automerge-repo/test/refs/ref.cleanup.test.ts
+++ b/packages/automerge-repo/test/refs/ref.cleanup.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from "vitest"
+import { Repo } from "../../src/Repo.js"
+import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
+import { DummyNetworkAdapter } from "../../src/helpers/DummyNetworkAdapter.js"
+import { flushGC, gcAvailable, waitForGC } from "../helpers/flushGC.js"
+
+const itGC = gcAvailable ? it : it.skip
+
+interface TestDoc {
+  foo: string
+  nested: { bar: string }
+}
+
+/**
+ * Test design — fake timers for the throttle phase, real timers for GC.
+ *
+ * `StorageSource.attach` registers a `heads-changed → asyncThrottle(saveFn,
+ * saveDebounceRate)` listener on the handle. The throttle's `setTimeout`
+ * retains the saveFn closure (which captures `{handle, doc}`), so a pending
+ * timer pins the handle independently of the cleanup work we're testing.
+ *
+ * Each itGC test activates fake timers around `repo.create` and the throttle
+ * settling, then switches to real timers for the GC helpers (`flushGC`,
+ * `waitForGC`) which need real `setImmediate` for finalizer drains.
+ */
+
+const SAVE_THROTTLE_MS = 100
+
+const setup = () => {
+  const storage = new DummyStorageAdapter()
+  const network = new DummyNetworkAdapter({ startReady: true })
+  const repo = new Repo({ storage, network: [network] })
+  return { repo, storage, network }
+}
+
+describe("Ref cleanup — listeners don't pin past the handle's lifetime", () => {
+  itGC(
+    "dropping a handle with refs created from it lets the handle be GC'd",
+    /**
+     * Why this matters
+     * ----------------
+     * Before the cleanup refactor, `RefImpl` registered a
+     * `FinalizationRegistry` whose held value was an arrow function
+     * `() => this.#cleanup()`. The registry holds its held value
+     * strongly while the target is alive — so the held value's
+     * reference to `this` (the Ref) prevented the Ref from ever
+     * becoming collectable. The Ref's strong `docHandle` field then
+     * pinned the handle. Net effect: any handle that ever had a Ref
+     * created from it was permanently retained.
+     *
+     * The fix removes the `FinalizationRegistry` entirely. The Ref's
+     * `change` listener on the handle still captures `this`, but that
+     * forms an internal cycle (`handle → events → listener → this →
+     * docHandle → handle`) which is collectable as a unit when
+     * nothing external pins either side. So dropping both the handle
+     * and the Ref together releases everything.
+     *
+     * Sequence
+     * --------
+     *   1. Create a handle and call `handle.ref(path)`.
+     *   2. Drop both inside an IIFE; capture a `WeakRef` to the handle.
+     *   3. Settle the StorageSource save throttle via fake timers.
+     *   4. `waitForGC(handleProbe)` — expect collection.
+     */
+    async () => {
+      let handleProbe!: WeakRef<object>
+      let repo!: Repo
+
+      vi.useFakeTimers()
+      try {
+        repo = setup().repo
+        ;(() => {
+          const handle = repo.create<TestDoc>({
+            foo: "bar",
+            nested: { bar: "baz" },
+          })
+          handleProbe = new WeakRef(handle)
+          // Create Refs pinned to the handle. Before the fix, this
+          // alone would prevent `handle` from ever being collected.
+          handle.ref("foo")
+          handle.ref("nested", "bar")
+        })()
+
+        await repo.flush()
+        await vi.advanceTimersByTimeAsync(SAVE_THROTTLE_MS * 2)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      expect(await waitForGC(handleProbe)).toBe(true)
+    }
+  )
+
+  itGC(
+    "ref.dispose() releases the listener and lets the Ref be GC'd while the handle is held",
+    /**
+     * Why this matters
+     * ----------------
+     * Without `dispose()`, a Ref is pinned by its own `change`
+     * listener on the handle (the listener closure captures `this`),
+     * so the Ref can't be collected while the handle is alive. For
+     * consumers who want to release a Ref while keeping the handle —
+     * e.g. they created many Refs over time and want to release the
+     * ones they're no longer using — `dispose()` removes the listener
+     * and resets `#updateHandler` to `noop`, releasing the closure.
+     *
+     * Sequence
+     * --------
+     *   1. Hold the handle strongly outside the IIFE.
+     *   2. Inside the IIFE, call `handle.ref(path)`, call `dispose()`
+     *      on the resulting Ref, and capture a `WeakRef` to it.
+     *   3. Settle throttles.
+     *   4. `waitForGC(refProbe)` — expect collection.
+     *
+     * Note: `DocHandle.#refCache` is a `WeakValueMap` that holds the
+     * Ref weakly, so it doesn't pin either.
+     */
+    async () => {
+      let refProbe!: WeakRef<object>
+      let handle!: ReturnType<Repo["create"]>
+      let repo!: Repo
+
+      vi.useFakeTimers()
+      try {
+        repo = setup().repo
+        handle = repo.create<TestDoc>({
+          foo: "bar",
+          nested: { bar: "baz" },
+        })
+        ;(() => {
+          const ref = handle.ref("foo")
+          ref.dispose()
+          refProbe = new WeakRef(ref)
+        })()
+
+        await repo.flush()
+        await vi.advanceTimersByTimeAsync(SAVE_THROTTLE_MS * 2)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      expect(await waitForGC(refProbe)).toBe(true)
+      // Sanity: the handle is still alive (we hold it).
+      expect(handle.documentId).toBeDefined()
+    }
+  )
+
+  itGC(
+    "a Ref kept alive (without dispose()) keeps its handle alive",
+    /**
+     * Why this matters
+     * ----------------
+     * Documents the natural consequence of `Ref.docHandle` being a
+     * strong field: while a consumer holds a Ref, the handle is
+     * implicitly reachable through it. This is intentional — calling
+     * methods on a Ref requires the document to be loaded.
+     *
+     * Sequence
+     * --------
+     *   1. Inside an IIFE, create a handle and call `handle.ref(path)`.
+     *      Capture a `WeakRef` to the handle. Keep the Ref strong.
+     *   2. Settle throttles.
+     *   3. `flushGC()` (fixed rounds, negative assertion).
+     *   4. Expect the handle to still be alive.
+     */
+    async () => {
+      let handleProbe!: WeakRef<object>
+      let ref: unknown
+      let repo!: Repo
+
+      vi.useFakeTimers()
+      try {
+        repo = setup().repo
+        ;(() => {
+          const handle = repo.create<TestDoc>({
+            foo: "bar",
+            nested: { bar: "baz" },
+          })
+          handleProbe = new WeakRef(handle)
+          ref = handle.ref("foo")
+        })()
+
+        await repo.flush()
+        await vi.advanceTimersByTimeAsync(SAVE_THROTTLE_MS * 2)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      // The Ref is held strongly; `Ref.docHandle` keeps the handle alive.
+      await flushGC()
+      expect(handleProbe.deref()).toBeDefined()
+
+      // Read `ref` so the static-analyzer is content; also documents
+      // the test premise (the Ref is what's holding the handle).
+      expect(ref).toBeDefined()
+    }
+  )
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
     // instanceof tests when going back and forth from wasm-bindgen
     environment: "happy-dom",
 
+    // Expose globalThis.gc to test workers so GC-dependent tests can opt in.
+    // Vitest 4 reads `test.execArgv` per project (cli-api: project.config.execArgv);
+    // poolOptions on its own doesn't reach project workers under `projects`.
+    execArgv: ["--expose-gc"],
+
     coverage: {
       provider: "v8",
       reporter: ["lcov", "text", "html"],


### PR DESCRIPTION
Builds on https://github.com/automerge/automerge-repo/pull/636 and https://github.com/automerge/automerge-repo/pull/618

The objective of this PR is to reduce a class of subtle memory leaks. Today, there are issues with tightly held references across coupled code in automerge-repo that prevent garbage collection.  The existing `Repo.removeFromCache()` has some edge cases where memory is not released because of some tightly held references.

This PR introduces a new mental model for the automerge-repo user: holding a strong reference keeps the document loaded; dropping the references lets the repo release its coordination state automatically.  `Repo.removeFromCache()` can still be used, but is unnecessary if the automerge-repo user drops reference.

The commit messages provide more details about the changes. The following is an abridged summary:

- New `WeakValueMap` encapusulates the existing `Map<string, WeakRef>` pattern already in place in `#refCache`  This allows the pattern to be reused with additional caches.  `refCache` and `viewCache` now use `WeakValueMap`.
    - The new `WeakValueMap` also affords cleanup of dead string keys
- Breaks up `Repo.#queries` into `Repo.#queriesByHandle` and `Repo.#querHandleByDocumentId`.  This enables Garbage Collection
- Weakens the `DocSynchronizer` references (which used to be strong refs) so that dropping the handle allows garbage collection
- Adds helpers for unit tests to do adaptive GC polling that demonstrates the weak refs are properly garbage collected
- `Repo` now has `FinalizationRegistry` to ensure cleanup of per-doc coordination state (that was coupled)
    - Adds unit tests to demonstrate consumer-driven cleanup per doc occurs
    - Adds tests for cross-cutting cases to guard against regressions
