### PR TITLE
test: stabilize useDocuments "changes during loading" test

### DIFF
--- a/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocuments.test.tsx
@@ -399,18 +399,17 @@ describe("useDocuments", () => {
       render(<Wrapped />, { wrapper })
 
       // Make a change while document is loading
-      handleA.change(doc => (doc.counter = 1))
-
-      // Wait for load
       await act(async () => {
-        await Promise.resolve()
+        handleA.change(doc => (doc.counter = 1))
       })
 
       // Should have latest state
-      const [docs] = onState.mock.lastCall || []
-      expect(docs.get(handleA.url)).toEqual({
-        foo: "A",
-        counter: 1,
+      await waitFor(() => {
+        const [docs] = onState.mock.lastCall || []
+        expect(docs.get(handleA.url)).toEqual({
+          foo: "A",
+          counter: 1,
+        })
       })
     })
 


### PR DESCRIPTION
Addresses flaky test: https://github.com/automerge/automerge-repo/pull/636#issuecomment-4544741530

`handle.change()` ran outside `act()` and the assertion relied on a single microtask flush. Under load the change event could fire while `useDocuments` was mid-re-attach of its change listener, leaving the `docMap` stale. Wrap the change in `act()` like every other change-propagation test in this file, and `waitFor` the assertion to tolerate extra microtasks.

Verified with 50/50 local runs.