### PR TITLE
fix: flaky repo test

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
+++ b/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
@@ -9,11 +9,23 @@ import { pause } from "../../automerge-repo/src/helpers/pause.js"
 
 describe("BroadcastChannel", () => {
   const setup: SetupFn = async () => {
-    const a = new BroadcastChannelNetworkAdapter()
-    const b = new BroadcastChannelNetworkAdapter()
-    const c = new BroadcastChannelNetworkAdapter()
+    // Isolate each test on its own channel. A shared channel lets stale
+    // adapters from another test in the same process answer "arrive" with
+    // "welcome", which fires extra peer-candidate events for the same
+    // peerIds and resets per-peer sync state mid-test.
+    const channelName = `broadcast-${Math.random().toString(36).slice(2)}`
+    const a = new BroadcastChannelNetworkAdapter({ channelName })
+    const b = new BroadcastChannelNetworkAdapter({ channelName })
+    const c = new BroadcastChannelNetworkAdapter({ channelName })
 
-    return { adapters: [a, b, c] }
+    return {
+      adapters: [a, b, c],
+      teardown: () => {
+        a.disconnect()
+        b.disconnect()
+        c.disconnect()
+      },
+    }
   }
 
   runNetworkAdapterTests(setup)

--- a/packages/automerge-repo/src/helpers/DummyNetworkAdapter.ts
+++ b/packages/automerge-repo/src/helpers/DummyNetworkAdapter.ts
@@ -66,16 +66,25 @@ export class DummyNetworkAdapter extends NetworkAdapter {
     this.emit("message", message)
   }
 
-  static createConnectedPair({ latency = 10 }: { latency?: number } = {}) {
+  static createConnectedPair({ latency = 0 }: { latency?: number } = {}) {
+    // Default to microtask delivery. `setTimeout`-based delivery (any
+    // `latency > 0`) is subject to event-loop starvation under concurrent
+    // test load, which produces flaky round-trip-heavy tests. Callers that
+    // actually want to simulate latency can still pass a positive value.
+    const deliver =
+      latency === 0
+        ? (adapter: DummyNetworkAdapter, message: Message) =>
+            Promise.resolve().then(() => adapter.receive(message))
+        : (adapter: DummyNetworkAdapter, message: Message) =>
+            pause(latency).then(() => adapter.receive(message))
+
     const adapter1: DummyNetworkAdapter = new DummyNetworkAdapter({
       startReady: true,
-      sendMessage: (message: Message) =>
-        pause(latency).then(() => adapter2.receive(message)),
+      sendMessage: (message: Message) => deliver(adapter2, message),
     })
     const adapter2: DummyNetworkAdapter = new DummyNetworkAdapter({
       startReady: true,
-      sendMessage: (message: Message) =>
-        pause(latency).then(() => adapter1.receive(message)),
+      sendMessage: (message: Message) => deliver(adapter1, message),
     })
 
     return [adapter1, adapter2]


### PR DESCRIPTION
https://github.com/automerge/automerge-repo/actions/runs/26454774295/job/77885482020?pr=637

I believe this test was flaky because it used `createConnectedPair()` with `{latency = 0}` default, and `pause(0)` is a macro task (not micro task) that caused event-loop starvation under rount-trip-heavy tests.   For `{latency = 0}`, it is better to have `micro` task for 0 latency case.