### PR TITLE
chore: adopt pnpm 11 + supply-chain controls (part 2 of #653)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "watch": "pnpm run --parallel --stream -r watch "
   },
   "engines": {
-    "node": ">=22.13"
+    "node": ">=22.13",
+    "pnpm": "^11"
   },
-  "packageManager": "pnpm@10.32.1",
+  "packageManager": "pnpm@11.5.0",
   "prettier": {
     "semi": false,
     "singleQuote": false,
@@ -77,10 +78,5 @@
   },
   "dependencies": {
     "happy-dom": "^20.0.10"
-  },
-  "pnpm": {
-    "overrides": {
-      "semver": "^7.5.2"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,15 @@ packages:
   - packages/**
   - examples/**
   - "!packages/create-vite-app/template/**"
+allowBuilds:
+  "@swc/core": true
+  cbor-extract: true
+  esbuild: true
+  nx: true
+  svelte-preprocess: true
+overrides:
+  semver: ^7.5.2
+# Supply-chain guard: wait 3 days (4320 minutes) after a version is published before
+# installing it, so a malicious or compromised release has time to be detected and
+# unpublished from the registry before it can land in our dependency tree.
+minimumReleaseAge: 4320


### PR DESCRIPTION
> ✅ #654 (CI + Node baseline) has merged. This is now rebased onto `main` and is a single, self-contained commit — ready for review.

Part 2 of breaking up #653 into a stack of smaller PRs.

## What this does

Switches the package manager from pnpm 10 to 11 and adopts pnpm 11's configuration model:

- `packageManager` pnpm@10.32.1 → **pnpm@11.5.0**; `engines.pnpm: ^11`.
- Move `overrides` (semver) out of package.json's `pnpm` field into `pnpm-workspace.yaml` — pnpm 11 reads overrides from there and silently ignores the package.json field.
- **`allowBuilds`** — pnpm 11's explicit build-script approval (replaces `onlyBuiltDependencies`): `@swc/core`, `cbor-extract`, `esbuild`, `nx`, `svelte-preprocess`.
- **`minimumReleaseAge: 4320`** — a 3-day quarantine on freshly published versions, so a malicious or compromised release has time to be caught before it can land in the tree.

No dependency versions change, and the lockfile is unaffected (pnpm 10 and 11 both use lockfile 9.0).

## Why no `catalog:` here

Intentionally deferred. main's shared dev deps are already version-fragmented (e.g. `vite` spans `^5` / `^6` / `^7` across packages, `vitest` `^3` / `^4`, `typescript` `^5.0` / `^5.4`), so adopting `catalog:` means picking a single version — which *is* the dependency-unification work of the later per-tool PRs. The `catalog:` protocol is introduced there (TypeScript → the TS 6 PR, Vite/vitest → the Vite 8 PR, React → the deps PR, and the published runtime deps once the release flow switches to `pnpm publish`).

## Verification

`pnpm build`, `pnpm lint`, and `pnpm test` (**817 passing**) all green on Node 25 / pnpm 11.5, rebased onto the post-#654 `main`.

---

Part of #653 · follows #654 (merged).
