### PR TITLE
chore: TypeScript 6 + type-aware oxlint (part 4 of #653)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,8 +40,9 @@ jobs:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
-      - name: Install
+      - name: Install and Build
         run: |
           pnpm install
+          pnpm build
       - name: Lint
         run: pnpm lint

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -52,14 +52,22 @@
       }
     ],
     "no-unused-expressions": ["error", { "allowShortCircuit": true }],
+    "typescript/no-floating-promises": "error",
     "no-empty-function": "off",
     "no-param-reassign": "off",
     "typescript/no-non-null-assertion": "off",
     "typescript/no-explicit-any": "off",
-    "react-hooks/exhaustive-deps": "off"
+    "react-hooks/exhaustive-deps": "off",
+    "typescript/restrict-template-expressions": "off",
+    "typescript/await-thenable": "off",
+    "typescript/no-useless-default-assignment": "off",
+    "typescript/no-meaningless-void-operator": "off"
   },
   "settings": {
     "react": { "version": "18" }
+  },
+  "options": {
+    "typeAware": true
   },
   "overrides": [
     {

--- a/examples/react-counter/tsconfig.json
+++ b/examples/react-counter/tsconfig.json
@@ -1,20 +1,4 @@
 {
-  "compilerOptions": {
-    "allowJs": false,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": false,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "noEmit": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "ESNext",
-    "useDefineForClassFields": true
-  },
+  "extends": "../../tsconfig.app.json",
   "include": ["src"]
 }

--- a/examples/react-todo/tsconfig.json
+++ b/examples/react-todo/tsconfig.json
@@ -1,20 +1,4 @@
 {
-  "compilerOptions": {
-    "allowJs": false,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": false,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "noEmit": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "ESNext",
-    "useDefineForClassFields": true
-  },
+  "extends": "../../tsconfig.app.json",
   "include": ["src"]
 }

--- a/examples/svelte-counter/tsconfig.json
+++ b/examples/svelte-counter/tsconfig.json
@@ -1,22 +1,9 @@
 {
+  "extends": ["../../tsconfig.app.json", "@tsconfig/svelte/tsconfig.json"],
   "compilerOptions": {
     "allowJs": true,
-    "allowSyntheticDefaultImports": true,
-    "checkJs": true,
-    "esModuleInterop": false,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "noEmit": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "ESNext",
-    "useDefineForClassFields": true
+    "checkJs": true
   },
-  "extends": "@tsconfig/svelte/tsconfig.json",
   "include": [
     "./node_modules/svelte/src/main/ambient.d.ts",
     "src/**/*.d.ts",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "preinstall": "npx only-allow pnpm",
     "repocheck": "manypkg check",
     "format": "oxfmt",
-    "lint": "oxfmt --check . && oxlint",
+    "lint": "oxfmt --check . && oxlint && pnpm run lint:check-types",
     "test": "vitest",
     "test:log": "cross-env DEBUG='automerge-repo:*' vitest",
     "test:coverage": "vitest --coverage",
     "test:ui": "vitest --coverage --ui",
-    "watch": "pnpm run --parallel --stream -r watch "
+    "watch": "pnpm run --parallel --stream -r watch ",
+    "lint:check-types": "pnpm run lint:check-types:packages",
+    "lint:check-types:packages": "pnpm --filter './packages/*' exec tsc --noEmit"
   },
   "engines": {
     "node": ">=22.13",
@@ -58,10 +60,11 @@
     "npm-watch": "^0.11.0",
     "oxfmt": "^0.52.0",
     "oxlint": "^1.67.0",
+    "oxlint-tsgolint": "^0.23.0",
     "portfinder": "^1.0.32",
     "ts-node": "^10.9.2",
     "typedoc": "^0.28.7",
-    "typescript": "^5.4.2",
+    "typescript": "^6.0.3",
     "vite": "^7.3.0",
     "vite-plugin-wasm": "^3.5.0",
     "vitest": "^4.0.15"

--- a/packages/automerge-react/package.json
+++ b/packages/automerge-react/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
-    "typescript": "^5.0.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.4"
   },
   "exports": {

--- a/packages/automerge-react/tsconfig.json
+++ b/packages/automerge-react/tsconfig.json
@@ -1,17 +1,8 @@
 {
+  "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "react",
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "skipLibCheck": true
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist"]

--- a/packages/automerge-repo-network-broadcastchannel/tsconfig.json
+++ b/packages/automerge-repo-network-broadcastchannel/tsconfig.json
@@ -1,16 +1,9 @@
 {
+  "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "react",
-    "module": "NodeNext",
-    "moduleResolution": "Node16",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
 }

--- a/packages/automerge-repo-network-messagechannel/tsconfig.json
+++ b/packages/automerge-repo-network-messagechannel/tsconfig.json
@@ -1,16 +1,9 @@
 {
+  "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "react",
-    "module": "NodeNext",
-    "moduleResolution": "Node16",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
 }

--- a/packages/automerge-repo-network-websocket/tsconfig.json
+++ b/packages/automerge-repo-network-websocket/tsconfig.json
@@ -1,16 +1,9 @@
 {
+  "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "react",
-    "module": "NodeNext",
-    "moduleResolution": "Node16",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
 }

--- a/packages/automerge-repo-react-hooks/tsconfig.json
+++ b/packages/automerge-repo-react-hooks/tsconfig.json
@@ -1,16 +1,9 @@
 {
+  "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "react",
-    "module": "NodeNext",
-    "moduleResolution": "Node16",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
 }

--- a/packages/automerge-repo-solid-primitives/tsconfig.build.json
+++ b/packages/automerge-repo-solid-primitives/tsconfig.build.json
@@ -1,20 +1,17 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "allowImportingTsExtensions": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
     "isolatedDeclarations": true,
-    "strict": true,
-    "skipLibCheck": true,
     "composite": true,
     "pretty": true,
-    "rootDir": "./src",
     "rewriteRelativeImportExtensions": true,
+    "rootDir": "./src",
     "outDir": "./out"
   },
   "include": ["src"]

--- a/packages/automerge-repo-solid-primitives/tsconfig.json
+++ b/packages/automerge-repo-solid-primitives/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/packages/automerge-repo-solid-primitives/tsconfig.test.json
+++ b/packages/automerge-repo-solid-primitives/tsconfig.test.json
@@ -1,20 +1,12 @@
 {
+  "extends": "../../tsconfig.app.json",
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
     "types": ["@testing-library/jest-dom"],
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
     "declaration": true,
     "declarationMap": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "isolatedModules": true,
-    "composite": true,
-    "noEmit": true
+    "composite": true
   },
   "include": ["test/**/*.tsx", "src/**/*.ts"]
 }

--- a/packages/automerge-repo-storage-indexeddb/tsconfig.json
+++ b/packages/automerge-repo-storage-indexeddb/tsconfig.json
@@ -1,16 +1,9 @@
 {
+  "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "react",
-    "module": "NodeNext",
-    "moduleResolution": "Node16",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
 }

--- a/packages/automerge-repo-storage-nodefs/tsconfig.json
+++ b/packages/automerge-repo-storage-nodefs/tsconfig.json
@@ -1,15 +1,10 @@
 {
+  "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "NodeNext",
-    "moduleResolution": "Node16",
-    "declaration": true,
-    "declarationMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
+    "types": ["node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
 }

--- a/packages/automerge-repo-svelte-store/package.json
+++ b/packages/automerge-repo-svelte-store/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@sveltejs/package": "^2.3.11",
-    "typescript": "^5.0.0"
+    "typescript": "^6.0.3"
   },
   "watch": {
     "build": {

--- a/packages/automerge-repo-svelte-store/src/lib/index.ts
+++ b/packages/automerge-repo-svelte-store/src/lib/index.ts
@@ -121,8 +121,10 @@ export function createAutomergeStore(repo: Repo) {
       subscribe,
       set,
       update: updater => {
+        // doc() returns `Doc<T> | undefined`; the store value is
+        // `Doc<T> | null`, so bridge undefined -> null (matching onChange above).
         const currentDoc = handle.doc()
-        const newValue = updater(currentDoc)
+        const newValue = updater(currentDoc ?? null)
         set(newValue)
       },
 

--- a/packages/automerge-repo-svelte-store/tsconfig.json
+++ b/packages/automerge-repo-svelte-store/tsconfig.json
@@ -1,14 +1,13 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
     "module": "ES2020",
     "moduleResolution": "bundler",
     "allowJs": true,
     "checkJs": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "declaration": true,
+    "sourceMap": true,
+    "rootDir": "./src",
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],

--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -893,11 +893,14 @@ export class DocHandle<T> {
     )
   }
 
-  /** Apply a scoped change to a mutable view: a mutator fn or a value. */
-  #applyScopedChange(
-    doc: A.Doc<any>,
-    fn: SubChangeFn<any> | unknown
-  ): A.Doc<any> {
+  /**
+   * Apply a scoped change to a mutable view: a mutator fn or a value.
+   *
+   * `fn` is typed `unknown` — identical to `SubChangeFn<any> | unknown`, which
+   * collapses to `unknown` (a union with `unknown` is just `unknown`). A
+   * function is treated as the mutator; any other value is a replacement.
+   */
+  #applyScopedChange(doc: A.Doc<any>, fn: unknown): A.Doc<any> {
     const propPath = this.#getPropPath(doc)
     this.#assertResolved(propPath, "change")
     return applyScopedChange(

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -37,7 +37,7 @@ import type {
   PeerId,
 } from "./types.js"
 import { AbortOptions, AbortError } from "./helpers/abortable.js"
-export { FindProgressWithMethods, ProgressSignal } from "./_compat.js"
+export type { FindProgressWithMethods, ProgressSignal } from "./_compat.js"
 import { Document } from "./Document.js"
 import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
 import { isPlainObject } from "./helpers/isPlainObject.js"

--- a/packages/automerge-repo/src/subdoc-handles/path-ops.ts
+++ b/packages/automerge-repo/src/subdoc-handles/path-ops.ts
@@ -141,7 +141,8 @@ export function applyScopedChange(
   propPath: Prop[] | undefined,
   range: CursorRange | undefined,
   rangePositions: () => [number, number] | undefined,
-  fn: A.ChangeFn<any> | unknown
+  // identical to `A.ChangeFn<any> | unknown`, which collapses to `unknown`
+  fn: unknown
 ): A.Doc<any> {
   // A function is a mutator; anything else is a replacement value.
   const isReplacement = typeof fn !== "function"

--- a/packages/automerge-repo/tsconfig.json
+++ b/packages/automerge-repo/tsconfig.json
@@ -1,17 +1,9 @@
 {
+  "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "react",
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
-    "declaration": true,
-    "declarationMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "skipLibCheck": true
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist"]

--- a/packages/automerge-vanillajs/package.json
+++ b/packages/automerge-vanillajs/package.json
@@ -22,7 +22,7 @@
     "@automerge/automerge-repo-storage-indexeddb": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "^5.0.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.4"
   },
   "exports": {

--- a/packages/automerge-vanillajs/tsconfig.json
+++ b/packages/automerge-vanillajs/tsconfig.json
@@ -1,17 +1,8 @@
 {
+  "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "react",
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "skipLibCheck": true
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist"]

--- a/packages/create-repo-node-app/tsconfig.json
+++ b/packages/create-repo-node-app/tsconfig.json
@@ -1,16 +1,9 @@
 {
+  "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "react",
-    "module": "NodeNext",
-    "moduleResolution": "Node16",
-    "declaration": true,
-    "declarationMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist"]

--- a/packages/create-vite-app/tsconfig.json
+++ b/packages/create-vite-app/tsconfig.json
@@ -1,16 +1,9 @@
 {
+  "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "react",
-    "module": "NodeNext",
-    "moduleResolution": "Node16",
-    "declaration": true,
-    "declarationMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,19 +77,22 @@ importers:
         version: 0.52.0(svelte@5.53.5)
       oxlint:
         specifier: ^1.67.0
-        version: 1.67.0
+        version: 1.67.0(oxlint-tsgolint@0.23.0)
+      oxlint-tsgolint:
+        specifier: ^0.23.0
+        version: 0.23.0
       portfinder:
         specifier: ^1.0.32
         version: 1.0.37
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@5.9.2)
+        version: 10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@6.0.3)
       typedoc:
         specifier: ^0.28.7
-        version: 0.28.9(typescript@5.9.2)
+        version: 0.28.9(typescript@6.0.3)
       typescript:
-        specifier: ^5.4.2
-        version: 5.9.2
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^7.3.0
         version: 7.3.0(@types/node@20.19.9)(jiti@1.21.7)(yaml@2.8.2)
@@ -138,7 +141,7 @@ importers:
     devDependencies:
       tailwindcss:
         specifier: ^3.2.4
-        version: 3.4.17(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@5.9.2))
+        version: 3.4.17(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@6.0.3))
 
   examples/react-use-presence:
     dependencies:
@@ -252,8 +255,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.23
       typescript:
-        specifier: ^5.0.0
-        version: 5.9.2
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(@vitest/ui@4.0.15(vitest@4.0.15))(happy-dom@20.8.8)(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.6))(yaml@2.8.2)
@@ -290,7 +293,7 @@ importers:
         version: 14.1.1(debug@4.4.1)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@5.9.2)
+        version: 10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@6.0.3)
       vite:
         specifier: ^5.0.8
         version: 5.4.19(@types/node@20.19.9)
@@ -378,7 +381,7 @@ importers:
         version: 6.3.5(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: ^3.9.1
-        version: 3.9.1(@types/node@25.2.3)(rollup@4.53.3)(typescript@5.9.2)(vite@6.3.5(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2))
+        version: 3.9.1(@types/node@25.2.3)(rollup@4.53.3)(typescript@6.0.3)(vite@6.3.5(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2))
 
   packages/automerge-repo-solid-primitives:
     devDependencies:
@@ -405,7 +408,7 @@ importers:
         version: 1.9.11
       vite-plugin-dts:
         specifier: ^3.9.1
-        version: 3.9.1(@types/node@25.2.3)(rollup@4.53.3)(typescript@5.9.2)(vite@7.3.0(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2))
+        version: 3.9.1(@types/node@25.2.3)(rollup@4.53.3)(typescript@6.0.3)(vite@7.3.0(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2))
       vite-plugin-solid:
         specifier: ^2.11.10
         version: 2.11.10(@testing-library/jest-dom@6.6.4)(solid-js@1.9.11)(vite@7.3.0(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2))
@@ -436,10 +439,10 @@ importers:
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.3.11
-        version: 2.4.0(svelte@5.53.5)(typescript@5.9.2)
+        version: 2.4.0(svelte@5.53.5)(typescript@6.0.3)
       typescript:
-        specifier: ^5.0.0
-        version: 5.9.2
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/automerge-vanillajs:
     dependencies:
@@ -460,8 +463,8 @@ importers:
         version: link:../automerge-repo-storage-indexeddb
     devDependencies:
       typescript:
-        specifier: ^5.0.0
-        version: 5.9.2
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(@vitest/ui@4.0.15(vitest@4.0.15))(happy-dom@20.8.8)(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.6))(yaml@2.8.2)
@@ -1831,6 +1834,36 @@ packages:
   '@oxfmt/binding-win32-x64-msvc@0.52.0':
     resolution: {integrity: sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+    resolution: {integrity: sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.23.0':
+    resolution: {integrity: sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.23.0':
+    resolution: {integrity: sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.23.0':
+    resolution: {integrity: sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.23.0':
+    resolution: {integrity: sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.23.0':
+    resolution: {integrity: sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==}
     cpu: [x64]
     os: [win32]
 
@@ -5168,6 +5201,10 @@ packages:
       vite-plus:
         optional: true
 
+  oxlint-tsgolint@0.23.0:
+    resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
+    hasBin: true
+
   oxlint@1.67.0:
     resolution: {integrity: sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6406,6 +6443,11 @@ packages:
 
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -8279,6 +8321,24 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.52.0':
     optional: true
 
+  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.23.0':
+    optional: true
+
   '@oxlint/binding-android-arm-eabi@1.67.0':
     optional: true
 
@@ -8594,14 +8654,14 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/package@2.4.0(svelte@5.53.5)(typescript@5.9.2)':
+  '@sveltejs/package@2.4.0(svelte@5.53.5)(typescript@6.0.3)':
     dependencies:
       chokidar: 4.0.3
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.7.2
       svelte: 5.53.5
-      svelte2tsx: 0.7.42(svelte@5.53.5)(typescript@5.9.2)
+      svelte2tsx: 0.7.42(svelte@5.53.5)(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -9041,7 +9101,7 @@ snapshots:
       '@vue/compiler-core': 3.5.18
       '@vue/shared': 3.5.18
 
-  '@vue/language-core@1.8.27(typescript@5.9.2)':
+  '@vue/language-core@1.8.27(typescript@6.0.3)':
     dependencies:
       '@volar/language-core': 1.11.1
       '@volar/source-map': 1.11.1
@@ -9053,7 +9113,7 @@ snapshots:
       path-browserify: 1.0.1
       vue-template-compiler: 2.7.16
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 6.0.3
 
   '@vue/shared@3.5.18': {}
 
@@ -11926,7 +11986,16 @@ snapshots:
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
       svelte: 5.53.5
 
-  oxlint@1.67.0:
+  oxlint-tsgolint@0.23.0:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.23.0
+      '@oxlint-tsgolint/darwin-x64': 0.23.0
+      '@oxlint-tsgolint/linux-arm64': 0.23.0
+      '@oxlint-tsgolint/linux-x64': 0.23.0
+      '@oxlint-tsgolint/win32-arm64': 0.23.0
+      '@oxlint-tsgolint/win32-x64': 0.23.0
+
+  oxlint@1.67.0(oxlint-tsgolint@0.23.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.67.0
       '@oxlint/binding-android-arm64': 1.67.0
@@ -11947,6 +12016,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.67.0
       '@oxlint/binding-win32-ia32-msvc': 1.67.0
       '@oxlint/binding-win32-x64-msvc': 1.67.0
+      oxlint-tsgolint: 0.23.0
 
   p-cancelable@3.0.0: {}
 
@@ -12188,13 +12258,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@5.9.2)):
+  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@6.0.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.0
     optionalDependencies:
       postcss: 8.5.6
-      ts-node: 10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@5.9.2)
+      ts-node: 10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@6.0.3)
 
   postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@25.2.3)(typescript@5.9.2)):
     dependencies:
@@ -13011,12 +13081,12 @@ snapshots:
       postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@25.2.3)(typescript@5.9.2))
       typescript: 5.9.2
 
-  svelte2tsx@0.7.42(svelte@5.53.5)(typescript@5.9.2):
+  svelte2tsx@0.7.42(svelte@5.53.5)(typescript@6.0.3):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
       svelte: 5.53.5
-      typescript: 5.9.2
+      typescript: 6.0.3
 
   svelte@5.53.5:
     dependencies:
@@ -13039,7 +13109,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@5.9.2)):
+  tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@6.0.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -13058,7 +13128,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.0.1(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@5.9.2))
+      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@6.0.3))
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -13182,7 +13252,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@5.9.2):
+  ts-node@10.9.2(@swc/core@1.13.3)(@types/node@20.19.9)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -13196,7 +13266,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.9.2
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -13293,18 +13363,20 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typedoc@0.28.9(typescript@5.9.2):
+  typedoc@0.28.9(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.9.2
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
-      typescript: 5.9.2
+      typescript: 6.0.3
       yaml: 2.8.0
 
   typescript@5.4.2: {}
 
   typescript@5.9.2: {}
+
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 
@@ -13416,16 +13488,16 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@3.9.1(@types/node@25.2.3)(rollup@4.53.3)(typescript@5.9.2)(vite@6.3.5(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2)):
+  vite-plugin-dts@3.9.1(@types/node@25.2.3)(rollup@4.53.3)(typescript@6.0.3)(vite@6.3.5(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2)):
     dependencies:
       '@microsoft/api-extractor': 7.43.0(@types/node@25.2.3)
       '@rollup/pluginutils': 5.2.0(rollup@4.53.3)
-      '@vue/language-core': 1.8.27(typescript@5.9.2)
+      '@vue/language-core': 1.8.27(typescript@6.0.3)
       debug: 4.4.1
       kolorist: 1.8.0
       magic-string: 0.30.17
-      typescript: 5.9.2
-      vue-tsc: 1.8.27(typescript@5.9.2)
+      typescript: 6.0.3
+      vue-tsc: 1.8.27(typescript@6.0.3)
     optionalDependencies:
       vite: 6.3.5(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -13433,16 +13505,16 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-dts@3.9.1(@types/node@25.2.3)(rollup@4.53.3)(typescript@5.9.2)(vite@7.3.0(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2)):
+  vite-plugin-dts@3.9.1(@types/node@25.2.3)(rollup@4.53.3)(typescript@6.0.3)(vite@7.3.0(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2)):
     dependencies:
       '@microsoft/api-extractor': 7.43.0(@types/node@25.2.3)
       '@rollup/pluginutils': 5.2.0(rollup@4.53.3)
-      '@vue/language-core': 1.8.27(typescript@5.9.2)
+      '@vue/language-core': 1.8.27(typescript@6.0.3)
       debug: 4.4.1
       kolorist: 1.8.0
       magic-string: 0.30.17
-      typescript: 5.9.2
-      vue-tsc: 1.8.27(typescript@5.9.2)
+      typescript: 6.0.3
+      vue-tsc: 1.8.27(typescript@6.0.3)
     optionalDependencies:
       vite: 7.3.0(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -13656,12 +13728,12 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  vue-tsc@1.8.27(typescript@5.9.2):
+  vue-tsc@1.8.27(typescript@6.0.3):
     dependencies:
       '@volar/typescript': 1.11.1
-      '@vue/language-core': 1.8.27(typescript@5.9.2)
+      '@vue/language-core': 1.8.27(typescript@6.0.3)
       semver: 7.7.2
-      typescript: 5.9.2
+      typescript: 6.0.3
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "useDefineForClassFields": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}


### PR DESCRIPTION
> Part 4 of #653. 

Upgrades TypeScript 5 → 6, consolidates the tsconfigs, and enables the type-aware oxlint layer the upgrade unlocks.

## TypeScript 6
- `typescript` ^5.x → **^6.0.3** in the packages that declare it.
- New root `tsconfig.base.json` / `tsconfig.lib.json` / `tsconfig.app.json`; every package tsconfig now extends one instead of duplicating settings (`isolatedModules` on base; `declaration`+`declarationMap`+`sourceMap` on lib; bundler/noEmit on app). `moduleResolution` uses the lowercase forms from the TS docs (`nodenext`, `bundler`).
- `isolatedModules` surfaced a type-only re-export → `export type` in `Repo.ts`.
- A few latent issues TS 6 / type-aware lint surfaced, fixed in place: `T | unknown` collapses to `unknown` (`path-ops.ts`, `DocHandle.ts`); svelte-store's `update()` bridges `doc()`'s `Doc<T> | undefined` to the store's `Doc<T> | null`.

### Looking ahead: TypeScript 7

As #653 noted, moving to TypeScript 6 positions us for a **trivial bump to TypeScript 7 (~June 2026)** — the Go-based native compiler. 7.0 targets the same language and config as 6.x (6.x mainly clears the deprecations 7 drops), so it should be a fast, low-risk follow-up, after which the whole workspace inherits the native compiler's ~10× type-checking/build performance win.

## Type-aware oxlint
- Added `oxlint-tsgolint`; `.oxlintrc.json` sets `typeAware: true` + `no-floating-promises`. (tsgolint needs the explicit tsconfig `rootDir` the base/lib/app refactor provides — which is why this rides with TS 6.)
- `lint.yaml` builds before linting; added `lint:check-types` (`tsc --noEmit` across packages) chained into `lint`. Example type-checking arrives with the examples-cleanup PR (which gives them tsconfigs and declares their worker deps).

## Verification

`pnpm build`, `pnpm lint`, and `pnpm test` (**817 passing**) all green on Node 25 / pnpm 11.5.

---

Part of #653 · stacked on #654, #655, #656.
