### PR TITLE
ci: split the Install and Build step into separate steps

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,9 +40,9 @@ jobs:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
-      - name: Install and Build
-        run: |
-          pnpm install
-          pnpm build
+      - name: Install
+        run: pnpm install
+      - name: Build
+        run: pnpm build
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -40,10 +40,10 @@ jobs:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
-      - name: Install and Build
-        run: |
-          pnpm install
-          pnpm build
+      - name: Install
+        run: pnpm install
+      - name: Build
+        run: pnpm build
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - name: Playwright react-use-presence tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,10 +41,10 @@ jobs:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
-      - name: Install and Build
-        run: |
-          pnpm install
-          pnpm build
+      - name: Install
+        run: pnpm install
+      - name: Build
+        run: pnpm build
       - name: Build docs
         run: pnpm exec typedoc
       - name: Deploy 🚀

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,9 +44,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
-      - name: Install and Build
-        run: |
-          pnpm install
-          pnpm build
+      - name: Install
+        run: pnpm install
+      - name: Build
+        run: pnpm build
       - name: Run Tests
         run: pnpm test


### PR DESCRIPTION
Splits the combined `Install and Build` CI step into separate `Install` and `Build` steps, so the per-step timing (install vs build) is visible in each run's summary.

Per review feedback from @psmolaga on #657.

Splits the combined step in all four workflows that carry it:
- `lint.yaml` (the build-before-lint step added in #657)
- `tests.yaml`
- `playwright.yaml`
- `release.yaml`'s docs job (the publish job already used separate Install/Build steps)

---

Part of #653.
