### PR TITLE
Subduction: lazy hydrate

### DIFF
--- a/packages/automerge-repo/src/AutomergeUrl.ts
+++ b/packages/automerge-repo/src/AutomergeUrl.ts
@@ -13,10 +13,7 @@ import {
   uint8ArrayFromHexString,
   uint8ArrayToHexString,
 } from "./helpers/bufferFromHex.js"
-import {
-  parsePath,
-  serializePath,
-} from "./subdoc-handles/parser.js"
+import { parsePath, serializePath } from "./subdoc-handles/parser.js"
 import type { Segment } from "./subdoc-handles/types.js"
 
 import type { Heads as AutomergeHeads } from "@automerge/automerge/slim"

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -275,7 +275,10 @@ export class Repo extends EventEmitter<RepoEvents> {
     networkSubsystem.on("message", message => {
       if (message.type === "ephemeral" && this.#subductionSource) {
         const payload = new Uint8Array(encode(message))
-        void this.#subductionSource.publishEphemeral(message.documentId, payload)
+        void this.#subductionSource.publishEphemeral(
+          message.documentId,
+          payload
+        )
       }
     })
 

--- a/packages/automerge-repo/src/subdoc-handles/parser.ts
+++ b/packages/automerge-repo/src/subdoc-handles/parser.ts
@@ -218,4 +218,3 @@ export function parsePath(path: string): Segment[] {
 export function serializePath(segments: Segment[]): string {
   return segments.map(serializeSegment).join("/")
 }
-

--- a/packages/automerge-repo/src/subdoc-handles/types.ts
+++ b/packages/automerge-repo/src/subdoc-handles/types.ts
@@ -179,10 +179,7 @@ type ExactPathValue<
  * nullable (e.g. chaining `.sub()` off an index/pattern handle) or some hop
  * along the path can be absent.
  */
-type PathIsNullable<
-  TDoc,
-  TPath extends readonly any[]
-> = undefined extends TDoc
+type PathIsNullable<TDoc, TPath extends readonly any[]> = undefined extends TDoc
   ? true
   : TPath extends readonly [infer First, ...infer Rest]
   ? HopCanBeAbsent<TDoc, First> extends true
@@ -275,22 +272,20 @@ type StepValueFromString<TObj, TSegment> = NonNullable<TObj> extends infer O
  * keys (`key`), array indices (`@n` → `number`) and cursor ranges, so the
  * absent-able hops are array indices and optional keys.
  */
-type HopCanBeAbsentFromString<
-  TObj,
-  TSegment
-> = NonNullable<TObj> extends infer O
-  ? TSegment extends number
-    ? true
-    : TSegment extends CursorRangeMarker
-    ? false
-    : TSegment extends string
-    ? TSegment extends keyof O
-      ? undefined extends O[TSegment]
-        ? true
+type HopCanBeAbsentFromString<TObj, TSegment> =
+  NonNullable<TObj> extends infer O
+    ? TSegment extends number
+      ? true
+      : TSegment extends CursorRangeMarker
+      ? false
+      : TSegment extends string
+      ? TSegment extends keyof O
+        ? undefined extends O[TSegment]
+          ? true
+          : false
         : false
       : false
     : false
-  : false
 
 /** Leaf value type for a parsed string path, intermediate nullability stripped. */
 type ExactPathValueFromString<

--- a/packages/automerge-repo/src/subduction/index.ts
+++ b/packages/automerge-repo/src/subduction/index.ts
@@ -21,8 +21,8 @@ import type { StorageAdapterInterface } from "@automerge/automerge-repo/slim"
 import { Subduction } from "@automerge/automerge-subduction/slim"
 export { SubductionSource, type OnRemoteHeadsChanged } from "./source.js"
 export type {
-  Policy as SubductionPolicy,
-  Transport as SubductionTransport,
+    Policy as SubductionPolicy,
+    Transport as SubductionTransport,
 } from "@automerge/automerge-subduction/slim"
 export type { OnHealExhausted } from "./SyncScheduler.js"
 
@@ -35,29 +35,28 @@ export { WebSocketTransport } from "./websocket-transport.js"
  * Options for {@link setupSubduction}.
  */
 export interface SetupSubductionOptions {
-  /**
-   * An Ed25519 signer (e.g. `WebCryptoSigner` in the browser, or a `NodeSigner` on the server).
-   * Must implement `sign(message: Uint8Array): Uint8Array` and `verifyingKey(): Uint8Array`.
-   */
-  signer: unknown
-  /** An automerge-repo storage adapter (e.g. `IndexedDBStorageAdapter`, `NodeFSStorageAdapter`). */
-  storageAdapter: StorageAdapterInterface
+    /**
+     * An Ed25519 signer (e.g. `WebCryptoSigner` in the browser, or a `NodeSigner` on the server).
+     * Must implement `sign(message: Uint8Array): Uint8Array` and `verifyingKey(): Uint8Array`.
+     */
+    signer: unknown
+    /** An automerge-repo storage adapter (e.g. `IndexedDBStorageAdapter`, `NodeFSStorageAdapter`). */
+    storageAdapter: StorageAdapterInterface
 }
 
 /**
  * Result of {@link setupSubduction}.
  */
 export interface SetupSubductionResult {
-  /** The hydrated Subduction instance. Pass this to `new Repo({ subduction })`. */
-  subduction: Subduction
-  /** The storage bridge wrapping your adapter. Subduction persists through this. */
-  storage: SubductionStorageBridge
+    /** The Subduction instance. Pass this to `new Repo({ subduction })`. */
+    subduction: Subduction
+    /** The storage bridge wrapping your adapter. Subduction persists through this. */
+    storage: SubductionStorageBridge
 }
 
 /**
  * Convenience helper that initializes the Subduction module references,
- * wraps a storage adapter with {@link SubductionStorageBridge}, and
- * hydrates a {@link Subduction} instance.
+ * and wraps a storage adapter with {@link SubductionStorageBridge}
  *
  * @example
  * ```ts
@@ -75,10 +74,10 @@ export interface SetupSubductionResult {
  * ```
  */
 export async function setupSubduction({
-  signer,
-  storageAdapter,
+    signer,
+    storageAdapter,
 }: SetupSubductionOptions): Promise<SetupSubductionResult> {
-  const storage = new SubductionStorageBridge(storageAdapter)
-  const subduction = await Subduction.hydrate(signer, storage)
-  return { subduction, storage }
+    const storage = new SubductionStorageBridge(storageAdapter)
+    const subduction = new Subduction(signer, storage)
+    return { subduction, storage }
 }

--- a/packages/automerge-repo/src/subduction/index.ts
+++ b/packages/automerge-repo/src/subduction/index.ts
@@ -21,8 +21,8 @@ import type { StorageAdapterInterface } from "@automerge/automerge-repo/slim"
 import { Subduction } from "@automerge/automerge-subduction/slim"
 export { SubductionSource, type OnRemoteHeadsChanged } from "./source.js"
 export type {
-    Policy as SubductionPolicy,
-    Transport as SubductionTransport,
+  Policy as SubductionPolicy,
+  Transport as SubductionTransport,
 } from "@automerge/automerge-subduction/slim"
 export type { OnHealExhausted } from "./SyncScheduler.js"
 
@@ -35,23 +35,23 @@ export { WebSocketTransport } from "./websocket-transport.js"
  * Options for {@link setupSubduction}.
  */
 export interface SetupSubductionOptions {
-    /**
-     * An Ed25519 signer (e.g. `WebCryptoSigner` in the browser, or a `NodeSigner` on the server).
-     * Must implement `sign(message: Uint8Array): Uint8Array` and `verifyingKey(): Uint8Array`.
-     */
-    signer: unknown
-    /** An automerge-repo storage adapter (e.g. `IndexedDBStorageAdapter`, `NodeFSStorageAdapter`). */
-    storageAdapter: StorageAdapterInterface
+  /**
+   * An Ed25519 signer (e.g. `WebCryptoSigner` in the browser, or a `NodeSigner` on the server).
+   * Must implement `sign(message: Uint8Array): Uint8Array` and `verifyingKey(): Uint8Array`.
+   */
+  signer: unknown
+  /** An automerge-repo storage adapter (e.g. `IndexedDBStorageAdapter`, `NodeFSStorageAdapter`). */
+  storageAdapter: StorageAdapterInterface
 }
 
 /**
  * Result of {@link setupSubduction}.
  */
 export interface SetupSubductionResult {
-    /** The Subduction instance. Pass this to `new Repo({ subduction })`. */
-    subduction: Subduction
-    /** The storage bridge wrapping your adapter. Subduction persists through this. */
-    storage: SubductionStorageBridge
+  /** The Subduction instance. Pass this to `new Repo({ subduction })`. */
+  subduction: Subduction
+  /** The storage bridge wrapping your adapter. Subduction persists through this. */
+  storage: SubductionStorageBridge
 }
 
 /**
@@ -74,10 +74,10 @@ export interface SetupSubductionResult {
  * ```
  */
 export async function setupSubduction({
-    signer,
-    storageAdapter,
+  signer,
+  storageAdapter,
 }: SetupSubductionOptions): Promise<SetupSubductionResult> {
-    const storage = new SubductionStorageBridge(storageAdapter)
-    const subduction = new Subduction(signer, storage)
-    return { subduction, storage }
+  const storage = new SubductionStorageBridge(storageAdapter)
+  const subduction = new Subduction(signer, storage)
+  return { subduction, storage }
 }

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -1271,16 +1271,15 @@ export class SubductionSource implements DocumentSource {
       for (const hex of staleFragments)
         entry.persistedFragmentHashes.delete(hex)
       this.#log(
-        `compacted ${sid.toString().slice(0, 8)}: -${staleCommits.length} commits, -${staleFragments.length} fragments`
+        `compacted ${sid.toString().slice(0, 8)}: -${
+          staleCommits.length
+        } commits, -${staleFragments.length} fragments`
       )
     } catch (e) {
       // A failed delete just means the data sticks around until the
       // next compaction attempt; nothing breaks on the read side
       // because automerge will simply re-apply the redundant bytes.
-      this.#log(
-        `compaction failed for ${sid.toString().slice(0, 8)}: %O`,
-        e
-      )
+      this.#log(`compaction failed for ${sid.toString().slice(0, 8)}: %O`, e)
     }
   }
 
@@ -1443,5 +1442,4 @@ export class SubductionSource implements DocumentSource {
       this.#log("ephemeral publish failed: %O", e)
     }
   }
-
 }

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -331,12 +331,13 @@ export class SubductionSource implements DocumentSource {
         }
       : undefined
 
-    if (websocketEndpoints.length > 0 || adapters.length > 0) {
-      // Full hydration: load persisted sedimentrees from storage so
-      // fingerprint-based sync can resume where it left off.
-      this.#log("starting hydrate...")
-      const hydrateStart = performance.now()
-      this.#subduction = Subduction.hydrate(
+    // Construct without hydrating: skip preloading persisted sedimentrees
+    // from storage at startup. State is loaded lazily on demand instead,
+    // which also avoids competing with the service worker's hydration on
+    // the same IndexedDB database.
+    this.#log("constructing subduction (no hydrate)")
+    this.#subduction = Promise.resolve(
+      new Subduction(
         signer,
         storage,
         undefined, // service_name
@@ -346,33 +347,8 @@ export class SubductionSource implements DocumentSource {
         undefined, // ephemeral_policy
         onRemoteHeads,
         onEphemeral
-      ).then(s => {
-        this.#log(
-          `hydrate complete in ${(performance.now() - hydrateStart).toFixed(
-            0
-          )}ms`
-        )
-        return s
-      })
-    } else {
-      // No endpoints — skip hydration to avoid hundreds of IndexedDB
-      // transactions that would compete with the service worker's real
-      // hydration on the same database.
-      this.#log("no endpoints, skipping hydrate")
-      this.#subduction = Promise.resolve(
-        new Subduction(
-          signer,
-          storage,
-          undefined, // service_name
-          undefined, // hash_metric_override
-          undefined, // max_pending_blob_requests
-          policy,
-          undefined, // ephemeral_policy
-          onRemoteHeads,
-          onEphemeral
-        )
       )
-    }
+    )
 
     // ── Connection managers ─────────────────────────────────────────
     const wsConnections = new SubductionConnections(this.#subduction)

--- a/packages/automerge-repo/src/subduction/storage.ts
+++ b/packages/automerge-repo/src/subduction/storage.ts
@@ -9,7 +9,7 @@
  *
  * const storageAdapter = new IndexedDBStorageAdapter("my-app-db")
  * const storage = new SubductionStorageBridge(storageAdapter)
- * const subduction = await Subduction.hydrate(signer, storage)
+ * const subduction = new Subduction(signer, storage)
  * ```
  */
 

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -191,7 +191,7 @@ describe("DocHandle", () => {
     const handle = setup()
     handle.change(d => (d.nested = { items: ["a"] }))
     const before = handle.heads()!
-    handle.change(d => (d.nested.items.push("b")))
+    handle.change(d => d.nested.items.push("b"))
 
     // A sub-handle scoped at `nested` reports the change to `items` with a
     // path relative to itself (`["items", 1]`, not `["nested", "items", 1]`).
@@ -599,10 +599,8 @@ describe("DocHandle", () => {
         lastHeads: encodeHeads(["abcd"]),
         lastSyncTimestamp: 12345,
       }
-      const document = new Document<TestDoc>(
-        TEST_ID,
-        A.init<TestDoc>(),
-        sid => (sid === "storage-1" ? sentinel : undefined)
+      const document = new Document<TestDoc>(TEST_ID, A.init<TestDoc>(), sid =>
+        sid === "storage-1" ? sentinel : undefined
       )
       const handle = new DocHandle<TestDoc>(document, {})
       assert.deepEqual(
@@ -619,10 +617,8 @@ describe("DocHandle", () => {
         lastHeads: encodeHeads(["abcd"]),
         lastSyncTimestamp: 12345,
       }
-      const document = new Document<TestDoc>(
-        TEST_ID,
-        A.init<TestDoc>(),
-        sid => (sid === "storage-1" ? sentinel : undefined)
+      const document = new Document<TestDoc>(TEST_ID, A.init<TestDoc>(), sid =>
+        sid === "storage-1" ? sentinel : undefined
       )
       const handle = new DocHandle<TestDoc>(document, {})
       handle.update(d => A.change(d, x => (x.foo = "bar")))

--- a/packages/automerge-repo/test/subdoc-handles/types.check.ts
+++ b/packages/automerge-repo/test/subdoc-handles/types.check.ts
@@ -155,9 +155,9 @@ titleRef2.change(title => {
 import type { InferSubType } from "../../src/subdoc-handles/types.js"
 
 // Compile-time exact-equality assertion (no runtime component).
-type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
-  T
->() => T extends Y ? 1 : 2
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
+  ? 1
+  : 2
   ? true
   : false
 type Expect<T extends true> = T

--- a/packages/automerge-repo/test/subduction/BlobInterceptor.test.ts
+++ b/packages/automerge-repo/test/subduction/BlobInterceptor.test.ts
@@ -71,10 +71,7 @@ class TestServer {
     const addr = wss.address()
     if (typeof addr === "string") throw new Error("unexpected address type")
 
-    const subduction = await Subduction.hydrate(
-      new MemorySigner(),
-      new MemoryStorage()
-    )
+    const subduction = new Subduction(new MemorySigner(), new MemoryStorage())
     const serviceName = `localhost:${addr.port}`
     wss.on("connection", ws => {
       subduction

--- a/packages/automerge-repo/test/subduction/Policy.test.ts
+++ b/packages/automerge-repo/test/subduction/Policy.test.ts
@@ -29,7 +29,7 @@ async function startSubductionServer(
 ): Promise<TestServer> {
   const signer = new MemorySigner()
   const storage = new MemoryStorage()
-  const subduction = await Subduction.hydrate(
+  const subduction = new Subduction(
     signer,
     storage,
     undefined, // service_name

--- a/packages/automerge-repo/test/subduction/Topology.test.ts
+++ b/packages/automerge-repo/test/subduction/Topology.test.ts
@@ -83,7 +83,7 @@ class TestServer {
       this.#signer = new MemorySigner()
       this.#storage = new MemoryStorage()
     }
-    this.#subduction = await Subduction.hydrate(this.#signer, this.#storage!)
+    this.#subduction = new Subduction(this.#signer, this.#storage!)
     const serviceName = `localhost:${this.#port}`
 
     this.#wss = new WebSocketServer({ port: this.#port })

--- a/packages/automerge-repo/test/subduction/WebSocket.test.ts
+++ b/packages/automerge-repo/test/subduction/WebSocket.test.ts
@@ -47,7 +47,7 @@ interface TestServer {
 async function startSubductionServer(listenPort = 0): Promise<TestServer> {
   const signer = new MemorySigner()
   const storage = new MemoryStorage()
-  const subduction = await Subduction.hydrate(signer, storage)
+  const subduction = new Subduction(signer, storage)
 
   const wss = new WebSocketServer({ port: listenPort })
   await once(wss, "listening")
@@ -210,7 +210,7 @@ describe("Subduction WebSocket sync", () => {
     // Now start the real server on the same port
     const signer = new MemorySigner()
     const memStorage = new MemoryStorage()
-    const subduction = await Subduction.hydrate(signer, memStorage)
+    const subduction = new Subduction(signer, memStorage)
     const serviceName = `localhost:${port}`
 
     const serverWss = new WebSocketServer({ port })


### PR DESCRIPTION
Subduction has had the ability to lazily hydrate for some time, but we never changed it in Automerge Repo. This PR fixes that. Tests pass and manual session with 2 browsers running `/examples/react-todo` was successful.

I also ran the formatter. Apologies :sweat_smile: 