### PR TITLE
Use `Automerge.getHeads` when checking saved heads

### DIFF
--- a/packages/automerge-repo/src/StorageSource.ts
+++ b/packages/automerge-repo/src/StorageSource.ts
@@ -39,7 +39,7 @@ export class StorageSource implements DocumentSource {
 
     // If the handle already has data (e.g. from create/import), persist it
     // immediately rather than waiting for a future heads-changed event.
-    if (handle.heads().length > 0) {
+    if (Automerge.getHeads(handle.fullDoc()).length > 0) {
       saveFn({ handle, doc: handle.fullDoc() })
       query.sourceUnavailable("storage")
       return


### PR DESCRIPTION
Problem: in the `StorageSource` we use `DocHandle.heads().length > 0` to
check if a document is empty before triggering a save.
`DocHandle.heads()` returns a UrlHeads, not an array of change hashes so

a) DocHandle.heads().length > 1 is always true, so we do redundnat work
b) DocHandle.heads() hashes the heads of the document in JS, which is
   very slow

Solution: Use `Automerge.getHeads(handle.fullDoc()).length`