### PR TITLE
trigger v2.6.0-alpha.2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-monorepo",
-  "version": "2.6.0-alpha.1",
+  "version": "2.6.0-alpha.2",
   "description": "Automerge Repo monorepo",
   "main": "packages/automerge-repo/dist/index.js",
   "repository": "https://github.com/automerge/automerge-repo",


### PR DESCRIPTION
Cutting a release to validate packaging updates in the PRs derived from #653.