### PR TITLE
chore(oxfmt): ignore lerna.json so the release version bump doesn't break lint

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -9,6 +9,7 @@
   "ignorePatterns": [
     "dist",
     "pnpm-lock.yaml",
+    "lerna.json",
     "/.nx/workspace-data",
     ".svelte-kit",
     "playwright-report",


### PR DESCRIPTION
`lerna version` (run by the release workflow) rewrites `lerna.json` without a trailing newline, so `oxfmt --check` (and therefore `pnpm lint`) fails after every release. It surfaced on `main` after the v2.6.0-alpha.2 release.

`lerna` owns `lerna.json`, so this adds it to oxfmt's `ignorePatterns` alongside the other tool-managed files (`pnpm-lock.yaml`, etc.). That keeps the lint green across future releases without any extra release-flow machinery.
