### PR TITLE
fix(StorageSource): settle the storage source when a load fails

### DIFF
--- a/packages/automerge-repo/src/StorageSource.ts
+++ b/packages/automerge-repo/src/StorageSource.ts
@@ -1,4 +1,5 @@
 import { next as Automerge } from "@automerge/automerge/slim"
+import { makeLogger } from "./Logger.js"
 import type { DocumentSource } from "./DocumentSource.js"
 import type { DocHandleEncodedChangePayload } from "./DocHandle.js"
 import type { DocumentQuery, SourcePriority } from "./DocumentQuery.js"
@@ -19,6 +20,7 @@ export class StorageSource implements DocumentSource {
     DocumentId,
     (payload: DocHandleEncodedChangePayload<any>) => void
   > = {}
+  #log = makeLogger("automerge-repo:storage-source")
 
   constructor(
     storage: StorageSubsystem,
@@ -47,20 +49,34 @@ export class StorageSource implements DocumentSource {
 
     // Load from storage
     query.sourcePending("storage")
-    void this.#storage.loadDoc(handle.documentId).then(loaded => {
-      if (loaded && Automerge.getHeads(loaded).length > 0) {
-        // Sync may have delivered data while we were loading from disk —
-        // merge instead of replacing to avoid clobbering newer state.
-        handle.update(current =>
-          Automerge.getHeads(current).length === 0
-            ? loaded
-            : Automerge.merge(current, loaded)
+    void this.#storage
+      .loadDoc(handle.documentId)
+      .then(loaded => {
+        if (loaded && Automerge.getHeads(loaded).length > 0) {
+          // Sync may have delivered data while we were loading from disk —
+          // merge instead of replacing to avoid clobbering newer state.
+          handle.update(current =>
+            Automerge.getHeads(current).length === 0
+              ? loaded
+              : Automerge.merge(current, loaded)
+          )
+          query.sourceReady("storage")
+        } else {
+          query.sourceUnavailable("storage")
+        }
+      })
+      .catch(err => {
+        // A failed storage read (or a throw while applying the loaded data)
+        // means this source can't provide the document. Mark it unavailable so
+        // the query can settle instead of hanging in `pending`, and surface the
+        // error rather than dropping it as an unhandled rejection. Other
+        // sources (e.g. sync) may still deliver the document.
+        this.#log.error(
+          `Error loading document ${handle.documentId} from storage`,
+          err
         )
-        query.sourceReady("storage")
-      } else {
         query.sourceUnavailable("storage")
-      }
-    })
+      })
   }
 
   detach(documentId: DocumentId): void {

--- a/packages/automerge-repo/test/StorageSource.test.ts
+++ b/packages/automerge-repo/test/StorageSource.test.ts
@@ -1,6 +1,6 @@
 import { next as A } from "@automerge/automerge"
 import assert from "assert"
-import { describe, it } from "vitest"
+import { describe, it, vi } from "vitest"
 import { generateAutomergeUrl, parseAutomergeUrl } from "../src/AutomergeUrl.js"
 import { DocumentQuery } from "../src/DocumentQuery.js"
 import { StorageSource } from "../src/StorageSource.js"
@@ -72,5 +72,43 @@ describe("StorageSource", () => {
     )
     assert.equal(merged.fromSync, true, "sync data should be preserved")
     assert.equal(merged.shared, "base")
+  })
+
+  it("marks the storage source unavailable when the load fails, instead of leaving the query stuck loading", async () => {
+    vi.useFakeTimers()
+    try {
+      type T = { foo?: string }
+      const documentId = parseAutomergeUrl(generateAutomergeUrl()).documentId
+
+      // A storage adapter whose read fails (corrupt store, disk/IO error, or
+      // a failed fetch in a remote-backed adapter).
+      const failingAdapter = new DummyStorageAdapter()
+      failingAdapter.loadRange = async () => {
+        throw new Error("storage read failed")
+      }
+
+      const query = createTestQuery<T>(documentId)
+      const source = new StorageSource(
+        new StorageSubsystem(failingAdapter),
+        10_000
+      )
+      source.attach(query as DocumentQuery<unknown>)
+
+      // attach() fires loadDoc() as a fire-and-forget promise; drain its
+      // (rejected) microtask chain deterministically (no real-time wait).
+      await vi.runAllTimersAsync()
+
+      // A failed storage load must settle the "storage" source as unavailable
+      // so the query can resolve. With storage the only source and no handle
+      // data, the query becomes "unavailable" and whenReady() rejects.
+      assert.equal(
+        query.peek().state,
+        "unavailable",
+        "failed storage load should mark the source unavailable, not hang the query"
+      )
+      await assert.rejects(query.whenReady(), /unavailable/)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })


### PR DESCRIPTION
## Problem

`StorageSource.attach` loads the document with a fire-and-forget `loadDoc().then(...)` that has no `.catch`. If the storage read rejects (corrupt store, disk/IO error, or a failed fetch in a remote-backed adapter), the `"storage"` source is never marked ready or unavailable, so it stays `pending`. As a result:

- the `DocumentQuery` is stuck `loading`, so `whenReady()` / `Repo.find()`   never settle, and
- the dropped rejection surfaces as an `unhandledRejection`.

## Fix

Add a `.catch` to the `loadDoc()` chain in `StorageSource.attach`. On a failed read (or a throw while applying the loaded data), mark the `"storage"` source unavailable so the query can settle, and log the error instead of dropping it. Other sources (e.g. sync) can still deliver the document, so a storage read error no longer blocks a find that a peer could satisfy.

## Commits

Split into two commits:

1. `test(StorageSource)` adds a failing test that reproduces the hang (the query stays `loading` and the rejection goes unhandled).
2. `fix(StorageSource)` adds the `.catch` that makes it pass.

## Related

- #676 - the save-side sibling in `StorageSource` (this PR is the load side). They overlap on the `#log` field, a trivial rebase for whichever merges second.
- #672 / #673 / #674 - the same unhandled-rejection / uncaught-error class in `StorageSubsystem`, `Repo`, and the WebSocket server adapter.
