### PR TITLE
fix(StorageSubsystem): reset the compacting flag in a finally

### DIFF
--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -284,39 +284,42 @@ export class StorageSubsystem extends EventEmitter<StorageSubsystemEvents> {
     sourceChunks: ChunkInfo[]
   ): Promise<void> {
     this.#compacting = true
-    const headsHandle = this.#storedHeads.lastSavedHeads(documentId)
+    try {
+      const headsHandle = this.#storedHeads.lastSavedHeads(documentId)
 
-    const start = performance.now()
-    const binary = A.save(doc)
-    const end = performance.now()
-    this.emit("doc-compacted", {
-      documentId,
-      durationMillis: end - start,
-      savedHeads: A.getHeads(doc),
-    })
+      const start = performance.now()
+      const binary = A.save(doc)
+      const end = performance.now()
+      this.emit("doc-compacted", {
+        documentId,
+        durationMillis: end - start,
+        savedHeads: A.getHeads(doc),
+      })
 
-    const snapshotHash = headsHash(A.getHeads(doc))
-    const key = [documentId, "snapshot", snapshotHash]
-    const oldKeys = new Set(
-      sourceChunks.map(c => c.key).filter(k => k[2] !== snapshotHash)
-    )
+      const snapshotHash = headsHash(A.getHeads(doc))
+      const key = [documentId, "snapshot", snapshotHash]
+      const oldKeys = new Set(
+        sourceChunks.map(c => c.key).filter(k => k[2] !== snapshotHash)
+      )
 
-    this.#log.debug(`Saving snapshot ${key} for document ${documentId}`)
-    this.#log.debug(`deleting old chunks ${Array.from(oldKeys)}`)
+      this.#log.debug(`Saving snapshot ${key} for document ${documentId}`)
+      this.#log.debug(`deleting old chunks ${Array.from(oldKeys)}`)
 
-    await this.#storageAdapter.save(key, binary)
+      await this.#storageAdapter.save(key, binary)
 
-    for (const key of oldKeys) {
-      await this.#storageAdapter.remove(key)
+      for (const key of oldKeys) {
+        await this.#storageAdapter.remove(key)
+      }
+
+      const newChunkInfos =
+        this.#chunkInfos.get(documentId)?.filter(c => !oldKeys.has(c.key)) ?? []
+      newChunkInfos.push({ key, type: "snapshot", size: binary.length })
+
+      this.#chunkInfos.set(documentId, newChunkInfos)
+      headsHandle.update(A.getHeads(doc))
+    } finally {
+      this.#compacting = false
     }
-
-    const newChunkInfos =
-      this.#chunkInfos.get(documentId)?.filter(c => !oldKeys.has(c.key)) ?? []
-    newChunkInfos.push({ key, type: "snapshot", size: binary.length })
-
-    this.#chunkInfos.set(documentId, newChunkInfos)
-    headsHandle.update(A.getHeads(doc))
-    this.#compacting = false
   }
 
   async loadSyncState(

--- a/packages/automerge-repo/test/StorageSubsystem.test.ts
+++ b/packages/automerge-repo/test/StorageSubsystem.test.ts
@@ -536,3 +536,69 @@ describe("StorageSubsystem", () => {
     })
   })
 })
+
+describe("StorageSubsystem compaction recovery", () => {
+  it("keeps compacting after a failed snapshot write (does not get stuck not-compacting)", async () => {
+    // Simulate a storage write that fails mid-compaction. Real, usually
+    // transient causes:
+    //   - IndexedDB: quota exceeded, or a transaction aborted under memory
+    //     pressure (often succeeds on retry).
+    //   - Remote/HTTP-backed adapter: a 503, a timeout, or an expired auth
+    //     token (refreshed before the next save).
+    //   - Local filesystem: disk full, or a momentary lock from another tab.
+    // This adapter fails the second snapshot write and succeeds otherwise.
+    class FlakySnapshotAdapter extends DummyStorageAdapter {
+      snapshotSaves = 0
+      override async save(key: string[], binary: Uint8Array) {
+        if (key[1] === "snapshot") {
+          this.snapshotSaves++
+          if (this.snapshotSaves === 2) {
+            throw new Error("snapshot write failed")
+          }
+        }
+        return super.save(key, binary)
+      }
+    }
+
+    const adapter = new FlakySnapshotAdapter()
+    const storage = new StorageSubsystem(adapter)
+    const documentId = parseAutomergeUrl(generateAutomergeUrl()).documentId
+
+    // A small doc compacts on every change (snapshot size < 1024).
+    let doc = A.from<{ n: number }>({ n: 0 })
+
+    // Save 1: compacts to snapshot #1 (succeeds).
+    doc = A.change(doc, d => {
+      d.n = 1
+    })
+    await storage.saveDoc(documentId, doc)
+
+    // Save 2: compaction attempt fails on the snapshot write, leaving the
+    // subsystem mid-compaction.
+    doc = A.change(doc, d => {
+      d.n = 2
+    })
+    await expect(storage.saveDoc(documentId, doc)).rejects.toThrow(
+      "snapshot write failed"
+    )
+
+    // Save 3: should compact again.
+    doc = A.change(doc, d => {
+      d.n = 3
+    })
+    await storage.saveDoc(documentId, doc)
+
+    assert.equal(
+      adapter.snapshotSaves,
+      3,
+      "after a failed compaction the next save should compact again, not be stuck doing incrementals"
+    )
+
+    // The change from the failed save is not lost: a fresh reload from the same
+    // adapter still sees the latest state.
+    const reloaded = await new StorageSubsystem(adapter).loadDoc<{ n: number }>(
+      documentId
+    )
+    assert.equal(reloaded?.n, 3, "a reload should see the latest update (n=3)")
+  })
+})


### PR DESCRIPTION
## Problem

`StorageSubsystem.#saveTotal` (compaction) sets the `#compacting` flag, writes the snapshot and removes the old chunks, then clears the flag, with no try/finally. If a write rejects (disk/IO error, IndexedDB quota or an aborted transaction, or a failed fetch in a remote-backed adapter), the flag stays set. `#shouldCompact` returns `false` whenever the flag is set, so compaction is **permanently disabled** for that subsystem: every later save falls back to an incremental, and incremental chunks grow without bound (larger storage, slower loads). No data is lost, but the document is never re-consolidated, and the condition persists until the process restarts.

## Fix

Wrap the body of `#saveTotal` in `try/finally` so the flag is always cleared, even when a write throws. Compaction then resumes on the next save once storage recovers; a transient storage hiccup should not disable compaction forever.

## Commits

1. `test(StorageSubsystem)` reproduces the bug: a flaky adapter fails the second  snapshot write, then asserts the next save compacts again and that a reload still sees the latest state (no data loss). It fails on `main`.
2. `fix(StorageSubsystem)` adds the `try/finally`.

## Known limitation (pre-existing, minor)

The flag is a single boolean on the shared subsystem, and `#saveIncremental`'s no-prior-save fallback can enter `#saveTotal` even while it is set, so two documents can briefly compact at once and whichever finishes first clears the
flag. This is best-effort serialization, not a lock. It does not corrupt data (each document writes its own keys; same-document saves are serialized by the throttle in `StorageSource`), so the only effect is occasional concurrent compaction of different documents. A per-document guard would tighten it but is not worth the added complexity for that minor effect.