### PR TITLE
fix(Repo): catch errors thrown while handling an inbound message

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -222,7 +222,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     })
 
     // Handle incoming messages
-    networkSubsystem.on("message", async msg => {
+    networkSubsystem.on("message", msg => {
       this.#receiveMessage(msg)
     })
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -221,9 +221,20 @@ export class Repo extends EventEmitter<RepoEvents> {
       this.#remoteHeadsSubscriptions.removePeer(peerId)
     })
 
-    // Handle incoming messages
+    // Inbound messages are untrusted peer input, so #receiveMessage can throw on
+    // a malformed or cross-version message. An EventEmitter does not trap a
+    // listener's exception, so an uncaught throw here aborts the emit() dispatch
+    // (other listeners skipped) and unwinds back through the transport's
+    // event-loop callback that delivered the message. In Node an uncaught error
+    // there terminates the process by default, so one bad message could take
+    // down a sync server; in a browser it is only logged. Catch it.
+    // See https://nodejs.org/api/process.html#event-uncaughtexception
     networkSubsystem.on("message", msg => {
-      this.#receiveMessage(msg)
+      try {
+        this.#receiveMessage(msg)
+      } catch (err) {
+        this.#log.error("error handling inbound message", err)
+      }
     })
 
     this.synchronizer.on("sync-state", message => {

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -2750,3 +2750,34 @@ const disableConsoleWarn = () => {
 const reenableConsoleWarn = () => {
   console.warn = warn
 }
+
+describe("Repo inbound message handling", () => {
+  // emit() runs its listeners synchronously, so a throw that escapes the
+  // "message" handler surfaces here as a failed assertion rather than a
+  // process exit.
+  it("isolates an error thrown while handling an inbound message", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      const repo = new Repo({
+        network: [new DummyNetworkAdapter({ startReady: true })],
+      })
+      errSpy.mockClear() // ignore any logging from construction
+
+      // A malformed "sync" message: it has no documentId, which
+      // CollectionSynchronizer.receiveMessage rejects by throwing. (Other real
+      // causes: corrupt or cross-version sync data, a buggy or malicious peer.)
+      const deliver = () =>
+        repo.networkSubsystem.emit("message", {
+          type: "sync",
+          senderId: "peer",
+          targetId: repo.peerId,
+        } as any)
+
+      // The throw must not escape the listener; it must be caught and logged.
+      expect(deliver).not.toThrow()
+      expect(errSpy).toHaveBeenCalled()
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
## Problem

The network `message` handler in the `Repo` constructor routes inbound messages into `#receiveMessage`, which dispatches to the synchronizer. That parses untrusted, cross-version binary from peers, so it can throw in normal operation:

- a `sync` message with no `documentId` (`CollectionSynchronizer.receiveMessage` rejects it by throwing),
- corrupt or cross-version sync data (`A.receiveSyncMessage` throws),
- a buggy or malicious peer on an open/public sync server.

An `EventEmitter` does not trap a listener's exception (eventemitter3's `emit` calls each listener with a bare `fn.call(...)`, no try/catch), so an uncaught throw in the handler escapes `emit()` (skipping any other listeners for the event). In production `emit("message")` is driven from the transport's I/O callback (a socket `data` / WS `message` event), so the escaped throw bubbles all the way back to the event loop. Per the Node docs, that is exactly what triggers `uncaughtException`:

> The `'uncaughtException'` event is emitted when an uncaught JavaScript exception bubbles all the way back to the event loop. By default, Node.js handles such exceptions by printing the stack trace to stderr and exiting with code `1`.

Source: https://nodejs.org/api/process.html#event-uncaughtexception

So on a sync server one malformed message from a single peer can terminate the process, dropping sync for every connected client. In a browser the throw is logged and the app keeps running (not serious).

Self-contained reproduction (eventemitter3 + a real socket `data` handler):

```typescript
import { EventEmitter } from "eventemitter3"
import net from "node:net"

const bus = new EventEmitter()
bus.on("message", () => {
  throw new Error("malformed message")
})

// add this to see the path: process.on("uncaughtException",
//   e => { console.log("uncaughtException:", e.message); process.exit(42) })

const server = net.createServer(s => s.on("data", () => bus.emit("message")))
server.listen(0, () => {
  const c = net.connect(server.address().port, () => c.write("x"))
})
// $ node demo.mjs  ->  stack trace + exit 1
//   (with the handler above: prints "uncaughtException: ..." and exits 42,
//    proving the listener throw routes through uncaughtException)
```

A vitest unit test cannot show that exit (the runner installs its own `uncaughtException` handler and reports the error instead of dying), so the test in this PR pins what it can deterministically: a throw must not escape the listener.

## Fix (3 commits)

1. `refactor`: drop the vestigial `async` from the listener, unused since #233 extracted the handler body into the synchronous `#receiveMessage`.
2. `test`: deliver a malformed `sync` message (no `documentId`) and assert the listener does not throw and logs instead. Red until the fix.
3. `fix`: wrap `#receiveMessage` in `try/catch` and log, so a bad message is caught and dropped instead of escaping the listener.

## Related

- #674 - the same crash class via `WebSocketServerAdapter.receiveMessage` (a single CBOR-null byte from any peer, pre-auth).
- #676 - the same class on the `StorageSource` save path (a storage write rejection floating from a "heads-changed" listener).
- Prior art: #297 was a host-process crash from a throw escaping the WebSocket adapter's send path, fixed by not throwing there.

