### PR TITLE
fix(WebSocketServerAdapter): catch errors thrown while handling a message

### DIFF
--- a/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
@@ -140,53 +140,68 @@ export class WebSocketServerAdapter extends NetworkAdapter {
       return
     }
 
-    const { type, senderId } = message
+    // A decoded message is still untrusted: a malformed one (e.g. CBOR null,
+    // which makes the destructure below throw) can throw while being handled.
+    // This runs in the socket "message" event-loop callback, so an uncaught
+    // throw would terminate a Node process by default. Drop the message and
+    // close the misbehaving connection.
+    // See https://nodejs.org/api/process.html#event-uncaughtexception
+    try {
+      const { type, senderId } = message
 
-    const myPeerId = this.peerId
-    assert(myPeerId)
+      const myPeerId = this.peerId
+      assert(myPeerId)
 
-    const documentId = "documentId" in message ? "@" + message.documentId : ""
-    const { byteLength } = messageBytes
-    log(`[${senderId}->${myPeerId}${documentId}] ${type} | ${byteLength} bytes`)
+      const documentId = "documentId" in message ? "@" + message.documentId : ""
+      const { byteLength } = messageBytes
+      log(
+        `[${senderId}->${myPeerId}${documentId}] ${type} | ${byteLength} bytes`
+      )
 
-    if (isJoinMessage(message)) {
-      const { peerMetadata, supportedProtocolVersions } = message
-      const existingSocket = this.sockets[senderId]
-      if (existingSocket) {
-        if (existingSocket.readyState === WebSocket.OPEN) {
-          existingSocket.close()
+      if (isJoinMessage(message)) {
+        const { peerMetadata, supportedProtocolVersions } = message
+        const existingSocket = this.sockets[senderId]
+        if (existingSocket) {
+          if (existingSocket.readyState === WebSocket.OPEN) {
+            existingSocket.close()
+          }
+          this.emit("peer-disconnected", { peerId: senderId })
         }
-        this.emit("peer-disconnected", { peerId: senderId })
-      }
 
-      // Let the repo know that we have a new connection.
-      this.emit("peer-candidate", { peerId: senderId, peerMetadata })
-      this.sockets[senderId] = socket
+        // Let the repo know that we have a new connection.
+        this.emit("peer-candidate", { peerId: senderId, peerMetadata })
+        this.sockets[senderId] = socket
 
-      const selectedProtocolVersion = selectProtocol(supportedProtocolVersions)
-      if (selectedProtocolVersion === null) {
-        this.send({
-          type: "error",
-          senderId: this.peerId!,
-          message: "unsupported protocol version",
-          targetId: senderId,
-        })
-        this.sockets[senderId].close()
-        delete this.sockets[senderId]
+        const selectedProtocolVersion = selectProtocol(
+          supportedProtocolVersions
+        )
+        if (selectedProtocolVersion === null) {
+          this.send({
+            type: "error",
+            senderId: this.peerId!,
+            message: "unsupported protocol version",
+            targetId: senderId,
+          })
+          this.sockets[senderId].close()
+          delete this.sockets[senderId]
+        } else {
+          this.send({
+            type: "peer",
+            senderId: this.peerId!,
+            peerMetadata: this.peerMetadata!,
+            selectedProtocolVersion: ProtocolV1,
+            targetId: senderId,
+          })
+        }
       } else {
-        this.send({
-          type: "peer",
-          senderId: this.peerId!,
-          peerMetadata: this.peerMetadata!,
-          selectedProtocolVersion: ProtocolV1,
-          targetId: senderId,
-        })
+        if (this.sockets[senderId] !== socket) {
+          return
+        }
+        this.emit("message", message)
       }
-    } else {
-      if (this.sockets[senderId] !== socket) {
-        return
-      }
-      this.emit("message", message)
+    } catch (e) {
+      log("error handling inbound message, closing connection", e)
+      socket.close()
     }
   }
 

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -884,6 +884,21 @@ const getPort = () => {
   return getAvailablePort({ port: base })
 }
 
+describe("WebSocketServerAdapter inbound message handling", () => {
+  // A throw while handling a message must not escape the socket "message"
+  // callback; it must be caught and the connection closed.
+  it("isolates an error thrown while handling an inbound message", () => {
+    const adapter = new WebSocketServerAdapter({} as unknown as WebSocketServer)
+    let closed = false
+    const socket = { close: () => (closed = true) } as unknown as WebSocket
+    // CBOR null (0xf6): decode() succeeds and returns null, so the destructure
+    // in receiveMessage throws.
+    const malformed = new Uint8Array([0xf6])
+    assert.doesNotThrow(() => adapter.receiveMessage(malformed, socket))
+    assert(closed, "expected the misbehaving connection to be closed")
+  })
+})
+
 // TYPES
 
 type SetupOptions = {


### PR DESCRIPTION
## Problem

`WebSocketServerAdapter.receiveMessage` decodes untrusted bytes from a peer and runs in the socket `"message"` event-loop callback. `decode()` is guarded (it closes the connection on a corrupt frame), but the handling after it was not: a decoded-but-malformed message throws there. Concretely, a peer can crash the server with a single byte: a frame containing CBOR null (`0xf6`) decodes to `null`, and `const { type, senderId } = message` throws. The `"message"` listener is registered on `connection`, before any join handshake, so this needs no prior message and no authentication.

That throw is not trapped, so it reaches the event loop and, in Node, terminates the process by default. Same class of bug as #673 (inbound `"message"` handler); see that PR for the EventEmitter / `uncaughtException` mechanism and a runnable
reproduction. It is also not hypothetical here: #297 was a host-process crash from a throw escaping this adapter's event-driven send path, fixed by not throwing there. This PR addresses the inbound (receive) side.

## Fix (2 commits)

1. `test`: deliver CBOR `null` to `receiveMessage` and assert it does not throw (and closes the connection). Red until the fix.
2. `fix`: wrap the post-decode body in `try/catch` (the `decode()` guard already handles corrupt frames) and close the connection on failure.

## Related

- #673 - `Repo` inbound `"message"` handler (mechanism + reproduction)
- #676 - the same class on the `StorageSource` save path (a storage write rejection floating from a "heads-changed" listener)

