### PR TITLE
fix(throttle): clamp throttle delays to a non-negative value

### DIFF
--- a/packages/automerge-repo/src/helpers/throttle.ts
+++ b/packages/automerge-repo/src/helpers/throttle.ts
@@ -33,7 +33,8 @@ export const throttle = <F extends (...args: Parameters<F>) => ReturnType<F>>(
   let wait: number | undefined
   let timeout: ReturnType<typeof setTimeout>
   return function (...args: Parameters<F>): void {
-    wait = lastCall + delay - Date.now()
+    // Clamp to 0: passing a negative delay to setTimeout warns on some runtimes.
+    wait = Math.max(0, lastCall + delay - Date.now())
     clearTimeout(timeout)
     timeout = setTimeout(() => {
       fn(...args)
@@ -106,7 +107,8 @@ export const asyncThrottle = <TArgs extends unknown[], TReturn>(
       clearTimeout(timeout)
     }
 
-    const wait = lastCall + delay - Date.now() //if negative, executes immediately
+    // Clamp to 0: passing a negative delay to setTimeout warns on some runtimes.
+    const wait = Math.max(0, lastCall + delay - Date.now()) //if negative, executes immediately
 
     return new Promise<TReturn>((resolve, reject) => {
       timeout = setTimeout(async () => {


### PR DESCRIPTION
## What

Both `throttle()` and `asyncThrottle()` compute their `setTimeout` delay as `lastCall + delay - Date.now()`. That value goes negative whenever a call arrives more than `delay` ms after the previous execution settled, or on the first call some time after the throttle was constructed. Both are normal for the save, sync-state, and sync throttles (an edit after a quiet period, or the first edit after a handle is set up). The negative value was passed straight to `setTimeout`.

This clamps both with `Math.max(0, ...)`, mirroring the fix @pvh already made for `asyncThrottle` on the subductionjs line in [`1650cc07`](https://github.com/automerge/automerge-repo/commit/1650cc07c8bbd289e1263ed22794d9cedd25f62f) (shipped there via #649), bringing the same clamp to `main`.

```diff
@@ throttle() @@
   return function (...args: Parameters<F>): void {
-    wait = lastCall + delay - Date.now()
+    // Clamp to 0: passing a negative delay to setTimeout warns on some runtimes.
+    wait = Math.max(0, lastCall + delay - Date.now())
     clearTimeout(timeout)

@@ asyncThrottle() @@
-    const wait = lastCall + delay - Date.now() //if negative, executes immediately
+    // Clamp to 0: passing a negative delay to setTimeout warns on some runtimes.
+    const wait = Math.max(0, lastCall + delay - Date.now()) //if negative, executes immediately
```

## Why it is mostly cosmetic

On modern runtimes a negative delay is harmless: Node clamps it to 1ms and browsers clamp to 0, both silently. I could not reproduce the `TimeoutNegativeWarning` from #469 on Node 22. So this does not change behavior on modern Node or browsers; it removes the negative value at the source for runtimes that still log on it, and makes the "fire on the next tick" intent explicit.

The synchronous `throttle()` has no call sites on `main` today (every live path uses `asyncThrottle`), but it shares the same arithmetic, so it is clamped here too as cheap defense in depth in case it is used again.

Re #469
