### PR TITLE
fix(StorageSource): catch errors from the throttled save

### DIFF
--- a/packages/automerge-repo/src/StorageSource.ts
+++ b/packages/automerge-repo/src/StorageSource.ts
@@ -89,8 +89,24 @@ export class StorageSource implements DocumentSource {
     let fn = this.#saveFns[documentId]
     if (!fn) {
       fn = this.#saveFns[documentId] = asyncThrottle(
-        ({ doc, handle }: DocHandleEncodedChangePayload<any>): Promise<void> =>
-          this.#storage.saveDoc(handle.documentId, doc),
+        async ({
+          doc,
+          handle,
+        }: DocHandleEncodedChangePayload<any>): Promise<void> => {
+          try {
+            await this.#storage.saveDoc(handle.documentId, doc)
+          } catch (err) {
+            // This save runs fire-and-forget from a "heads-changed" listener,
+            // so a rejection would surface as an unhandled rejection and, in
+            // Node, exit the process by default. Catch and log it; the change
+            // stays in memory and a later save or reload can re-persist it.
+            // See https://nodejs.org/api/process.html#event-unhandledrejection
+            this.#log.error(
+              `Error saving document ${handle.documentId} to storage`,
+              err
+            )
+          }
+        },
         this.#saveDebounceRate
       )
     }

--- a/packages/automerge-repo/test/StorageSource.test.ts
+++ b/packages/automerge-repo/test/StorageSource.test.ts
@@ -111,4 +111,40 @@ describe("StorageSource", () => {
       vi.useRealTimers()
     }
   })
+
+  it("logs a failed save instead of leaking an unhandled rejection", async () => {
+    // A save runs fire-and-forget from the "heads-changed" listener. If the
+    // storage write rejects, the rejection must be caught and logged, not left
+    // to surface as an unhandled rejection.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      const documentId = parseAutomergeUrl(generateAutomergeUrl()).documentId
+
+      // An adapter whose save() always rejects (disk/IO error, quota, ...).
+      const adapter = new DummyStorageAdapter()
+      adapter.save = async () => {
+        throw new Error("simulated storage write failure")
+      }
+
+      const source = new StorageSource(new StorageSubsystem(adapter), 10)
+      const query = createTestQuery<TestDoc>(documentId)
+      source.attach(query as DocumentQuery<unknown>)
+
+      // A change triggers the throttled save, whose saveDoc rejects.
+      const changed = A.from({ foo: "bar" }) as A.Doc<unknown>
+      query.handle.update(() => changed)
+
+      // The failure must be caught and logged, not floated as a rejection.
+      await vi.waitFor(() =>
+        assert.ok(
+          errSpy.mock.calls.some(call =>
+            call.some(arg => String(arg).includes("Error saving document"))
+          ),
+          "the failed save should be caught and logged"
+        )
+      )
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
 })


### PR DESCRIPTION
## Problem

`StorageSource` persists on every `"heads-changed"` event via a throttled save:

    handle.on("heads-changed", saveFn)   // saveFn = asyncThrottle(() => storage.saveDoc(...))

`asyncThrottle` returns a promise that rejects when `saveDoc` rejects, and that promise is ignored (the listener's return value is dropped; the bare call at attach is not awaited). So a storage write failure (disk/IO error, quota, an aborted IndexedDB transaction, a failed remote write) floats as an unhandled rejection, which in Node exits the process by default ([unhandled-rejections][1]).

This is the save side of #389 ("Storage errors cause node to exit") and the same class as the intermittent unhandled-rejection failures in #275. The load side is handled in #671; this is its sibling.

## Fix (2 commits)

1. `test`: point `StorageSource` at an adapter whose `save()` rejects, make a  change, and assert the failure is caught and logged. Red until the fix (it fails the assertion and Vitest reports the floating unhandled rejection).
2. `fix`: wrap `saveDoc` in `try/catch` inside the throttled function and log. The change stays in memory, so a later save or reload can re-persist it.

## Related

- #671 - load-side sibling in `StorageSource` (lightly overlaps: both add the `#log` field, a trivial rebase for whichever merges second)
- #672 - `StorageSubsystem` compaction error handling
- #673 / #674 - same crash class in the `Repo` inbound-message and WebSocket-server handlers
- Issues: #389 (storage errors exit the process), #275 (intermittent unhandled-rejection CI failures), #264 (durability)

[1]: https://nodejs.org/api/process.html#event-unhandledrejection
