### PR TITLE
perf(storage-nodefs): prefix-trie for cached keys

### DIFF
--- a/packages/automerge-repo-storage-nodefs/package.json
+++ b/packages/automerge-repo-storage-nodefs/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "fast-check": "^4.8.0",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -13,7 +13,9 @@ import path from "path"
 
 export class NodeFSStorageAdapter implements StorageAdapterInterface {
   private baseDirectory: string
-  private cache: { [key: string]: Uint8Array } = {}
+  private cache: { [key: string]: Uint8Array } = Object.create(null)
+  private keyIndex: KeyTrieNode = { children: new Map(), key: null, seq: 0 }
+  private keySeq = 0
 
   /**
    * @param baseDirectory - The path to the directory to store data in. Defaults to "./automerge-repo-data".
@@ -40,7 +42,7 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
   async save(keyArray: StorageKey, binary: Uint8Array): Promise<void> {
     const key = getKey(keyArray)
-    this.cache[key] = binary
+    this.cacheSet(key, binary)
 
     const filePath = this.getFilePath(keyArray)
 
@@ -50,7 +52,7 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
   async remove(keyArray: string[]): Promise<void> {
     // remove from cache
-    delete this.cache[getKey(keyArray)]
+    this.cacheDelete(getKey(keyArray))
     // remove from disk
     const filePath = this.getFilePath(keyArray)
     try {
@@ -97,18 +99,29 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 
   async removeRange(keyPrefix: string[]): Promise<void> {
     // remove from cache
-    this.cachedKeys(keyPrefix).forEach(key => delete this.cache[key])
+    this.cachedKeys(keyPrefix).forEach(key => this.cacheDelete(key))
 
     // remove from disk
     const dirPath = this.getFilePath(keyPrefix)
     await fs.promises.rm(dirPath, { recursive: true, force: true })
   }
 
+  /** Set a cache entry, keeping the prefix index in sync. */
+  private cacheSet(key: string, binary: Uint8Array): void {
+    if (this.cache[key] === undefined)
+      trieInsert(this.keyIndex, key, this.keySeq++)
+    this.cache[key] = binary
+  }
+
+  /** Delete a cache entry, keeping the prefix index in sync. */
+  private cacheDelete(key: string): void {
+    if (this.cache[key] === undefined) return
+    delete this.cache[key]
+    trieDelete(this.keyIndex, key)
+  }
+
   private cachedKeys(keyPrefix: string[]): string[] {
-    const cacheKeyPrefixString = getKey(keyPrefix)
-    return Object.keys(this.cache).filter(key =>
-      key.startsWith(cacheKeyPrefixString)
-    )
+    return trieCollect(this.keyIndex, getKey(keyPrefix).split(path.sep))
   }
 
   private getFilePath(keyArray: string[]): string {
@@ -125,6 +138,78 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 // HELPERS
 
 const getKey = (key: StorageKey): string => path.join(...key)
+
+/**
+ * A trie over storage keys split on `path.sep`, used to answer
+ * `loadRange` prefix queries in O(matches) rather than scanning every
+ * cached key. Terminal nodes store the full key string so collection
+ * returns exact keys without reconstruction.
+ *
+ * Segment-boundary matching (rather than raw string `startsWith`) mirrors
+ * the on-disk `walkdir`, which is inherently directory-scoped; the two
+ * sides of `loadRange` therefore agree.
+ */
+interface KeyTrieNode {
+  children: Map<string, KeyTrieNode>
+  key: string | null
+  // Insertion sequence of `key`, so `trieCollect` can reproduce the
+  // insertion-ordered results that the previous `Object.keys` scan gave
+  // (and that the storage acceptance tests assert). Meaningless unless
+  // `key !== null`.
+  seq: number
+}
+
+const trieInsert = (root: KeyTrieNode, fullKey: string, seq: number): void => {
+  let node = root
+  for (const seg of fullKey.split(path.sep)) {
+    let child = node.children.get(seg)
+    if (child === undefined) {
+      child = { children: new Map(), key: null, seq: 0 }
+      node.children.set(seg, child)
+    }
+    node = child
+  }
+  node.key = fullKey
+  node.seq = seq
+}
+
+const trieDelete = (root: KeyTrieNode, fullKey: string): void => {
+  const segs = fullKey.split(path.sep)
+  const nodes: KeyTrieNode[] = [root]
+  let node = root
+  for (const seg of segs) {
+    const child = node.children.get(seg)
+    if (child === undefined) return
+    nodes.push(child)
+    node = child
+  }
+  node.key = null
+  // Prune now-empty nodes bottom-up so the index doesn't accumulate
+  // dead interior nodes as keys come and go.
+  for (let i = segs.length - 1; i >= 0; i--) {
+    const child = nodes[i + 1]
+    if (child.key !== null || child.children.size > 0) break
+    nodes[i].children.delete(segs[i])
+  }
+}
+
+const trieCollect = (root: KeyTrieNode, prefixSegs: string[]): string[] => {
+  let node = root
+  for (const seg of prefixSegs) {
+    const child = node.children.get(seg)
+    if (child === undefined) return []
+    node = child
+  }
+  const found: Array<{ key: string; seq: number }> = []
+  const stack: KeyTrieNode[] = [node]
+  while (stack.length > 0) {
+    const n = stack.pop()!
+    if (n.key !== null) found.push({ key: n.key, seq: n.seq })
+    for (const child of n.children.values()) stack.push(child)
+  }
+  found.sort((a, b) => a.seq - b.seq)
+  return found.map(f => f.key)
+}
 
 /** returns all files in a directory, recursively  */
 const walkdir = async (dirPath: string): Promise<string[]> => {

--- a/packages/automerge-repo-storage-nodefs/test/KeyIndexOracle.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/KeyIndexOracle.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Model-based oracle test for the adapter's prefix index.
+ *
+ * `loadRange` answers prefix queries from an incremental segment trie
+ * (`keyIndex`) kept in lockstep with the flat `cache` object. Before the
+ * trie, the same answer came from a linear scan:
+ *
+ *   Object.keys(this.cache).filter(k => k.startsWith(prefix))
+ *
+ * whose result order was object-insertion order. The trie must reproduce
+ * that scan exactly — same result set (segment-boundary matching; real
+ * storage keys are segment-prefix-free, and this test's vocabulary is
+ * too) and same order, including the subtle cases:
+ *
+ *   - overwriting a key preserves its original position
+ *   - delete + re-insert moves a key to the end
+ *
+ * The reference model here is that old scan, expressed over an
+ * insertion-ordered Map (identical semantics for non-index string keys).
+ * fast-check drives random op sequences (save / remove / removeRange)
+ * against both the real adapter and the model, comparing every prefix
+ * query after every op.
+ */
+
+import fc from "fast-check"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { describe, expect, it } from "vitest"
+import { NodeFSStorageAdapter } from "../src"
+
+// ─── Vocabulary ───────────────────────────────────────────────────────
+//
+// Mirrors real storage keys: fixed-length shard ids, then a chunk-type
+// segment, then a fixed-length hash. No segment is a string prefix of a
+// sibling, so segment-boundary matching and the old string `startsWith`
+// agree — the equivalence the production code relies on.
+
+const IDS = ["AAAAAAAA", "BBBBBBBB", "CCCCCCCC"] as const
+const TYPES = ["snapshot", "incremental", "sync-state"] as const
+const HASHES = ["h0", "h1", "h2"] as const
+
+/** Every prefix the oracle checks after each operation. */
+const QUERY_PREFIXES: string[][] = IDS.flatMap(id => [
+  [id],
+  ...TYPES.map(type => [id, type]),
+])
+
+// ─── Reference model: the old Object.keys scan ────────────────────────
+
+const SEP = "\u0000"
+const join = (key: string[]) => key.join(SEP)
+const split = (key: string) => key.split(SEP)
+
+const segmentsMatch = (key: string[], prefix: string[]): boolean =>
+  prefix.length <= key.length && prefix.every((seg, i) => key[i] === seg)
+
+class ReferenceModel {
+  /** Insertion-ordered, like Object.keys on non-index string keys. */
+  private entries = new Map<string, Uint8Array>()
+
+  save(key: string[], value: Uint8Array): void {
+    // Map.set preserves position on overwrite and appends when new —
+    // exactly the old object-property semantics.
+    this.entries.set(join(key), value)
+  }
+
+  remove(key: string[]): void {
+    this.entries.delete(join(key))
+  }
+
+  removeRange(prefix: string[]): void {
+    for (const k of [...this.entries.keys()]) {
+      if (segmentsMatch(split(k), prefix)) this.entries.delete(k)
+    }
+  }
+
+  loadRange(prefix: string[]): Array<{ key: string[]; data: Uint8Array }> {
+    return [...this.entries]
+      .filter(([k]) => segmentsMatch(split(k), prefix))
+      .map(([k, data]) => ({ key: split(k), data }))
+  }
+}
+
+// ─── Operation generators ─────────────────────────────────────────────
+
+type Op =
+  | { type: "save"; key: string[]; value: Uint8Array }
+  | { type: "remove"; key: string[] }
+  | { type: "removeRange"; prefix: string[] }
+
+const keyArb = fc
+  .tuple(
+    fc.constantFrom(...IDS),
+    fc.constantFrom(...TYPES),
+    fc.constantFrom(...HASHES)
+  )
+  .map(segs => [...segs])
+
+const bytesArb = fc.uint8Array({ minLength: 1, maxLength: 8 })
+
+const opArb: fc.Arbitrary<Op> = fc.oneof(
+  {
+    weight: 4,
+    arbitrary: fc.record({
+      type: fc.constant("save" as const),
+      key: keyArb,
+      value: bytesArb,
+    }),
+  },
+  {
+    weight: 2,
+    arbitrary: fc.record({ type: fc.constant("remove" as const), key: keyArb }),
+  },
+  {
+    weight: 1,
+    arbitrary: fc.record({
+      type: fc.constant("removeRange" as const),
+      prefix: fc.oneof(
+        keyArb.map(k => k.slice(0, 1)),
+        keyArb.map(k => k.slice(0, 2))
+      ),
+    }),
+  }
+)
+
+// ─── The property ─────────────────────────────────────────────────────
+
+describe("NodeFSStorageAdapter prefix-index oracle", () => {
+  it("loadRange matches the reference Object.keys scan after any op sequence", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(opArb, { minLength: 1, maxLength: 15 }),
+        async ops => {
+          const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nodefs-oracle-"))
+          try {
+            const adapter = new NodeFSStorageAdapter(dir)
+            const model = new ReferenceModel()
+
+            for (const op of ops) {
+              switch (op.type) {
+                case "save":
+                  await adapter.save(op.key, op.value)
+                  model.save(op.key, op.value)
+                  break
+                case "remove":
+                  await adapter.remove(op.key)
+                  model.remove(op.key)
+                  break
+                case "removeRange":
+                  await adapter.removeRange(op.prefix)
+                  model.removeRange(op.prefix)
+                  break
+              }
+
+              // Compare every prefix query after every op, so a desync
+              // can't be masked by a later removeRange.
+              for (const prefix of QUERY_PREFIXES) {
+                expect(await adapter.loadRange(prefix)).toStrictEqual(
+                  model.loadRange(prefix)
+                )
+              }
+            }
+          } finally {
+            fs.rmSync(dir, { force: true, recursive: true })
+          }
+        }
+      ),
+      { numRuns: 25 }
+    )
+  }, 120_000)
+})

--- a/packages/automerge-repo-storage-nodefs/test/LoadRangePerf.test.ts
+++ b/packages/automerge-repo-storage-nodefs/test/LoadRangePerf.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Perf sweep for `loadRange` over many documents (the bulk-load path).
+ *
+ * Benches whatever adapter is in `../src` — to compare two revisions,
+ * run it on each. For example, to reproduce the before/after numbers
+ * for the prefix-trie key index:
+ *
+ *   # before (old startsWith scan), from the PR branch:
+ *   git checkout <base-sha> -- packages/automerge-repo-storage-nodefs/src/index.ts
+ *   RUN_PERF=1 pnpm exec vitest run \
+ *     packages/automerge-repo-storage-nodefs/test/LoadRangePerf.test.ts \
+ *     --disable-console-intercept
+ *   git checkout HEAD -- packages/automerge-repo-storage-nodefs/src/index.ts
+ *
+ *   # after (current source): same command, unmodified tree
+ *
+ * Workload mimics `StorageSubsystem.loadDocData` on a warm adapter
+ * (cache populated by the saves that created the data): N docs x 3
+ * chunks, then per doc one `loadRange([id, "snapshot"])` plus one
+ * `loadRange([id, "incremental"])`. Reports medians of 3 reps and the
+ * per-doubling growth factor T(2N)/T(N) — the machine-load-immune
+ * signal: ~4x per doubling is quadratic, ~2x is linear.
+ */
+
+import crypto from "node:crypto"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { describe, it } from "vitest"
+import { NodeFSStorageAdapter } from "../src"
+
+const SIZES = [250, 500, 1000, 2000, 4000, 8000]
+const REPS = 3
+const CHUNK_TYPES = ["snapshot", "incremental", "sync-state"] as const
+
+/** Random 27/28-char ids mimicking bs58check DocumentIds. */
+const makeIds = (n: number): string[] =>
+  Array.from({ length: n }, () =>
+    crypto
+      .randomBytes(21)
+      .toString("base64url")
+      .replace(/[-_]/g, "x")
+      .slice(0, 27 + (Math.random() < 0.5 ? 1 : 0))
+  )
+
+const populate = async (adapter: NodeFSStorageAdapter, ids: string[]) => {
+  const payload = crypto.randomBytes(64)
+  for (const id of ids) {
+    for (const type of CHUNK_TYPES) {
+      await adapter.save(
+        [id, type, crypto.randomBytes(8).toString("hex")],
+        payload
+      )
+    }
+  }
+}
+
+/** The StorageSubsystem.loadDocData query pattern, for every doc. */
+const sweep = async (
+  adapter: NodeFSStorageAdapter,
+  ids: string[]
+): Promise<number> => {
+  const t0 = performance.now()
+  for (const id of ids) {
+    await adapter.loadRange([id, "snapshot"])
+    await adapter.loadRange([id, "incremental"])
+  }
+  return performance.now() - t0
+}
+
+const median = (xs: number[]): number =>
+  [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)]
+
+describe.skipIf(!process.env.RUN_PERF)("loadRange bulk sweep", () => {
+  it(
+    "per-doc loadRange over N docs, warm cache",
+    { timeout: 1_800_000 },
+    async () => {
+      const rows: Array<{ n: number; ms: number }> = []
+
+      for (const n of SIZES) {
+        const ids = makeIds(n)
+        const times: number[] = []
+
+        for (let rep = 0; rep < REPS; rep++) {
+          const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nodefs-perf-"))
+          try {
+            const adapter = new NodeFSStorageAdapter(dir)
+            await populate(adapter, ids)
+            times.push(await sweep(adapter, ids))
+          } finally {
+            fs.rmSync(dir, { force: true, recursive: true })
+          }
+        }
+
+        rows.push({ n, ms: median(times) })
+      }
+
+      console.log("\nN docs | sweep (ms) | growth vs previous")
+      console.log("-------|------------|-------------------")
+      for (let i = 0; i < rows.length; i++) {
+        const growth =
+          i === 0 ? "—" : `${(rows[i].ms / rows[i - 1].ms).toFixed(2)}x`
+        console.log(
+          `${String(rows[i].n).padStart(6)} | ${rows[i].ms
+            .toFixed(1)
+            .padStart(10)} | ${growth}`
+        )
+      }
+      console.log(
+        "\n(~2x growth per doubling = linear in N; ~4x or worse = quadratic)"
+      )
+    }
+  )
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,6 +577,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.19
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2966,6 +2969,10 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -4447,6 +4454,9 @@ packages:
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -7581,6 +7591,10 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -9210,6 +9224,8 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   punycode.js@2.3.1: {}
+
+  pure-rand@8.4.0: {}
 
   qs@6.14.2:
     dependencies:


### PR DESCRIPTION
The `NodeFSStorageAdapter` keeps an in-memory write-through cache in front of the filesystem (good!). Every `loadRange(prefix)` call must find which cached keys fall under the prefix, and it did this by scanning every key in the cache with `startsWith`. That's fine for one call, but `automerge-repo` calls `loadRange` _once per document_ when loading, so bulk operations (e.g. open a repo with thousands of docs, or sync thousands in) degrade quadratically: the 1000th document's scan walks all the keys written by the previous 999.

This PR replaces the scan with a trie keyed on path segments, kept in lockstep with the cache by two helpers (`cacheSet` & `cacheDelete`) — every `save`/`remove` updates both structures, and `loadRange` now descends the trie to the prefix node and collects just that subtree: `O(matches)` instead of `O(everything)`.

We ran into this in [`pushwork`](https://github.com/inkandswitch/pushwork) where it was causing a surprising amount of work when paired with also quadratic `#recompute` (separate PR coming soon™️)

# Machine Generated Diagram

```
BEFORE: every loadRange scans every cached key          AFTER: descend + collect subtree

loadRange(["AAAA","sync-state"])                        loadRange(["AAAA","sync-state"])
  │                                                       │
  ▼                                                       ▼ descend 2 segments
  AAAA/snapshot/h0      ── startsWith? ✓                 (root)
  AAAA/sync-state/h1    ── startsWith? ✓                  ├─ AAAA
  BBBB/snapshot/h0      ── startsWith? ✗                  │   ├─ snapshot ── h0 ●
  BBBB/incremental/h2   ── startsWith? ✗                  │   └─ sync-state ── h1 ●  ◄─ collect
  CCCC/sync-state/h7    ── startsWith? ✗                  ├─ BBBB ─ ···   (never visited)
  ··· × every key ever written                            └─ CCCC ─ ···   (never visited)

  cost: O(total keys) per call                            cost: O(matches)
  × N docs at load time = O(N²)                           × N docs = O(N)
```

# Isolated Benches

Captured on an AMD Zen 5 (`x86_64`) with the `RUN_PERF=1`-gated bench that ships in this PR (`test/LoadRangePerf.test.ts`). It benches whatever adapter is in `src/`, so before/after comes from running it against each revision (recipe in the file header). Median of 3 reps, back-to-back:

| N docs | before (ms) | after (ms) | speedup |
| ------ | ----------- | ---------- | ------- |
| 250    | 40.6        | 29.8       | 1.4x    |
| 500    | 240.8       | 31.7       | 7.6x    |
| 1000   | 756.2       | 68.6       | 11.0x   |
| 2000   | 2082.3      | 124.0      | 16.8x   |
| 4000   | 9003.5      | 257.7      | 34.9x   |
| 8000   | 56265.3     | 740.6      | 76.0x   |

The machine-load-immune signal is growth per doubling: before runs at ~3–6× (quadratic), after at ~2× (linear). At 8k documents that's a 56-second hang vs 0.74s.

# End-to-end Test (`pushwork`)

| Test | Baseline | trie | Speedup |
|------|------------------|--------------|---------|
| Offline push 4000 files — real world dir # 1 | 85.5s | 10.2s | 8.4× |
| Offline push 4000 files — real world dir # 2 | 104s | 21.3s | 4.9× |
| **Online `pushwork init` 4000 → prod** with this change alone | **319.5s** | **167–177s** | **~1.85×** |

Why are those end-to-end runs so different? When we're using the CPU, Node (or the browser) can't check in on async tasks or sockets, so work piles up and we can't make progress on things like IO which may kick off more work. There are further PRs coming to help with these additional factors.

# Testing

- Model-based oracle (`KeyIndexOracle.test.ts`, fast-check): random op sequences run against both the adapter and a reference model implementing the old scan's exact semantics (insertion-ordered `Map`), comparing every prefix query after every op — desyncs and ordering deviations can't hide behind later operations.
- Existing storage acceptance tests pass unchanged.
