### PR TITLE
fix(throttle): settle superseded asyncThrottle calls instead of orphaning them

### DIFF
--- a/packages/automerge-repo/src/helpers/throttle.ts
+++ b/packages/automerge-repo/src/helpers/throttle.ts
@@ -50,6 +50,8 @@ export const throttle = <F extends (...args: Parameters<F>) => ReturnType<F>>(
  * - Previous calls complete before new ones start (so there is no race with previous calls)
  * - There's always a minimum delay between executions
  * - The latest call always runs (canceling previous pending calls)
+ * - Superseded calls still settle — every coalesced caller resolves (or rejects)
+ *   with the winning run's result rather than being left with an orphaned promise
  * - Each call waits for the previous execution to complete
  *
  * This creates a batching behavior that prevents flooding while ensuring
@@ -90,6 +92,11 @@ export const asyncThrottle = <TArgs extends unknown[], TReturn>(
   let lastCall = Date.now()
   let timeout: ReturnType<typeof setTimeout> | undefined
   let currentPromise: Promise<TReturn> | undefined
+  // A deferred shared by every call coalesced into the next run. Sharing it is
+  // what keeps a superseded call from being orphaned: when a later call clears
+  // the pending timeout below, the earlier call still settles with the run's
+  // result (or error) instead of hanging forever.
+  let pending: PromiseWithResolvers<TReturn> | undefined
 
   return async function (...args: TArgs): Promise<TReturn> {
     // Wait for any previous call to settle, so that there is not a race with
@@ -102,6 +109,11 @@ export const asyncThrottle = <TArgs extends unknown[], TReturn>(
       }
     }
 
+    // Join (or open) the batch waiting on the next run. Every caller shares this
+    // deferred; the run itself uses the latest call's args, captured below.
+    pending ??= Promise.withResolvers<TReturn>()
+    const deferred = pending
+
     // Clear any pending timeout
     if (timeout) {
       clearTimeout(timeout)
@@ -110,19 +122,20 @@ export const asyncThrottle = <TArgs extends unknown[], TReturn>(
     // Clamp to 0: passing a negative delay to setTimeout warns on some runtimes.
     const wait = Math.max(0, lastCall + delay - Date.now()) //if negative, executes immediately
 
-    return new Promise<TReturn>((resolve, reject) => {
-      timeout = setTimeout(async () => {
-        try {
-          currentPromise = fn(...args)
-          resolve(await currentPromise)
-        } catch (error) {
-          reject(error)
-        } finally {
-          lastCall = Date.now()
-          currentPromise = undefined
-          timeout = undefined
-        }
-      }, wait)
-    })
+    timeout = setTimeout(async () => {
+      pending = undefined
+      timeout = undefined
+      try {
+        currentPromise = fn(...args)
+        deferred.resolve(await currentPromise)
+      } catch (error) {
+        deferred.reject(error)
+      } finally {
+        lastCall = Date.now()
+        currentPromise = undefined
+      }
+    }, wait)
+
+    return deferred.promise
   }
 }

--- a/packages/automerge-repo/test/throttle.test.ts
+++ b/packages/automerge-repo/test/throttle.test.ts
@@ -149,6 +149,32 @@ describe("asyncThrottle", () => {
     expect(ranWith).not.toContain(1) // fn(1) never ran — its pending timeout was cleared
     expect(ranWith).toEqual([2]) // ...and fn(2) ran in its place
   })
+
+  it("settles a superseded call's promise instead of orphaning it", async () => {
+    // Regression: previously a call whose pending timeout was cleared by a later
+    // call had its returned promise dropped — awaiting it hung forever. Now every
+    // coalesced caller (1 and 2, superseded by 3) settles with the winning run's
+    // result.
+    const throttled = asyncThrottle(async (x: number) => x * 10, 30)
+    const p1 = throttled(1) // superseded
+    const p2 = throttled(2) // superseded
+    const p3 = throttled(3) // wins
+    await vi.advanceTimersByTimeAsync(30)
+
+    expect(await Promise.all([p1, p2, p3])).toEqual([30, 30, 30])
+  })
+
+  it("propagates a rejection to every superseded caller", async () => {
+    const throttled = asyncThrottle(async (_x: number) => {
+      throw new Error("boom")
+    }, 30)
+    // Attach the rejection assertions synchronously (see the note in the
+    // "rejects" test above) so both handlers are in place before the fn runs.
+    const a1 = expect(throttled(1)).rejects.toThrow("boom")
+    const a2 = expect(throttled(2)).rejects.toThrow("boom")
+    await vi.advanceTimersByTimeAsync(30)
+    await Promise.all([a1, a2])
+  })
 })
 
 // -- Concurrency property ----------------------------------------------------


### PR DESCRIPTION
## What

`asyncThrottle` coalesces calls that arrive within the throttle window so that only the latest one runs. Each call used to create its own `Promise` wired to its own `setTimeout`. When a later call arrived it cleared the earlier call's timeout, but nothing ever resolved or rejected the earlier call's promise, so awaiting a superseded call hung forever. (A concern for GC)

```ts
const throttled = asyncThrottle(fn, 100)
const a = throttled(1) // superseded: its timeout is cleared by the next call
const b = throttled(2) // runs
await a // never settles
```

## Fix

Share a single deferred (`Promise.withResolvers`) across every call coalesced into the next run. The run still uses the latest call's args, and the existing `await currentPromise` serialization (each call waits for the previous execution to settle) is unchanged. The difference is that when the run settles, every caller coalesced into it settles with that same result, instead of only the last caller's promise being wired to the timeout.

```diff
-    return new Promise<TReturn>((resolve, reject) => {
-      timeout = setTimeout(async () => {
-        try {
-          currentPromise = fn(...args)
-          resolve(await currentPromise)
-        } catch (error) {
-          reject(error)
-        } finally {
-          lastCall = Date.now()
-          currentPromise = undefined
-          timeout = undefined
-        }
-      }, wait)
-    })
+    pending ??= Promise.withResolvers<TReturn>()
+    const deferred = pending
+    ...
+    timeout = setTimeout(async () => {
+      pending = undefined
+      timeout = undefined
+      try {
+        currentPromise = fn(...args)
+        deferred.resolve(await currentPromise)
+      } catch (error) {
+        deferred.reject(error)
+      } finally {
+        lastCall = Date.now()
+        currentPromise = undefined
+      }
+    }, wait)
+    return deferred.promise
```

## Tests

Adds two regression tests covering the coalesced callers:

- a superseded caller's promise resolves with the winning run's result
- a rejection propagates to every superseded caller

`vitest run test/throttle.test.ts`: 12 passed.

Follows #675, which clamped the same throttle's `setTimeout` delay.
