### PR TITLE
fix(websocket): clear timers and listeners on disconnect

### DIFF
--- a/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
@@ -45,6 +45,14 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   #retryIntervalId?: TimeoutId
+  // The one-shot reconnect timer armed in onClose() and the forceReady fallback
+  // timer armed in connect(), held on the instance so disconnect() can cancel
+  // them.
+  #reconnectTimeoutId?: TimeoutId
+  #forceReadyTimeoutId?: TimeoutId
+  // Set by disconnect(); guards the reconnect timer so a pending reconnect that
+  // fires after disconnect() does not revive the socket.
+  #disconnected = false
   #log = debug("automerge-repo:websocket:browser")
 
   remotePeerId?: PeerId // this adapter only connects to one remote client at a time
@@ -58,6 +66,7 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   connect(peerId: PeerId, peerMetadata?: PeerMetadata) {
+    this.#disconnected = false
     if (!this.socket || !this.peerId) {
       // first time connecting
       this.#log("connecting")
@@ -89,8 +98,10 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
 
     // Mark this adapter as ready if we haven't received an ack in 1 second.
     // We might hear back from the other end at some point but we shouldn't
-    // hold up marking things as unavailable for any longer
-    setTimeout(() => this.#forceReady(), 1000)
+    // hold up marking things as unavailable for any longer. Clear any pending
+    // fallback so reconnects don't accumulate timers.
+    clearTimeout(this.#forceReadyTimeoutId)
+    this.#forceReadyTimeoutId = setTimeout(() => this.#forceReady(), 1000)
     this.join()
   }
 
@@ -109,7 +120,9 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
 
     if (this.retryInterval > 0 && !this.#retryIntervalId)
       // try to reconnect
-      setTimeout(() => {
+      this.#reconnectTimeoutId = setTimeout(() => {
+        // Skip the reconnect if disconnect() ran after it was scheduled.
+        if (this.#disconnected) return
         assert(this.peerId)
         return this.connect(this.peerId, this.peerMetadata)
       }, this.retryInterval)
@@ -138,8 +151,13 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   disconnect() {
+    // disconnect() can be called more than once (e.g. React StrictMode double-
+    // invokes the effect cleanup that runs repo.shutdown()); make it idempotent
+    // rather than tripping the assert below on the second call.
+    if (this.#disconnected) return
     assert(this.peerId)
     assert(this.socket)
+    this.#disconnected = true
     const socket = this.socket
     if (socket) {
       socket.removeEventListener("open", this.onOpen)
@@ -148,7 +166,15 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
       socket.removeEventListener("error", this.onError)
       socket.close()
     }
+    // Cancel every pending timer and clear its id, so a later connect() can
+    // re-arm the retry interval (the connect() guard re-arms only when the id
+    // is unset).
     clearInterval(this.#retryIntervalId)
+    this.#retryIntervalId = undefined
+    clearTimeout(this.#reconnectTimeoutId)
+    this.#reconnectTimeoutId = undefined
+    clearTimeout(this.#forceReadyTimeoutId)
+    this.#forceReadyTimeoutId = undefined
     if (this.remotePeerId)
       this.emit("peer-disconnected", { peerId: this.remotePeerId })
     this.socket = undefined

--- a/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
@@ -45,13 +45,8 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   #retryIntervalId?: TimeoutId
-  // The one-shot reconnect timer armed in onClose() and the forceReady fallback
-  // timer armed in connect(), held on the instance so disconnect() can cancel
-  // them.
   #reconnectTimeoutId?: TimeoutId
   #forceReadyTimeoutId?: TimeoutId
-  // Set by disconnect(); guards the reconnect timer so a pending reconnect that
-  // fires after disconnect() does not revive the socket.
   #disconnected = false
   #log = debug("automerge-repo:websocket:browser")
 
@@ -151,9 +146,6 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   disconnect() {
-    // disconnect() can be called more than once (e.g. React StrictMode double-
-    // invokes the effect cleanup that runs repo.shutdown()); make it idempotent
-    // rather than tripping the assert below on the second call.
     if (this.#disconnected) return
     assert(this.peerId)
     assert(this.socket)
@@ -166,9 +158,6 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
       socket.removeEventListener("error", this.onError)
       socket.close()
     }
-    // Cancel every pending timer and clear its id, so a later connect() can
-    // re-arm the retry interval (the connect() guard re-arms only when the id
-    // is unset).
     clearInterval(this.#retryIntervalId)
     this.#retryIntervalId = undefined
     clearTimeout(this.#reconnectTimeoutId)

--- a/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
@@ -115,8 +115,6 @@ export class WebSocketServerAdapter extends NetworkAdapter {
     })
   }
 
-  /** Clear the keepalive interval and detach the listeners we registered on
-   * the shared WebSocketServer in connect(). Idempotent. */
   #teardownServerWiring() {
     if (this.#keepAliveId !== undefined) {
       clearInterval(this.#keepAliveId)

--- a/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
@@ -44,6 +44,14 @@ export class WebSocketServerAdapter extends NetworkAdapter {
     }
   }
 
+  // Server-level wiring registered in connect(), held on the instance so
+  // disconnect() can clear the keepalive interval and remove the listeners we
+  // add to the long-lived WebSocketServer, and so a repeated connect() does not
+  // stack duplicates.
+  #keepAliveId?: ReturnType<typeof setInterval>
+  #onServerClose?: () => void
+  #onServerConnection?: (socket: WebSocketWithIsAlive) => void
+
   constructor(
     private server: WebSocketServer,
     private keepAliveInterval = 5000
@@ -55,12 +63,16 @@ export class WebSocketServerAdapter extends NetworkAdapter {
     this.peerId = peerId
     this.peerMetadata = peerMetadata
 
-    this.server.on("close", () => {
-      clearInterval(keepAliveId)
-      this.disconnect()
-    })
+    // Detach any wiring from an earlier connect() so repeated calls don't stack
+    // listeners or intervals on the shared server.
+    this.#teardownServerWiring()
 
-    this.server.on("connection", (socket: WebSocketWithIsAlive) => {
+    this.#onServerClose = () => {
+      this.disconnect()
+    }
+    this.server.on("close", this.#onServerClose)
+
+    this.#onServerConnection = (socket: WebSocketWithIsAlive) => {
       // When a socket closes, or disconnects, remove it from our list
       socket.on("close", () => {
         this.#removeSocket(socket)
@@ -75,9 +87,10 @@ export class WebSocketServerAdapter extends NetworkAdapter {
       socket.on("pong", () => (socket.isAlive = true))
 
       this.#forceReady()
-    })
+    }
+    this.server.on("connection", this.#onServerConnection)
 
-    const keepAliveId = setInterval(() => {
+    this.#keepAliveId = setInterval(() => {
       // Terminate connections to lost clients
       const clients = this.server.clients as Set<WebSocketWithIsAlive>
       clients.forEach(socket => {
@@ -93,11 +106,30 @@ export class WebSocketServerAdapter extends NetworkAdapter {
   }
 
   disconnect() {
+    this.#teardownServerWiring()
+
     const clients = this.server.clients as Set<WebSocketWithIsAlive>
     clients.forEach(socket => {
       this.#terminate(socket)
       this.#removeSocket(socket)
     })
+  }
+
+  /** Clear the keepalive interval and detach the listeners we registered on
+   * the shared WebSocketServer in connect(). Idempotent. */
+  #teardownServerWiring() {
+    if (this.#keepAliveId !== undefined) {
+      clearInterval(this.#keepAliveId)
+      this.#keepAliveId = undefined
+    }
+    if (this.#onServerClose) {
+      this.server.off("close", this.#onServerClose)
+      this.#onServerClose = undefined
+    }
+    if (this.#onServerConnection) {
+      this.server.off("connection", this.#onServerConnection)
+      this.#onServerConnection = undefined
+    }
   }
 
   send(message: FromServerMessage) {

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -15,7 +15,7 @@ import { runNetworkAdapterTests } from "@automerge/automerge-repo/helpers/tests/
 import { DummyStorageAdapter } from "@automerge/automerge-repo/helpers/DummyStorageAdapter.js"
 import assert from "assert"
 import * as CBOR from "cbor-x"
-import { once } from "events"
+import { EventEmitter, once } from "events"
 import http from "http"
 import { getPortPromise as getAvailablePort } from "portfinder"
 import { afterEach, describe, it, vi } from "vitest"
@@ -167,6 +167,33 @@ describe("Websocket adapters", () => {
         //  The browserAdapter reconnects on its own
         await eventPromise(browser, "peer-candidate")
       }
+    })
+
+    it("should be safe to disconnect more than once", async () => {
+      const port = await getPort()
+      const browser = await setupClient({ port })
+      const { server, serverSocket, serverAdapter } = await setupServer({
+        port,
+      })
+
+      const _browserRepo = new Repo({
+        network: [browser],
+        peerId: browserPeerId,
+      })
+      const _serverRepo = new Repo({
+        network: [serverAdapter],
+        peerId: serverPeerId,
+      })
+
+      await eventPromise(browser, "peer-candidate")
+
+      browser.disconnect()
+      // A repeat disconnect (e.g. React StrictMode double-invokes the effect
+      // cleanup that runs repo.shutdown()) must be a no-op, not throw.
+      assert.doesNotThrow(() => browser.disconnect())
+
+      server.close()
+      serverSocket.close()
     })
 
     it("should throw an error if asked to send a zero-length message", async () => {
@@ -829,6 +856,53 @@ describe("Websocket adapters", () => {
       if (!headsAreSame(encodeHeads(localHeads), remoteHeads)) {
         throw new Error("heads not equal")
       }
+    })
+
+    describe("teardown (resource-leak regressions)", () => {
+      // A stand-in for `ws`'s WebSocketServer: an EventEmitter that also exposes
+      // the `clients` set the keepalive sweep reads. Lets us assert listener and
+      // timer hygiene without opening a real socket.
+      class FakeServer extends EventEmitter {
+        clients = new Set()
+      }
+
+      it("removes the listeners it added to the shared server on disconnect, and does not stack them across repeated connect() calls", () => {
+        const server = new FakeServer()
+        const adapter = new WebSocketServerAdapter(
+          server as unknown as WebSocketServer
+        )
+
+        adapter.connect(serverPeerId)
+        adapter.connect(serverPeerId) // a second connect() must not stack listeners
+
+        assert.equal(server.listenerCount("connection"), 1)
+        assert.equal(server.listenerCount("close"), 1)
+
+        adapter.disconnect()
+
+        assert.equal(server.listenerCount("connection"), 0)
+        assert.equal(server.listenerCount("close"), 0)
+      })
+
+      it("clears the keepalive interval on disconnect", () => {
+        // Fake only the interval timers the adapter owns; leave setTimeout real.
+        vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] })
+        try {
+          const server = new FakeServer()
+          const adapter = new WebSocketServerAdapter(
+            server as unknown as WebSocketServer
+          )
+
+          adapter.connect(serverPeerId)
+          // The only interval this bare adapter arms is the keepalive sweep.
+          assert.equal(vi.getTimerCount(), 1)
+
+          adapter.disconnect()
+          assert.equal(vi.getTimerCount(), 0)
+        } finally {
+          vi.useRealTimers()
+        }
+      })
     })
   })
 })


### PR DESCRIPTION
## What

`WebSocketServerAdapter` left its keepalive `setInterval` running after `disconnect()` (it was only cleared if the underlying `WebSocketServer` emitted `close`), and registered `connection`/`close` listeners on the shared server that were never removed, so a second `connect()` stacked duplicates and orphaned the earlier interval. On a long-running sync server these accumulate.

`WebSocketClientAdapter` never tracked the reconnect `setTimeout` armed in `onClose()` or the forceReady fallback `setTimeout`, so a reconnect scheduled just before `disconnect()` would still fire and revive a torn-down adapter. `disconnect()` was also not idempotent: the first call clears `this.socket`, so a second call tripped `assert(this.socket)` and threw. That surfaces under React StrictMode, which double-invokes the effect cleanup that runs `repo.shutdown()`. https://discord.com/channels/1200006940210757672/1497472347869806624

## Fix

- Server: track the keepalive interval and the server listeners on the instance and tear them down in `disconnect()`; a repeated `connect()` no longer stacks them.
- Client: track and cancel both timers in `disconnect()`, reset `#retryIntervalId` so a later `connect()` can re-arm retries, and use a `#disconnected` flag both to stop a pending reconnect from reviving the socket and to make `disconnect()` idempotent (a second call returns early instead of throwing).

## Tests

Adds regression tests: the server adapter removes its listeners and clears the keepalive interval on `disconnect()`, and the client adapter is safe to `disconnect()` more than once. Existing suite passes.
