### PR TITLE
fix(SyncStateTracker): catch errors from the throttled sync-state save

### DIFF
--- a/packages/automerge-repo/src/SyncStateTracker.ts
+++ b/packages/automerge-repo/src/SyncStateTracker.ts
@@ -1,6 +1,7 @@
 import { encodeHeads } from "./AutomergeUrl.js"
 import type { DocHandle, SyncInfo } from "./DocHandle.js"
 import { headsAreSame } from "./helpers/headsAreSame.js"
+import { makeLogger } from "./Logger.js"
 import type { PeerMetadata } from "./network/NetworkAdapterInterface.js"
 import type { StorageSubsystem } from "./storage/StorageSubsystem.js"
 import type { StorageId } from "./storage/types.js"
@@ -29,6 +30,7 @@ export class SyncStateTracker {
     StorageId,
     (payload: SyncStatePayload) => Promise<void>
   > = {}
+  #log = makeLogger("automerge-repo:sync-state-tracker")
 
   constructor(storage: StorageSubsystem | undefined, saveDebounceRate: number) {
     this.#storage = storage
@@ -148,8 +150,20 @@ export class SyncStateTracker {
     let handler = this.#throttledSaveSyncStateHandlers[storageId]
     if (!handler) {
       handler = this.#throttledSaveSyncStateHandlers[storageId] = asyncThrottle(
-        ({ documentId, syncState }: SyncStatePayload) =>
-          this.#storage!.saveSyncState(documentId, storageId, syncState),
+        async ({ documentId, syncState }: SyncStatePayload) => {
+          try {
+            await this.#storage!.saveSyncState(documentId, storageId, syncState)
+          } catch (err) {
+            // Fire-and-forget (the result is discarded below): catch and log a
+            // failed write instead of letting it surface as an unhandled
+            // rejection. Sync state is re-derived from the next sync exchange,
+            // so a dropped save is recoverable.
+            this.#log.error(
+              `Error saving sync state for ${documentId} to ${storageId}`,
+              err
+            )
+          }
+        },
         this.#saveDebounceRate
       )
     }

--- a/packages/automerge-repo/test/SyncStateTracker.test.ts
+++ b/packages/automerge-repo/test/SyncStateTracker.test.ts
@@ -1,0 +1,57 @@
+import { next as A } from "@automerge/automerge"
+import assert from "assert"
+import { describe, it, vi } from "vitest"
+import { generateAutomergeUrl, parseAutomergeUrl } from "../src/AutomergeUrl.js"
+import type { DocHandle } from "../src/DocHandle.js"
+import { SyncStateTracker } from "../src/SyncStateTracker.js"
+import { StorageSubsystem } from "../src/storage/StorageSubsystem.js"
+import { DummyStorageAdapter } from "../src/helpers/DummyStorageAdapter.js"
+import type { StorageId } from "../src/storage/types.js"
+import type { SyncStatePayload } from "../src/synchronizer/Synchronizer.js"
+import type { PeerId } from "../src/types.js"
+
+describe("SyncStateTracker", () => {
+  it("logs a failed sync-state save instead of leaking an unhandled rejection", async () => {
+    // The throttled sync-state save runs fire-and-forget (its promise is
+    // discarded). If the storage write rejects, the rejection must be caught
+    // and logged, not left to surface as an unhandled rejection (which exits a
+    // Node sync server by default). Mirrors StorageSource's save path.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      // An adapter whose save() always rejects (disk/IO error, quota, ...).
+      const adapter = new DummyStorageAdapter()
+      adapter.save = async () => {
+        throw new Error("simulated storage write failure")
+      }
+
+      const tracker = new SyncStateTracker(new StorageSubsystem(adapter), 10)
+
+      // handleSyncState only touches `handle` to emit "remote-heads" after the
+      // save is scheduled, so a minimal stub is enough to exercise the save path.
+      const handle = { emit: () => true } as unknown as DocHandle<unknown>
+      const message: SyncStatePayload = {
+        peerId: "peer-1" as PeerId,
+        documentId: parseAutomergeUrl(generateAutomergeUrl()).documentId,
+        syncState: A.initSyncState(),
+      }
+      const peerMetadata = {
+        storageId: "storage-1" as StorageId,
+        isEphemeral: false,
+      }
+
+      tracker.handleSyncState(message, peerMetadata, handle)
+
+      // The failure must be caught and logged, not floated as a rejection.
+      await vi.waitFor(() =>
+        assert.ok(
+          errSpy.mock.calls.some(call =>
+            call.some(arg => String(arg).includes("Error saving sync state"))
+          ),
+          "the failed sync-state save should be caught and logged"
+        )
+      )
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
## What

The per-storage-id throttled `saveSyncState` handler ran fire-and-forget (`void handler(payload)`) with no error handling, so a rejected storage write surfaced as an unhandled rejection and, in Node, exits the process by default.

## Fix

Wrap the throttled save in try/catch and log, mirroring `StorageSource`'s heads-changed save. Sync state is re-derived from the next sync exchange, so a dropped save is recoverable.

## Tests

Adds a regression test asserting a rejecting `saveSyncState` is caught and logged rather than floated.
