### PR TITLE
perf(storage): bound storage fan-out and make flush drain before teardown

### DIFF
--- a/packages/automerge-repo-storage-nodefs/src/index.ts
+++ b/packages/automerge-repo-storage-nodefs/src/index.ts
@@ -8,18 +8,51 @@ import {
   StorageAdapterInterface,
   type StorageKey,
 } from "@automerge/automerge-repo/slim"
+import { semaphore } from "@automerge/automerge-repo/helpers/semaphore.js"
 import fs from "fs"
 import path from "path"
+
+/**
+ * Default cap on concurrent filesystem operations. loadRange() can fan out
+ * across thousands of chunk files for a single document; without a bound,
+ * Promise.all would open that many file descriptors at once and can exhaust the
+ * process's FD limit (EMFILE).
+ */
+const DEFAULT_MAX_CONCURRENT_FILE_OPERATIONS = 100
+
+export interface NodeFSStorageAdapterOptions {
+  /**
+   * Maximum number of filesystem operations in flight at once, shared across all
+   * concurrent `loadRange` / `walkdir` calls on this adapter. Defaults to 100.
+   *
+   * @remarks
+   * Tie this to the process's file-descriptor ceiling (commonly 1024 on Linux,
+   * 256 on macOS), leaving headroom for everything else holding descriptors.
+   * The default 100 is well under typical limits while still loading a
+   * many-chunk document in parallel.
+   */
+  maxConcurrency?: number
+}
 
 export class NodeFSStorageAdapter implements StorageAdapterInterface {
   private baseDirectory: string
   private cache: { [key: string]: Uint8Array } = {}
+  // Shared per-adapter so concurrent loadRange / walkdir calls stay under the
+  // cap together rather than each getting its own budget.
+  private limit: ReturnType<typeof semaphore>
 
   /**
    * @param baseDirectory - The path to the directory to store data in. Defaults to "./automerge-repo-data".
+   * @param options - see {@link NodeFSStorageAdapterOptions}.
    */
-  constructor(baseDirectory = "automerge-repo-data") {
+  constructor(
+    baseDirectory = "automerge-repo-data",
+    options: NodeFSStorageAdapterOptions = {}
+  ) {
     this.baseDirectory = baseDirectory
+    this.limit = semaphore(
+      options.maxConcurrency ?? DEFAULT_MAX_CONCURRENT_FILE_OPERATIONS
+    )
   }
 
   async load(keyArray: StorageKey): Promise<Uint8Array | undefined> {
@@ -71,7 +104,7 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
     const cachedKeys = this.cachedKeys(keyPrefix)
 
     // Read filenames from disk
-    const diskFiles = await walkdir(dirPath)
+    const diskFiles = await walkdir(dirPath, this.limit)
 
     // The "keys" in the cache don't include the baseDirectory.
     // We want to de-dupe with the cached keys so we'll use getKey to normalize them.
@@ -83,13 +116,16 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
     // Combine and deduplicate the lists of keys
     const allKeys = [...new Set([...cachedKeys, ...diskKeys])]
 
-    // Load all files
+    // Load all files, bounding concurrent reads so a document with many chunks
+    // doesn't open every file descriptor at once.
     const chunks = await Promise.all(
-      allKeys.map(async keyString => {
-        const key: StorageKey = keyString.split(path.sep)
-        const data = await this.load(key)
-        return { data, key }
-      })
+      allKeys.map(keyString =>
+        this.limit(async () => {
+          const key: StorageKey = keyString.split(path.sep)
+          const data = await this.load(key)
+          return { data, key }
+        })
+      )
     )
 
     return chunks
@@ -127,13 +163,21 @@ export class NodeFSStorageAdapter implements StorageAdapterInterface {
 const getKey = (key: StorageKey): string => path.join(...key)
 
 /** returns all files in a directory, recursively  */
-const walkdir = async (dirPath: string): Promise<string[]> => {
+const walkdir = async (
+  dirPath: string,
+  limit: ReturnType<typeof semaphore>
+): Promise<string[]> => {
   try {
-    const entries = await fs.promises.readdir(dirPath, { withFileTypes: true })
+    // Bound concurrent readdir calls. The slot is released as soon as the
+    // readdir resolves, before recursing, so a parent never holds a slot while
+    // waiting on its children (which would risk deadlock under a small cap).
+    const entries = await limit(() =>
+      fs.promises.readdir(dirPath, { withFileTypes: true })
+    )
     const files = await Promise.all(
       entries.map(entry => {
         const subpath = path.resolve(dirPath, entry.name)
-        return entry.isDirectory() ? walkdir(subpath) : subpath
+        return entry.isDirectory() ? walkdir(subpath, limit) : subpath
       })
     )
     return files.flat()

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -702,8 +702,7 @@ export class Repo extends EventEmitter<RepoEvents> {
    *   `flush()` settles, even if some fail; this is what makes `flush()` safe to
    *   `await` before teardown in {@link Repo.shutdown} (nothing is still writing
    *   when the caller proceeds). Failures are collected and rethrown as an
-   *   `AggregateError`. This differs from a fail-fast `Promise.all`, which would
-   *   reject on the first failure while other saves were still in flight.
+   *   `AggregateError`.
    */
   async flush(documents?: DocumentId[]): Promise<void> {
     if (!this.storageSubsystem) {
@@ -827,7 +826,7 @@ export interface RepoConfig {
    *
    * @remarks
    * Tie this to the constraining resource of your
-   * {@link StorageAdapterInterface}, not a round number:
+   * {@link StorageAdapterInterface}:
    * - **filesystem** (e.g. the nodefs adapter): stay well under the process's
    *   file-descriptor ceiling; the default 20 is comfortable.
    * - **HTTP/1.1-backed**: a browser caps connections per origin at ~6, so a

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -43,6 +43,15 @@ import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
 import { isPlainObject } from "./helpers/isPlainObject.js"
 import { hasAtLeastOneKey } from "./helpers/has-at-least-one-key.js"
 import { noop } from "./helpers/noop.js"
+import { semaphore } from "./helpers/semaphore.js"
+
+/**
+ * Default for {@link RepoConfig.flushConcurrency}: the number of documents
+ * {@link Repo.flush} writes to storage concurrently. A sync server may hold
+ * thousands of documents; flushing them all at once would spike the storage
+ * adapter's connections / file descriptors / memory, so the fan-out is bounded.
+ */
+const DEFAULT_FLUSH_CONCURRENCY = 20
 
 export type { DocumentProgress } from "./DocumentQuery.js"
 export { DocumentQuery } from "./DocumentQuery.js"
@@ -87,6 +96,7 @@ export class Repo extends EventEmitter<RepoEvents> {
   #remoteHeadsSubscriptions = new RemoteHeadsSubscriptions()
   #remoteHeadsGossipingEnabled = false
   #idFactory: ((initialHeads: Heads) => Promise<Uint8Array>) | null
+  #flushConcurrency: number
 
   constructor({
     storage,
@@ -98,10 +108,12 @@ export class Repo extends EventEmitter<RepoEvents> {
     enableRemoteHeadsGossiping = false,
     denylist = [],
     saveDebounceRate = 100,
+    flushConcurrency = DEFAULT_FLUSH_CONCURRENCY,
     idFactory,
   }: RepoConfig = {}) {
     super()
     this.#remoteHeadsGossipingEnabled = enableRemoteHeadsGossiping
+    this.#flushConcurrency = flushConcurrency
 
     this.#idFactory = idFactory || null
     // Handle legacy sharePolicy
@@ -679,6 +691,19 @@ export class Repo extends EventEmitter<RepoEvents> {
    * @hidden this API is experimental and may change.
    * @param documents - if provided, only writes the specified documents.
    * @returns Promise<void>
+   *
+   * @remarks
+   * Two coordination guarantees, both aimed at flushing a large collection
+   * safely (a sync server may hold thousands of documents):
+   *
+   * - **Bounded fan-out.** At most {@link RepoConfig.flushConcurrency} document
+   *   saves run at once, instead of launching every save simultaneously.
+   * - **Drain before settle.** Every save is awaited (`allSettled`) before
+   *   `flush()` settles, even if some fail; this is what makes `flush()` safe to
+   *   `await` before teardown in {@link Repo.shutdown} (nothing is still writing
+   *   when the caller proceeds). Failures are collected and rethrown as an
+   *   `AggregateError`. This differs from a fail-fast `Promise.all`, which would
+   *   reject on the first failure while other saves were still in flight.
    */
   async flush(documents?: DocumentId[]): Promise<void> {
     if (!this.storageSubsystem) {
@@ -686,14 +711,32 @@ export class Repo extends EventEmitter<RepoEvents> {
     }
 
     const ids = documents ?? (Object.keys(this.#queries) as DocumentId[])
-    await Promise.all(
-      ids.map(async id => {
-        const state = this.#queries[id]?.peek()
-        if (state?.state === "ready") {
-          await this.storageSubsystem!.saveDoc(id, state.handle.fullDoc())
-        }
-      })
+    // Bound the fan-out so flushing a large collection doesn't open every
+    // storage write at once. State is re-read inside the limited task because a
+    // query may have changed between enqueue and execution.
+    const limit = semaphore(this.#flushConcurrency)
+    const results = await Promise.allSettled(
+      ids.map(id =>
+        limit(async () => {
+          const state = this.#queries[id]?.peek()
+          if (state?.state === "ready") {
+            await this.storageSubsystem!.saveDoc(id, state.handle.fullDoc())
+          }
+        })
+      )
     )
+
+    // Surface failures, but only after every save has settled so teardown
+    // (shutdown) never runs while a save is still in flight.
+    const failures = results
+      .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+      .map(r => r.reason)
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        `flush: ${failures.length} of ${ids.length} document save(s) failed`
+      )
+    }
   }
 
   /**
@@ -709,10 +752,16 @@ export class Repo extends EventEmitter<RepoEvents> {
     this.#syncStateTracker.delete(documentId)
   }
 
-  async shutdown() {
-    await this.flush()
-    this.networkSubsystem.disconnect()
-    await this.storageSubsystem?.close()
+  async shutdown(): Promise<void> {
+    // Drain saves first (flush awaits all of them), then always tear down in
+    // the finally so a partial flush failure (which rejects flush) still
+    // disconnects the network and closes storage rather than leaking resources.
+    try {
+      await this.flush()
+    } finally {
+      this.networkSubsystem.disconnect()
+      await this.storageSubsystem?.close()
+    }
   }
 
   metrics(): { documents: { [key: string]: any } } {
@@ -771,6 +820,24 @@ export interface RepoConfig {
    * The debounce rate in milliseconds for saving documents. Defaults to 100ms.
    */
   saveDebounceRate?: number
+
+  /**
+   * Maximum number of documents {@link Repo.flush} (and {@link Repo.shutdown})
+   * write to storage concurrently. Defaults to 20.
+   *
+   * @remarks
+   * Tie this to the constraining resource of your
+   * {@link StorageAdapterInterface}, not a round number:
+   * - **filesystem** (e.g. the nodefs adapter): stay well under the process's
+   *   file-descriptor ceiling; the default 20 is comfortable.
+   * - **HTTP/1.1-backed**: a browser caps connections per origin at ~6, so a
+   *   limit near that avoids head-of-line queueing you can't see.
+   * - **HTTP/2-backed**: ~100 multiplexed streams per connection, so you can go
+   *   higher.
+   * - **database-backed**: at or below the connection-pool size, leaving
+   *   headroom for other callers.
+   */
+  flushConcurrency?: number
 
   // This is hidden for now because it's an experimental API, mostly here in order
   // for keyhive to be able to control the ID generation

--- a/packages/automerge-repo/src/helpers/semaphore.ts
+++ b/packages/automerge-repo/src/helpers/semaphore.ts
@@ -1,0 +1,83 @@
+/**
+ * A counting semaphore that caps how many of the functions passed to it run at
+ * once. Returns a gate, `limit`, that you wrap each call in; at most
+ * `concurrency` run concurrently and the rest queue (FIFO), starting as slots
+ * free up.
+ *
+ * @remarks
+ * This is the fix for the most common async pitfall: `Promise.all(items.map(fn))`
+ * launches *every* task at once (promises are eager), overwhelming a bounded
+ * resource such as a connection pool, an HTTP host's connection cap, a
+ * file-descriptor limit, an API rate limit, or just memory. Gate each call so
+ * at most `concurrency` run concurrently:
+ *
+ * ```typescript
+ * const limit = semaphore(10)
+ * const results = await Promise.all(items.map(item => limit(() => work(item))))
+ * ```
+ *
+ * `Promise.all` still resolves results in input order, and its rejection
+ * semantics are unchanged; the gate only throttles *when* each function is
+ * invoked. A slot is released in `finally`, so a rejecting task does not stall
+ * the queue. Note this is the "run a function under the gate" shape
+ * (`limit(() => fn())`), not a classic `acquire()` / `release()` semaphore.
+ *
+ * **Choosing `concurrency`**: tie it to the constraining resource, not a vibe.
+ * - filesystem: stay well under the process's file-descriptor ceiling
+ * - HTTP/1.1-backed: a browser allows ~6 connections per origin
+ * - HTTP/2-backed: ~100 multiplexed streams per connection
+ * - database-backed: at or below the connection-pool size, with headroom for
+ *   other callers
+ *
+ * **Synchronous-start contract**: when a slot is free, `fn` is invoked
+ * *synchronously* in the current tick (like a bare `items.map(fn)`), not
+ * deferred to a microtask. Callers that start work and then synchronously act
+ * on it (for example, unblocking a paused test double immediately after kicking
+ * the work off) rely on this. Do not refactor the call to `fn` behind a
+ * `.then()` / `queueMicrotask` (or an `await` before `fn()` is reached on the
+ * free-slot path).
+ *
+ * @param concurrency - Maximum number of wrapped functions allowed to run at
+ *   once. Must be a positive integer.
+ * @returns A `limit(fn)` gate. Each call runs `fn` when a slot is free and
+ *   resolves/rejects with `fn`'s result.
+ */
+export function semaphore(concurrency: number): Limit {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new TypeError("semaphore: concurrency must be a positive integer")
+  }
+
+  let active = 0
+  const waiters: Array<() => void> = []
+
+  const release = () => {
+    // Hand the slot straight to the next waiter (active unchanged) so a caller
+    // arriving in the same tick can't slip in front of it; only free the slot
+    // when nobody is waiting.
+    const wake = waiters.shift()
+    if (wake) wake()
+    else active--
+  }
+
+  return async <T>(fn: () => PromiseLike<T> | T): Promise<T> => {
+    if (active < concurrency) {
+      active++
+    } else {
+      // At capacity: park until release() hands us a slot.
+      const { promise, resolve } = Promise.withResolvers<void>()
+      waiters.push(resolve)
+      await promise
+    }
+    // The free-slot path reaches here with no intervening await, so `fn()` runs
+    // synchronously in the current tick (the synchronous-start contract).
+    try {
+      return await fn()
+    } finally {
+      release()
+    }
+  }
+}
+
+/** The gate returned by {@link semaphore}: runs `fn` under the concurrency
+ * limit and resolves/rejects with its result. */
+export type Limit = <T>(fn: () => PromiseLike<T> | T) => Promise<T>

--- a/packages/automerge-repo/src/helpers/semaphore.ts
+++ b/packages/automerge-repo/src/helpers/semaphore.ts
@@ -5,11 +5,7 @@
  * free up.
  *
  * @remarks
- * This is the fix for the most common async pitfall: `Promise.all(items.map(fn))`
- * launches *every* task at once (promises are eager), overwhelming a bounded
- * resource such as a connection pool, an HTTP host's connection cap, a
- * file-descriptor limit, an API rate limit, or just memory. Gate each call so
- * at most `concurrency` run concurrently:
+ * Gate each call so at most `concurrency` run concurrently:
  *
  * ```typescript
  * const limit = semaphore(10)
@@ -22,7 +18,7 @@
  * the queue. Note this is the "run a function under the gate" shape
  * (`limit(() => fn())`), not a classic `acquire()` / `release()` semaphore.
  *
- * **Choosing `concurrency`**: tie it to the constraining resource, not a vibe.
+ * **Choosing `concurrency`**: tie it to the constraining resource.
  * - filesystem: stay well under the process's file-descriptor ceiling
  * - HTTP/1.1-backed: a browser allows ~6 connections per origin
  * - HTTP/2-backed: ~100 multiplexed streams per connection

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1031,6 +1031,52 @@ describe("Repo", () => {
         await flushPromise
       }
     })
+
+    it("drains all saves and rejects with an AggregateError when saves fail", async () => {
+      // allSettled, not fail-fast: every save is attempted and awaited before
+      // flush() settles, then failures are aggregated and rethrown.
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      try {
+        const storage = new DummyStorageAdapter()
+        const realSave = storage.save.bind(storage)
+        storage.save = async (key, data) => {
+          // Fail only document saves; let the internal storage-adapter-id save
+          // through so Repo construction's peer-metadata lookup still resolves.
+          if (key[0] === "storage-adapter-id") return realSave(key, data)
+          throw new Error("disk full")
+        }
+        const repo = new Repo({ storage })
+        repo.create({ a: 1 })
+        repo.create({ b: 2 })
+
+        await expect(repo.flush()).rejects.toThrow(AggregateError)
+      } finally {
+        errSpy.mockRestore()
+      }
+    })
+
+    it("shutdown() disconnects even if flush() fails", async () => {
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      try {
+        const storage = new DummyStorageAdapter()
+        const realSave = storage.save.bind(storage)
+        storage.save = async (key, data) => {
+          // Fail only document saves; let the internal storage-adapter-id save
+          // through so Repo construction's peer-metadata lookup still resolves.
+          if (key[0] === "storage-adapter-id") return realSave(key, data)
+          throw new Error("disk full")
+        }
+        const repo = new Repo({ storage })
+        repo.create({ a: 1 })
+        const disconnectSpy = vi.spyOn(repo.networkSubsystem, "disconnect")
+
+        // shutdown rethrows flush's failure, but the finally must still run.
+        await expect(repo.shutdown()).rejects.toThrow(AggregateError)
+        expect(disconnectSpy).toHaveBeenCalledOnce()
+      } finally {
+        errSpy.mockRestore()
+      }
+    })
   })
 
   describe("with peers (linear network)", async () => {

--- a/packages/automerge-repo/test/semaphore.test.ts
+++ b/packages/automerge-repo/test/semaphore.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest"
+import { semaphore } from "../src/helpers/semaphore.js"
+
+// Drain all pending microtasks by bouncing off a macrotask.
+const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+describe("semaphore", () => {
+  it("runs free-slot tasks synchronously and defers only the over-capacity ones", () => {
+    // Pins the synchronous-start contract: a free slot must invoke `fn` in the
+    // current tick (callers like Repo.flush unblock a paused test double right
+    // after starting the work). An `await` before `fn` (e.g. `await acquire()`)
+    // would defer it to a microtask: this test would then see `[]` here. A
+    // missing gate would see `[0, 1, 2]`. Only `[0, 1]` is correct.
+    const limit = semaphore(2)
+    const startedSync: number[] = []
+    const holdSlotOpen = () => new Promise<void>(() => {})
+    void limit(() => {
+      startedSync.push(0)
+      return holdSlotOpen()
+    })
+    void limit(() => {
+      startedSync.push(1)
+      return holdSlotOpen()
+    })
+    void limit(() => {
+      startedSync.push(2) // over capacity — must not run in this tick
+      return holdSlotOpen()
+    })
+    expect(startedSync).toEqual([0, 1])
+  })
+
+  it("runs at most `concurrency` tasks at once and starts queued tasks as slots free", async () => {
+    const limit = semaphore(2)
+    const started: number[] = []
+    const resolvers: Array<() => void> = []
+    const make = (i: number) =>
+      limit(() => {
+        started.push(i)
+        return new Promise<void>(resolve => {
+          resolvers[i] = resolve
+        })
+      })
+
+    const all = Promise.all([make(0), make(1), make(2), make(3)])
+
+    await flush()
+    expect(started).toEqual([0, 1]) // only two slots
+
+    resolvers[0]()
+    await flush()
+    expect(started).toEqual([0, 1, 2]) // a freed slot admits the next
+
+    resolvers[1]()
+    await flush()
+    expect(started).toEqual([0, 1, 2, 3])
+
+    resolvers[2]()
+    resolvers[3]()
+    await all
+  })
+
+  it("resolves results in input order regardless of completion order", async () => {
+    const limit = semaphore(3)
+    const results = await Promise.all(
+      [30, 10, 20].map((ms, i) =>
+        limit(
+          () => new Promise<number>(resolve => setTimeout(() => resolve(i), ms))
+        )
+      )
+    )
+    expect(results).toEqual([0, 1, 2])
+  })
+
+  it("releases the slot when a task rejects so the queue keeps draining", async () => {
+    const limit = semaphore(1)
+    let bRan = false
+    const a = limit(() => Promise.reject(new Error("boom")))
+    const b = limit(() => {
+      bRan = true
+    })
+    // If a rejection did not free the slot, `b` would never run and the await
+    // below would hang the test.
+    await expect(a).rejects.toThrow("boom")
+    await b
+    expect(bRan).toBe(true)
+  })
+
+  it("rejects an invalid concurrency", () => {
+    expect(() => semaphore(0)).toThrow(TypeError)
+    expect(() => semaphore(-1)).toThrow(TypeError)
+    expect(() => semaphore(1.5)).toThrow(TypeError)
+  })
+})


### PR DESCRIPTION
## What

`Repo.flush()` and the nodefs adapter's `loadRange()`/`walkdir()` each used `Promise.all(items.map(...))` over a bounded resource, launching every storage write / file read at once. On a sync server holding thousands of documents this spikes the storage adapter's connections, and for nodefs can exhaust the process's file-descriptor limit (EMFILE) when a document has many chunks.

## Fix

- Add a small, dependency-free `semaphore()` concurrency limiter and wrap the fan-outs in it. Concurrency is configurable: `RepoConfig.flushConcurrency` (default 20) and `NodeFSStorageAdapterOptions.maxConcurrency` (default 100), each with TSDoc guidance for picking a value per storage-adapter kind (filesystem / HTTP1.1 / HTTP2 / database).
- `flush()` now drains before it settles: it awaits every save via `allSettled` (collecting failures into an `AggregateError`) instead of fail-fast `Promise.all`, and `shutdown()` disconnects in a `finally`.

## Note: public-contract change to `flush()`

This intentionally changes `flush()`'s rejection behavior: it now rejects with an `AggregateError` after every save has settled, rather than rejecting on the first failure while other saves are still writing. The reason is correctness on teardown: awaiting `flush()` before `shutdown()` should mean nothing is still writing when teardown proceeds, which a fail-fast `Promise.all` does not guarantee.

## Tests

`semaphore` unit tests (including a synchronous-start contract guard), and `flush` drain / `AggregateError` plus shutdown-disconnect-on-failure regressions.
