### PR TITLE
fix(svelte-store): remove the handle listener when the store has no subscribers

### DIFF
--- a/packages/automerge-repo-svelte-store/src/lib/index.ts
+++ b/packages/automerge-repo-svelte-store/src/lib/index.ts
@@ -105,16 +105,23 @@ export function createAutomergeStore(repo: Repo) {
   function createDocumentStore<T>(
     handle: DocHandle<T>
   ): AutomergeDocumentStore<T> {
-    // Create a writable store with the current document
-    const { subscribe, set } = writable<Doc<T> | null>(handle.doc() ?? null)
-
-    // Set up change listener
-    const onChange = ({ doc }: { doc: Doc<T> | undefined }) => {
-      set(doc ?? null)
-    }
-
-    // Subscribe to changes
-    handle.on("change", onChange)
+    // Create a writable store with the current document. The start/stop
+    // notifier ties the handle's "change" subscription to the store's own
+    // subscriber lifecycle: attach the listener when the first subscriber
+    // arrives, detach it when the last unsubscribes.
+    const { subscribe, set } = writable<Doc<T> | null>(
+      handle.doc() ?? null,
+      () => {
+        const onChange = ({ doc }: { doc: Doc<T> | undefined }) => {
+          set(doc ?? null)
+        }
+        handle.on("change", onChange)
+        // Re-sync in case the document changed between store creation and the
+        // first subscription.
+        set(handle.doc() ?? null)
+        return () => handle.removeListener("change", onChange)
+      }
+    )
 
     // Create the store implementation
     const store: AutomergeDocumentStore<T> = {

--- a/packages/automerge-repo-svelte-store/test/store.test.ts
+++ b/packages/automerge-repo-svelte-store/test/store.test.ts
@@ -1,0 +1,53 @@
+import { Repo } from "@automerge/automerge-repo"
+import { describe, expect, it } from "vitest"
+import { createAutomergeStore } from "../src/lib/index.js"
+
+type Counter = { count: number }
+
+describe("createAutomergeStore", () => {
+  it("attaches a change listener only while the store has subscribers", async () => {
+    const repo = new Repo({})
+    const handle = repo.create<Counter>({ count: 0 })
+    const docStore = await createAutomergeStore(repo).find<Counter>(handle.url)
+    expect(docStore).not.toBeNull()
+
+    // Measure relative to the baseline: other subsystems (e.g. the
+    // DocSynchronizer) also attach "change" listeners, so assert on the delta
+    // the store contributes rather than an absolute count.
+    const base = docStore!.handle.listenerCount("change")
+
+    const unsub1 = docStore!.subscribe(() => {})
+    expect(docStore!.handle.listenerCount("change")).toBe(base + 1)
+
+    // Svelte refcounts subscribers: a second subscriber does not add a second
+    // handle listener.
+    const unsub2 = docStore!.subscribe(() => {})
+    expect(docStore!.handle.listenerCount("change")).toBe(base + 1)
+
+    unsub1()
+    expect(docStore!.handle.listenerCount("change")).toBe(base + 1)
+
+    // Last subscriber gone -> the store's handle listener is removed.
+    unsub2()
+    expect(docStore!.handle.listenerCount("change")).toBe(base)
+  })
+
+  it("reflects document changes while subscribed", async () => {
+    const repo = new Repo({})
+    const handle = repo.create<Counter>({ count: 0 })
+    const docStore = await createAutomergeStore(repo).find<Counter>(handle.url)
+
+    let latest: Counter | null = null
+    const unsub = docStore!.subscribe(value => {
+      latest = value
+    })
+    expect(latest!.count).toBe(0)
+
+    docStore!.change(d => {
+      d.count = 5
+    })
+    expect(latest!.count).toBe(5)
+
+    unsub()
+  })
+})

--- a/packages/automerge-repo-svelte-store/test/store.test.ts
+++ b/packages/automerge-repo-svelte-store/test/store.test.ts
@@ -32,6 +32,33 @@ describe("createAutomergeStore", () => {
     expect(docStore!.handle.listenerCount("change")).toBe(base)
   })
 
+  it("catches up when a subscriber returns after a quiet period", async () => {
+    const repo = new Repo({})
+    const handle = repo.create<Counter>({ count: 0 })
+    const docStore = await createAutomergeStore(repo).find<Counter>(handle.url)
+
+    const first = docStore!.subscribe(() => {})
+    first()
+
+    // Change while nobody subscribes: no listener is attached, so the store
+    // must refresh from the handle when the next subscriber arrives.
+    docStore!.change(d => {
+      d.count = 42
+    })
+
+    let latest: Counter | null = null
+    const unsub = docStore!.subscribe(value => {
+      latest = value
+    })
+    expect(latest!.count).toBe(42)
+
+    docStore!.change(d => {
+      d.count = 43
+    })
+    expect(latest!.count).toBe(43)
+    unsub()
+  })
+
   it("reflects document changes while subscribed", async () => {
     const repo = new Repo({})
     const handle = repo.create<Counter>({ count: 0 })


### PR DESCRIPTION
## What

`createDocumentStore` attached a `change` listener to the handle at store-creation time and never removed it, so every store created and then dropped leaked a handle listener.

## Fix

Move the subscription into `writable`'s start/stop notifier so the listener is attached on the first subscriber and detached when the last unsubscribes.

## Tests

Adds a regression test asserting the store contributes exactly one handle listener while subscribed and none after the last unsubscribe.



---

**Update:** added a test covering catch-up after a subscriber-free gap (the start notifier re-reads the handle, so a returning subscriber sees changes made while nobody was subscribed). This fix also matters for #737 (consumer-driven document GC): under that model an attached listener roots its document, so the missing teardown here would permanently pin every document opened through a store, and subscriber-free gaps become routine once unobserved documents can be evicted and re-materialized.
