### PR TITLE
fix(broadcastchannel): tear down the channel on disconnect and drop malformed messages

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -15,11 +15,14 @@
  */
 
 import {
+  makeLogger,
   NetworkAdapter,
   type Message,
   type PeerId,
   type PeerMetadata,
 } from "@automerge/automerge-repo/slim"
+
+const log = makeLogger("automerge-repo:broadcastchannel")
 
 export type BroadcastChannelNetworkAdapterOptions = {
   /** BroadcastChannel name to use */
@@ -30,6 +33,9 @@ export type BroadcastChannelNetworkAdapterOptions = {
 
 export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
   #broadcastChannel: BroadcastChannel
+  // Held on the instance so disconnect() can remove it and connect() can avoid
+  // stacking duplicates.
+  #messageListener?: (e: { data: BroadcastChannelMessage }) => void
   #disconnected = false
   #ready = false
   // reassigned in constructor, but keeps TS from complaining
@@ -68,66 +74,78 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
   connect(peerId: PeerId, peerMetadata?: PeerMetadata) {
     this.peerId = peerId
     this.peerMetadata = peerMetadata
+
+    // disconnect() closes the channel, so reopen one when reconnecting after a
+    // disconnect; otherwise detach the current listener before re-adding so we
+    // never stack duplicates.
+    if (this.#disconnected) {
+      this.#broadcastChannel = new BroadcastChannel(this.#options.channelName)
+    } else if (this.#messageListener) {
+      this.#broadcastChannel.removeEventListener(
+        "message",
+        this.#messageListener
+      )
+    }
     this.#disconnected = false
 
-    this.#broadcastChannel.addEventListener(
-      "message",
-      (e: { data: BroadcastChannelMessage }) => {
-        const message = e.data
-        if ("targetId" in message && message.targetId !== this.peerId) {
-          return
-        }
-
-        if (this.#disconnected) {
-          return
-        }
-
-        const { senderId, type } = message
-
-        switch (type) {
-          case "arrive":
-            {
-              const { peerMetadata } = message as ArriveMessage
-              this.#broadcastChannel.postMessage({
-                senderId: this.peerId,
-                targetId: senderId,
-                type: "welcome",
-                peerMetadata: this.peerMetadata,
-              })
-              this.#announceConnection(senderId, peerMetadata)
-            }
-            break
-          case "welcome":
-            {
-              const { peerMetadata } = message as WelcomeMessage
-              this.#announceConnection(senderId, peerMetadata)
-            }
-            break
-          case "leave":
-            this.#connectedPeers = this.#connectedPeers.filter(
-              p => p !== senderId
-            )
-            this.emit("peer-disconnected", { peerId: senderId })
-            break
-          default:
-            if (!("data" in message)) {
-              this.emit("message", message)
-            } else {
-              if (!message.data) {
-                throw new Error(
-                  "We got a message without data, we can't send this."
-                )
-              }
-              const data = message.data
-              this.emit("message", {
-                ...message,
-                data: new Uint8Array(data),
-              })
-            }
-            break
-        }
+    this.#messageListener = (e: { data: BroadcastChannelMessage }) => {
+      const message = e.data
+      if ("targetId" in message && message.targetId !== this.peerId) {
+        return
       }
-    )
+
+      if (this.#disconnected) {
+        return
+      }
+
+      const { senderId, type } = message
+
+      switch (type) {
+        case "arrive":
+          {
+            const { peerMetadata } = message as ArriveMessage
+            this.#broadcastChannel.postMessage({
+              senderId: this.peerId,
+              targetId: senderId,
+              type: "welcome",
+              peerMetadata: this.peerMetadata,
+            })
+            this.#announceConnection(senderId, peerMetadata)
+          }
+          break
+        case "welcome":
+          {
+            const { peerMetadata } = message as WelcomeMessage
+            this.#announceConnection(senderId, peerMetadata)
+          }
+          break
+        case "leave":
+          this.#connectedPeers = this.#connectedPeers.filter(
+            p => p !== senderId
+          )
+          this.emit("peer-disconnected", { peerId: senderId })
+          break
+        default:
+          if (!("data" in message)) {
+            this.emit("message", message)
+          } else {
+            if (!message.data) {
+              // A throw inside this "message" listener escapes dispatch and can
+              // crash the process under Node, so log and drop the malformed
+              // message.
+              log.warn("dropping a data message with no data from %o", senderId)
+              return
+            }
+            const data = message.data
+            this.emit("message", {
+              ...message,
+              data: new Uint8Array(data),
+            })
+          }
+          break
+      }
+    }
+    this.#broadcastChannel.addEventListener("message", this.#messageListener)
 
     this.#broadcastChannel.postMessage({
       senderId: this.peerId,
@@ -162,6 +180,11 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
   }
 
   disconnect() {
+    // Idempotent: a second disconnect() must not post on / close the channel
+    // again (closing it makes a further postMessage throw).
+    if (this.#disconnected) {
+      return
+    }
     this.#broadcastChannel.postMessage({
       senderId: this.peerId,
       type: "leave",
@@ -170,6 +193,17 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
       this.emit("peer-disconnected", { peerId })
     }
     this.#disconnected = true
+
+    // Detach the listener and close the channel so nothing is retained after
+    // disconnect; connect() reopens a fresh channel.
+    if (this.#messageListener) {
+      this.#broadcastChannel.removeEventListener(
+        "message",
+        this.#messageListener
+      )
+      this.#messageListener = undefined
+    }
+    this.#broadcastChannel.close()
   }
 }
 

--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -75,9 +75,6 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
     this.peerId = peerId
     this.peerMetadata = peerMetadata
 
-    // disconnect() closes the channel, so reopen one when reconnecting after a
-    // disconnect; otherwise detach the current listener before re-adding so we
-    // never stack duplicates.
     if (this.#disconnected) {
       this.#broadcastChannel = new BroadcastChannel(this.#options.channelName)
     } else if (this.#messageListener) {
@@ -180,8 +177,6 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
   }
 
   disconnect() {
-    // Idempotent: a second disconnect() must not post on / close the channel
-    // again (closing it makes a further postMessage throw).
     if (this.#disconnected) {
       return
     }

--- a/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
+++ b/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
@@ -85,8 +85,6 @@ describe("BroadcastChannel", () => {
       expect(removeSpy.mock.calls.length).toBe(removesBefore + 1)
       expect(closeSpy.mock.calls.length).toBe(closesBefore + 1)
 
-      // A second disconnect is a no-op: it must not throw or touch the channel
-      // again (the channel is already closed).
       expect(() => a.disconnect()).not.toThrow()
       expect(closeSpy.mock.calls.length).toBe(closesBefore + 1)
     } finally {

--- a/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
+++ b/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
@@ -1,5 +1,5 @@
 import { PeerId } from "@automerge/automerge-repo"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   runNetworkAdapterTests,
   type SetupFn,
@@ -63,5 +63,35 @@ describe("BroadcastChannel", () => {
     })
     await pause(10)
     expect(a.isReady()).toBe(true)
+  })
+
+  it("removes its listener and closes its channel on disconnect, and is idempotent", () => {
+    const channelName = `broadcast-${Math.random().toString(36).slice(2)}`
+    // Spy on the prototype and assert on deltas so other adapters in the
+    // process don't perturb the counts.
+    const removeSpy = vi.spyOn(
+      BroadcastChannel.prototype,
+      "removeEventListener"
+    )
+    const closeSpy = vi.spyOn(BroadcastChannel.prototype, "close")
+    try {
+      const a = new BroadcastChannelNetworkAdapter({ channelName })
+      a.connect("a-peer" as PeerId)
+
+      const removesBefore = removeSpy.mock.calls.length
+      const closesBefore = closeSpy.mock.calls.length
+
+      a.disconnect()
+      expect(removeSpy.mock.calls.length).toBe(removesBefore + 1)
+      expect(closeSpy.mock.calls.length).toBe(closesBefore + 1)
+
+      // A second disconnect is a no-op: it must not throw or touch the channel
+      // again (the channel is already closed).
+      expect(() => a.disconnect()).not.toThrow()
+      expect(closeSpy.mock.calls.length).toBe(closesBefore + 1)
+    } finally {
+      removeSpy.mockRestore()
+      closeSpy.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
## What

`connect()` registered an anonymous `message` listener that could never be detached, and `disconnect()` never removed it or closed the channel, so the adapter and the channel leaked for the channel's lifetime and a repeated `connect()` stacked duplicate listeners. Separately, a data message with no data made the listener throw, and a synchronous throw inside an event listener escapes dispatch and can crash a Node process.

## Fix

- Hoist the listener to a named field, remove it and `close()` the channel on `disconnect()`, reopen a fresh channel on reconnect, and guard `disconnect()` to stay idempotent.
- Log the malformed message via the repo's `makeLogger` and drop it instead of throwing.

## Tests

Adds a regression test for the disconnect teardown. Existing suite passes.
