### PR TITLE
fix(messagechannel): log and drop a misrouted message instead of throwing

### DIFF
--- a/packages/automerge-repo-network-messagechannel/package.json
+++ b/packages/automerge-repo-network-messagechannel/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@automerge/automerge-repo": "workspace:*",
-    "debug": "catalog:",
     "eventemitter3": "catalog:"
   },
   "devDependencies": {

--- a/packages/automerge-repo-network-messagechannel/src/index.ts
+++ b/packages/automerge-repo-network-messagechannel/src/index.ts
@@ -7,6 +7,7 @@
  */
 import {
   type RepoMessage,
+  makeLogger,
   NetworkAdapter,
   type PeerId,
   type Message,
@@ -16,8 +17,7 @@ import { MessagePortRef } from "./MessagePortRef.js"
 import { StrongMessagePortRef } from "./StrongMessagePortRef.js"
 import { WeakMessagePortRef } from "./WeakMessagePortRef.js"
 
-import debug from "debug"
-const log = debug("automerge-repo:messagechannel")
+const log = makeLogger("automerge-repo:messagechannel")
 
 export class MessageChannelNetworkAdapter extends NetworkAdapter {
   channels = {}
@@ -60,7 +60,7 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
   }
 
   connect(peerId: PeerId, peerMetadata?: PeerMetadata) {
-    log("messageport connecting")
+    log.debug("messageport connecting")
     this.peerId = peerId
     this.peerMetadata = peerMetadata
 
@@ -68,13 +68,19 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
     this.messagePortRef.addListener(
       "message",
       (e: { data: MessageChannelMessage }) => {
-        log("message port received %o", e.data)
+        log.debug("message port received %o", e.data)
 
         const message = e.data
         if ("targetId" in message && message.targetId !== this.peerId) {
-          throw new Error(
-            "MessagePortNetwork should never receive messages for a different peer."
+          // A throw inside this "message" listener escapes dispatch and can
+          // terminate the process under Node, so log and drop a message
+          // addressed to another peer.
+          log.warn(
+            "ignoring a message addressed to a different peer (targetId %o, ours %o)",
+            message.targetId,
+            this.peerId
           )
+          return
         }
 
         const { senderId, type } = message

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,9 +425,6 @@ importers:
       '@automerge/automerge-repo':
         specifier: workspace:*
         version: link:../automerge-repo
-      debug:
-        specifier: 'catalog:'
-        version: 4.4.3
       eventemitter3:
         specifier: 'catalog:'
         version: 5.0.4


### PR DESCRIPTION
## What

A message whose `targetId` is not ours made the `MessagePort` `message` listener throw; a synchronous throw inside an event listener escapes dispatch and can terminate a Node process.

## Fix

Log it and drop it instead. Logging is routed through the repo's `makeLogger` (the same mechanism `Repo` uses) rather than the `debug` package directly, dropping the now-unused `debug` dependency.
