### PR TITLE
fix(react-hooks): guard useDocHandle against stale results and a stuck rejected cache entry

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocHandle.ts
@@ -75,14 +75,25 @@ export function useDocHandle<T>(
     if (currentHandle || suspense || !wrapper) {
       return
     }
+    // Stays true until this effect run is torn down (unmount or id change); a
+    // result that arrives after that must not setState for a stale id.
+    let active = true
     wrapper.promise
       .then(handle => {
-        setHandle(handle as DocHandle<T>)
+        if (active) setHandle(handle as DocHandle<T>)
       })
       .catch(() => {
-        setHandle(undefined)
+        // Drop the failed wrapper so a later render retries instead of reusing
+        // the rejection.
+        if (id && wrapperCache.get(id) === wrapper) {
+          wrapperCache.delete(id)
+        }
+        if (active) setHandle(undefined)
       })
-  }, [currentHandle, suspense, wrapper])
+    return () => {
+      active = false
+    }
+  }, [currentHandle, suspense, wrapper, id])
 
   if (currentHandle || !suspense || !wrapper) {
     return currentHandle

--- a/packages/automerge-repo-react-hooks/test/useDocHandle.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocHandle.test.tsx
@@ -8,7 +8,7 @@ import { render, screen, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
 
 import { describe, expect, it, vi } from "vitest"
-import { useDocHandle } from "../src/useDocHandle"
+import { useDocHandle, wrapperCache } from "../src/useDocHandle"
 import { ErrorBoundary } from "react-error-boundary"
 import { setup, setupPairedRepos } from "./testSetup"
 import { pause } from "../src/helpers/DummyNetworkAdapter"
@@ -249,6 +249,35 @@ describe("useDocHandle", () => {
       // Should continue to return undefined after attempted load
       await waitFor(() => {
         expect(onHandle).toHaveBeenLastCalledWith(undefined)
+      })
+    })
+
+    it("evicts a rejected wrapper so a later attempt can retry", async () => {
+      const { wrapper } = await setup()
+      const url = generateAutomergeUrl() // unavailable document
+      const onHandle = vi.fn()
+
+      const NonSuspenseComponent = ({
+        url,
+        onHandle,
+      }: {
+        url: AutomergeUrl
+        onHandle: (handle: DocHandle<unknown> | undefined) => void
+      }) => {
+        const handle = useDocHandle(url, { suspense: false })
+        onHandle(handle)
+        return null
+      }
+
+      render(<NonSuspenseComponent url={url} onHandle={onHandle} />, {
+        wrapper,
+      })
+
+      // Once the unavailable find rejects, the cached wrapper is dropped, so a
+      // later render re-fetches instead of replaying the stored rejection.
+      await waitFor(() => {
+        expect(onHandle).toHaveBeenLastCalledWith(undefined)
+        expect(wrapperCache.has(url)).toBe(false)
       })
     })
 


### PR DESCRIPTION
## What

`useDocHandle`'s non-suspense effect set state from the resolved `find` with no guard against unmount or an `id` change, and the shared `wrapperCache` was never evicted. Two consequences:

- A late result from a superseded `id` could still call `setHandle`. The url-match guard reconciles it on the next render, so the visible effect was a brief flicker / extra render rather than wrong data, but the stale `setState` is avoidable.
- A `find` that rejects (unavailable doc, or aborted on an `id` change) stayed cached forever, so on the non-suspense path the doc could not recover.

## Fix

- Add an `active` flag, cleared in the effect's cleanup, so a result that arrives after unmount or an `id` change does not `setHandle` for a stale id (this removes the flicker above).
- Evict the rejected wrapper on the non-suspense path so a later render re-fetches instead of replaying the stored rejection.

The suspense-path stuck-on-unavailable case, and the cache's unbounded and not-repo-keyed retention, need a cache redesign (a naive eviction would infinite-loop a suspended render); that is left to follow-up.

## Tests

Adds a regression test asserting the rejected wrapper is evicted. Existing suite passes.
