### PR TITLE
fix(react-hooks): ignore a superseded url set in useDocHandles

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocHandles.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocHandles.ts
@@ -73,9 +73,14 @@ export function useDocHandles<T>(
   // Suspense is handled quasi-synchronously below by throwing if we still have
   // unresolved promises.
   useEffect(() => {
+    // Stays true until this effect run is torn down; if idSet changes (or we
+    // unmount) before these finds settle, the now-stale map must not overwrite
+    // a newer one.
+    let active = true
     if (pendingPromises.length > 0) {
       void Promise.allSettled(pendingPromises.map(p => p.promise)).then(
         handles => {
+          if (!active) return
           handles.forEach(r => {
             if (r.status === "fulfilled") {
               const h = r.value as DocHandle<T>
@@ -87,6 +92,9 @@ export function useDocHandles<T>(
       )
     } else {
       setHandleMap(nextHandleMap)
+    }
+    return () => {
+      active = false
     }
   }, [suspense, idSet])
 

--- a/packages/automerge-repo-react-hooks/test/useDocHandles.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocHandles.test.tsx
@@ -293,5 +293,28 @@ describe("useDocHandles", () => {
       expect(result2?.size).toBe(1)
       expect(result2?.get(handleB.url)?.url).toEqual(handleB.url)
     })
+
+    it("does not let a superseded url set overwrite the current one", async () => {
+      const { repoCreator, repoFinder, wrapper } = await setupPairedRepos()
+      const handleA = repoCreator.create({ foo: "A" })
+      const handleB = repoFinder.create({ foo: "B" })
+      const onHandles = mockOnHandles()
+
+      const { rerender } = render(
+        <Component urls={[handleA.url]} onHandles={onHandles} />,
+        { wrapper }
+      )
+
+      // Switch to B before A resolves.
+      rerender(<Component urls={[handleB.url]} onHandles={onHandles} />)
+
+      // The committed map settles on B; A's superseded find must not overwrite
+      // it back in.
+      await waitFor(() => {
+        const result = onHandles.mock.lastCall?.at(0)
+        expect(result?.get(handleB.url)?.url).toEqual(handleB.url)
+      })
+      expect(onHandles.mock.lastCall?.at(0)?.has(handleA.url)).toBe(false)
+    })
   })
 })


### PR DESCRIPTION
## What

`useDocHandles`'s effect resolved pending finds and called `setHandleMap` with no cleanup, so if the url set changed before the finds settled, an older set's `Promise.allSettled` could settle last and overwrite the newer set's map, briefly showing the wrong set of handles (it self-corrects on the next change).

## Fix

Add an `active` flag, cleared in the effect's cleanup, so a superseded run cannot install a stale map.

## Tests

Adds a regression test that switches the url set mid-load and asserts the superseded set does not overwrite the current one.
