### PR TITLE
fix(repo): handle a network-adapter readiness failure at the source

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -42,6 +42,7 @@ import { Document } from "./Document.js"
 import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
 import { isPlainObject } from "./helpers/isPlainObject.js"
 import { hasAtLeastOneKey } from "./helpers/has-at-least-one-key.js"
+import { noop } from "./helpers/noop.js"
 
 export type { DocumentProgress } from "./DocumentQuery.js"
 export { DocumentQuery } from "./DocumentQuery.js"
@@ -171,7 +172,16 @@ export class Repo extends EventEmitter<RepoEvents> {
           if (!storageId || isEph) return
           return this.storageSubsystem.loadSyncState(documentId, storageId)
         },
-        networkReady: networkSubsystem.whenReady().then(() => {}),
+        // Resolve to void once the adapters are ready, or on adapter failure
+        // (logged): networkReady gates "peers have had their chance to connect",
+        // so a failed network should let documents settle rather than hang, and
+        // it must never reject (no consumer acts on the rejection, and an
+        // unhandled one would surface before any DocSynchronizer attaches).
+        networkReady: networkSubsystem
+          .whenReady()
+          .then(noop, err =>
+            this.#log.error("network adapters failed to become ready", err)
+          ),
       },
       denylist
     )

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -68,6 +68,30 @@ describe("Repo", () => {
       assert(repo.storageSubsystem)
     })
 
+    it("logs and does not leak when a network adapter fails to become ready", async () => {
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      try {
+        const networkAdapter = new DummyNetworkAdapter({ startReady: false })
+        networkAdapter.whenReady = () =>
+          Promise.reject(new Error("adapter boom"))
+        // No documents are open, so nothing attaches to networkReady; a
+        // rejection there must be handled at the source, not left to float.
+        const _repo = new Repo({ network: [networkAdapter] })
+        await vi.waitFor(() =>
+          assert.ok(
+            errSpy.mock.calls.some(call =>
+              call.some(arg =>
+                String(arg).includes("network adapters failed to become ready")
+              )
+            ),
+            "the adapter failure should be caught and logged"
+          )
+        )
+      } finally {
+        errSpy.mockRestore()
+      }
+    })
+
     it("can create a document", () => {
       const { repo } = setup()
       const handle = repo.create()


### PR DESCRIPTION
## What

`networkReady` was `networkSubsystem.whenReady().then(() => {})` with no rejection handler. `whenReady()` is a `Promise.all` over the adapters' own `whenReady()`, so it rejects if any adapter fails to become ready. That derived promise is only consumed by `DocSynchronizer`s, which attach their own `.then().catch()`. If the network failed before any document was open, nothing had attached yet, so the rejection surfaced as an unhandled promise rejection (which in Node can terminate the process).

## Fix

Handle it once at the source: resolve `networkReady` to `void` both on success and on adapter failure (logged via the repo logger), so it never rejects. No consumer acts on the rejection, and resolving on failure matches what the gate means ("peers have had their chance to connect"), so a document on a failed network settles to `unavailable` instead of hanging.

## Tests

Adds a regression test: a repo with a failing network adapter and no documents logs the failure instead of leaking an unhandled rejection. Existing suite passes.
