### PR TITLE
perf(sync): bound the loadSyncState fan-out when adding peers

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -109,6 +109,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     denylist = [],
     saveDebounceRate = 100,
     flushConcurrency = DEFAULT_FLUSH_CONCURRENCY,
+    syncStateLoadConcurrency,
     idFactory,
   }: RepoConfig = {}) {
     super()
@@ -194,6 +195,7 @@ export class Repo extends EventEmitter<RepoEvents> {
           .then(noop, err =>
             this.#log.error("network adapters failed to become ready", err)
           ),
+        syncStateLoadConcurrency,
       },
       denylist
     )
@@ -837,6 +839,19 @@ export interface RepoConfig {
    *   headroom for other callers.
    */
   flushConcurrency?: number
+
+  /**
+   * Maximum number of persisted sync-state reads the synchronizer issues
+   * concurrently while adding peers to documents (one read per peer-document
+   * pair). Defaults to 20.
+   *
+   * @remarks
+   * Like {@link RepoConfig.flushConcurrency}, tie this to your
+   * {@link StorageAdapterInterface}: stay under a filesystem adapter's
+   * file-descriptor ceiling, near a browser's per-origin connection cap for an
+   * HTTP/1.1-backed adapter, or at or below a database adapter's pool size.
+   */
+  syncStateLoadConcurrency?: number
 
   // This is hidden for now because it's an experimental API, mostly here in order
   // for keyhive to be able to control the ID generation

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -14,6 +14,15 @@ import type { ShareConfig } from "./DocSynchronizer.js"
 import type { DocumentSource } from "../DocumentSource.js"
 import type { DocumentQuery, SourcePriority } from "../DocumentQuery.js"
 import type { SyncStatePayload, DocSyncMetrics } from "./Synchronizer.js"
+import { semaphore, type Limit } from "../helpers/semaphore.js"
+
+/**
+ * Default cap on concurrent `loadSyncState` reads. Adding a peer loads sync
+ * state once per document, and the collection adds every peer to every document
+ * (`addPeer` loops all docs, `attach` loops all peers), so on a many-document
+ * sync server an unbounded fan-out would issue that many storage reads at once.
+ */
+export const DEFAULT_SYNC_STATE_LOAD_CONCURRENCY = 20
 
 export interface AutomergeSyncConfig {
   peerId: PeerId
@@ -32,12 +41,20 @@ export interface AutomergeSyncConfig {
 
   /**
    * Load persisted sync state for a peer on a specific document. Returns
-   * undefined if no sync state is available.
+   * undefined if no sync state is available. Calls are bounded by
+   * {@link AutomergeSyncConfig.syncStateLoadConcurrency}.
    */
   loadSyncState?: (
     documentId: DocumentId,
     peerId: PeerId
   ) => Promise<A.SyncState | undefined>
+
+  /**
+   * Maximum number of {@link AutomergeSyncConfig.loadSyncState} reads run
+   * concurrently while adding peers to documents. Defaults to
+   * {@link DEFAULT_SYNC_STATE_LOAD_CONCURRENCY}.
+   */
+  syncStateLoadConcurrency?: number
 
   /**
    * Resolves when the network layer is ready to send messages.
@@ -74,12 +91,20 @@ export class CollectionSynchronizer
   #networkReady: Promise<void>
   #log = makeLogger("automerge-repo:collectionsync")
 
+  // Bounds the loadSyncState reads fanned out when peers are added to documents,
+  // so a peer connecting to a many-document collection doesn't issue one storage
+  // read per document at once.
+  #loadSyncStateLimit: Limit
+
   constructor(config: AutomergeSyncConfig, denylist: AutomergeUrl[] = []) {
     super()
     this.#networkReady = config.networkReady
     this.#config = config
     this.priority = config.priority
     this.#denylist = denylist.map(url => parseAutomergeUrl(url).documentId)
+    this.#loadSyncStateLimit = semaphore(
+      config.syncStateLoadConcurrency ?? DEFAULT_SYNC_STATE_LOAD_CONCURRENCY
+    )
   }
 
   /** Expose doc synchronizers for Repo access (e.g. metrics) */
@@ -252,9 +277,10 @@ export class CollectionSynchronizer
     documentId: DocumentId,
     peerId: PeerId
   ): Promise<A.SyncState | undefined> {
-    return (
-      this.#config.loadSyncState?.(documentId, peerId) ??
-      Promise.resolve(undefined)
+    return this.#loadSyncStateLimit(
+      () =>
+        this.#config.loadSyncState?.(documentId, peerId) ??
+        Promise.resolve(undefined)
     )
   }
 }

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -6,6 +6,7 @@ import { Repo } from "../src/Repo.js"
 import {
   CollectionSynchronizer,
   AutomergeSyncConfig,
+  DEFAULT_SYNC_STATE_LOAD_CONCURRENCY,
 } from "../src/synchronizer/CollectionSynchronizer.js"
 import { PeerId } from "../src/types.js"
 import { SyncMessage } from "../src/network/messages.js"
@@ -258,5 +259,41 @@ describe("CollectionSynchronizer", () => {
         )
       }
     })
+  })
+
+  it("bounds concurrent loadSyncState reads when a peer is added", async () => {
+    // Each loadSyncState call parks on a deferred we control, so concurrency is
+    // observed deterministically rather than via a timed sleep. `peak` records
+    // the most that ran at once.
+    let active = 0
+    let peak = 0
+    const release: Array<() => void> = []
+    const loadSyncState = () =>
+      new Promise<undefined>(resolve => {
+        active++
+        peak = Math.max(peak, active)
+        release.push(() => {
+          active--
+          resolve(undefined)
+        })
+      })
+
+    const sync = new CollectionSynchronizer(createConfig({ loadSyncState }))
+    const docCount = DEFAULT_SYNC_STATE_LOAD_CONCURRENCY + 5
+    for (let i = 0; i < docCount; i++) sync.attach(createReadyQuery())
+
+    // Adding a peer loads sync state once per document. The shared limiter
+    // admits its first batch synchronously, so the cap is observable
+    // immediately: at most DEFAULT_SYNC_STATE_LOAD_CONCURRENCY in flight, the
+    // rest queued.
+    sync.addPeer(alice)
+    assert.equal(active, DEFAULT_SYNC_STATE_LOAD_CONCURRENCY)
+
+    // Release each batch and let the queued reads start, until fully drained.
+    for (let i = 0; i <= docCount && release.length > 0; i++) {
+      release.splice(0).forEach(r => r())
+      await new Promise(resolve => setTimeout(resolve, 0)) // macrotask flush
+    }
+    assert.equal(peak, DEFAULT_SYNC_STATE_LOAD_CONCURRENCY)
   })
 })


### PR DESCRIPTION
## What

Adding a peer loads persisted sync state once per document. `CollectionSynchronizer` adds every peer to every document (`addPeer` loops all docs, `attach` loops all peers), so on a many-document sync server one peer connecting issues one `loadSyncState` storage read per document at once, with no bound.

This is the **same family as #692** (which bounds `Repo.flush`'s storage writes): an unbounded burst of storage I/O scaled by collection size. Where #692 bounds the write fan-out, this bounds the per-connect read fan-out.

## Fix

`CollectionSynchronizer` owns one `semaphore` limiter that gates every `loadSyncState` read, so concurrent reads are capped across all documents together (default `DEFAULT_SYNC_STATE_LOAD_CONCURRENCY = 20`). Configurable via `RepoConfig.syncStateLoadConcurrency`, which flows through to `AutomergeSyncConfig.syncStateLoadConcurrency` and defaults when unset.

## Tests

Adds a regression test asserting concurrent `loadSyncState` reads stay within the cap (deterministic deferreds plus a synchronous assertion via the limiter's synchronous-start, no fixed sleeps).

## Stacking

Stacked on #692 for the `semaphore` helper. **#692 should merge first**: the first commit shown here is #692's, and it drops out once #692 lands and this branch rebases onto `main`.

Sibling of #700, which bounds the share-policy callback fan-out driven by the same `addPeer` / `attach` loops (a separate limiter for a separate resource: auth/share-policy callbacks vs storage reads). The two touch the same files, so whichever merges second needs a trivial rebase.
