### PR TITLE
perf(sync): bound the share-policy resolution fan-out

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -110,6 +110,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     saveDebounceRate = 100,
     flushConcurrency = DEFAULT_FLUSH_CONCURRENCY,
     syncStateLoadConcurrency,
+    sharePolicyConcurrency,
     idFactory,
   }: RepoConfig = {}) {
     super()
@@ -196,6 +197,7 @@ export class Repo extends EventEmitter<RepoEvents> {
             this.#log.error("network adapters failed to become ready", err)
           ),
         syncStateLoadConcurrency,
+        sharePolicyConcurrency,
       },
       denylist
     )
@@ -852,6 +854,18 @@ export interface RepoConfig {
    * HTTP/1.1-backed adapter, or at or below a database adapter's pool size.
    */
   syncStateLoadConcurrency?: number
+
+  /**
+   * Maximum number of share-policy resolutions the synchronizer runs
+   * concurrently when re-evaluating which peers each document is shared with.
+   * Defaults to the synchronizer's `SHARE_POLICY_CONCURRENCY` (10).
+   *
+   * @remarks
+   * Each resolution may invoke an async {@link SharePolicy}. On a sync server
+   * with many peers and many documents, an unbounded fan-out launches one policy
+   * call per peer-document pair at once; this caps how many run together.
+   */
+  sharePolicyConcurrency?: number
 
   // This is hidden for now because it's an experimental API, mostly here in order
   // for keyhive to be able to control the ID generation

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -9,12 +9,12 @@ import {
   OpenDocMessage,
 } from "../network/messages.js"
 import { AutomergeUrl, DocumentId, PeerId } from "../types.js"
-import { DocSynchronizer } from "./DocSynchronizer.js"
+import { DocSynchronizer, SHARE_POLICY_CONCURRENCY } from "./DocSynchronizer.js"
 import type { ShareConfig } from "./DocSynchronizer.js"
+import { semaphore, type Limit } from "../helpers/semaphore.js"
 import type { DocumentSource } from "../DocumentSource.js"
 import type { DocumentQuery, SourcePriority } from "../DocumentQuery.js"
 import type { SyncStatePayload, DocSyncMetrics } from "./Synchronizer.js"
-import { semaphore, type Limit } from "../helpers/semaphore.js"
 
 /**
  * Default cap on concurrent `loadSyncState` reads. Adding a peer loads sync
@@ -63,6 +63,13 @@ export interface AutomergeSyncConfig {
    * peers have had a chance to connect.
    */
   networkReady: Promise<void>
+
+  /**
+   * Maximum number of share-policy resolutions run concurrently during
+   * {@link CollectionSynchronizer.reevaluateDocumentShare}. Defaults to
+   * {@link SHARE_POLICY_CONCURRENCY}.
+   */
+  sharePolicyConcurrency?: number
 }
 
 interface CollectionSynchronizerEvents {
@@ -96,6 +103,12 @@ export class CollectionSynchronizer
   // read per document at once.
   #loadSyncStateLimit: Limit
 
+  // One shared limiter for every share-policy resolution in the collection, so
+  // the concurrent user announce/access callbacks are capped across all
+  // documents and peers together: both the per-peer resolution on addPeer and
+  // the whole-collection re-evaluation on reevaluateDocumentShare draw from it.
+  #sharePolicyLimit: Limit
+
   constructor(config: AutomergeSyncConfig, denylist: AutomergeUrl[] = []) {
     super()
     this.#networkReady = config.networkReady
@@ -104,6 +117,9 @@ export class CollectionSynchronizer
     this.#denylist = denylist.map(url => parseAutomergeUrl(url).documentId)
     this.#loadSyncStateLimit = semaphore(
       config.syncStateLoadConcurrency ?? DEFAULT_SYNC_STATE_LOAD_CONCURRENCY
+    )
+    this.#sharePolicyLimit = semaphore(
+      config.sharePolicyConcurrency ?? SHARE_POLICY_CONCURRENCY
     )
   }
 
@@ -221,7 +237,7 @@ export class CollectionSynchronizer
 
   reevaluateDocumentShare(): void {
     for (const docSync of Object.values(this.#docSynchronizers)) {
-      docSync.reevaluateSharePolicy()
+      docSync.reevaluateSharePolicy(this.#sharePolicyLimit)
     }
   }
 
@@ -270,6 +286,7 @@ export class CollectionSynchronizer
 
     docSync.addPeer(peerId, this.#loadSyncStateFor(documentId, peerId), {
       messages,
+      limit: this.#sharePolicyLimit,
     })
   }
 

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -18,9 +18,29 @@ import {
 } from "../network/messages.js"
 import { DocumentId, PeerId } from "../types.js"
 import { asyncThrottle } from "../helpers/throttle.js"
+import { semaphore, type Limit } from "../helpers/semaphore.js"
 import { HashRing } from "../helpers/HashRing.js"
 import type { DocumentQuery } from "../DocumentQuery.js"
 import type { SyncStatePayload, DocSyncMetrics } from "./Synchronizer.js"
+
+/**
+ * Default cap on concurrent share-policy resolutions. Resolving a peer's share
+ * policy runs a user `announce` / `access` callback, and that happens both on
+ * `addPeer` (per peer) and on `reevaluateSharePolicy` (for every peer). Since
+ * the collection adds every peer to every document and re-evaluates every
+ * document, an unbounded fan-out on a many-peer / many-document sync server
+ * would fire that many callbacks at once.
+ */
+export const SHARE_POLICY_CONCURRENCY = 10
+
+/**
+ * Passthrough gate used when no shared limiter is supplied: runs `fn`
+ * immediately with no concurrency bound. A single `addPeer` resolves one peer,
+ * so a bound is only meaningful when CollectionSynchronizer shares one limiter
+ * across its many `addPeer` calls.
+ */
+const runUnbounded: Limit = <T>(fn: () => PromiseLike<T> | T): Promise<T> =>
+  Promise.resolve(fn())
 
 export type PeerDocumentStatus = "unknown" | "has" | "unavailable" | "wants"
 
@@ -194,7 +214,13 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
   addPeer(
     peerId: PeerId,
     syncState: Promise<A.SyncState | undefined>,
-    { messages = [] }: { messages?: (SyncMessage | RequestMessage)[] } = {}
+    {
+      messages = [],
+      limit = runUnbounded,
+    }: {
+      messages?: (SyncMessage | RequestMessage)[]
+      limit?: Limit
+    } = {}
   ): void {
     const previous = this.#peers.get(peerId)
     const isNewPeer = !previous
@@ -222,7 +248,9 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
       this.#query.sourcePending("automerge-sync")
     }
 
-    Promise.all([syncState, this.#resolveSharePolicy(peerId)])
+    // Gate the share-policy resolution through the (optionally shared) limiter
+    // so adding one peer to many documents does not fan out unbounded callbacks.
+    Promise.all([syncState, limit(() => this.#resolveSharePolicy(peerId))])
       .then(([syncState, sharePolicyState]) =>
         this.#activatePeer(peerId, peer, isNewPeer, syncState, sharePolicyState)
       )
@@ -270,10 +298,16 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
   /**
    * Re-evaluate share policy for all peers. Called when the share config
    * functions may return different results (e.g. after Repo.shareConfigChanged).
+   *
+   * Pass a shared `limit` (from the collection) to bound the concurrent
+   * share-policy resolutions across all documents; defaults to a per-call
+   * limiter when used standalone.
    */
-  reevaluateSharePolicy(): void {
+  reevaluateSharePolicy(
+    limit: Limit = semaphore(SHARE_POLICY_CONCURRENCY)
+  ): void {
     for (const peerId of Array.from(this.#peers.keys())) {
-      this.#resolveSharePolicy(peerId)
+      limit(() => this.#resolveSharePolicy(peerId))
         .then(newPolicy => {
           const peer = this.#peers.get(peerId)
           if (!peer) return

--- a/packages/automerge-repo/test/SharePolicy.test.ts
+++ b/packages/automerge-repo/test/SharePolicy.test.ts
@@ -7,6 +7,7 @@ import withTimeout from "./helpers/withTimeout.js"
 import pause from "./helpers/pause.js"
 import { Repo } from "../src/Repo.js"
 import { PeerId } from "../src/types.js"
+import { SHARE_POLICY_CONCURRENCY } from "../src/synchronizer/DocSynchronizer.js"
 
 describe("the sharePolicy APIs", () => {
   describe("the legacy API", () => {
@@ -132,6 +133,59 @@ describe("the sharePolicy APIs", () => {
 
       const bobHandle = await bob.find(aliceHandle.url)
       expect(bobHandle.doc()).toEqual({ foo: "bar" })
+    })
+
+    it("bounds concurrent share-policy resolutions across addPeer and shareConfigChanged", async () => {
+      // Each access call parks on a deferred we control, so concurrency is
+      // observed deterministically rather than via a timed sleep. `peak` records
+      // the most that ran at once.
+      let active = 0
+      let peak = 0
+      const release: Array<() => void> = []
+      const access = () =>
+        new Promise<boolean>(resolve => {
+          active++
+          peak = Math.max(peak, active)
+          release.push(() => {
+            active--
+            resolve(true)
+          })
+        })
+
+      const repo = new Repo({
+        peerId: "alice" as PeerId,
+        shareConfig: { announce: async () => true, access },
+      })
+      const docCount = SHARE_POLICY_CONCURRENCY + 5
+      for (let i = 0; i < docCount; i++) repo.create({ i })
+
+      // Release each parked batch and let the queued resolutions start, until
+      // the fan-out is fully drained. A macrotask boundary fully flushes the
+      // release chain (resolve access -> resolveSharePolicy -> free slot -> wake
+      // the next waiter) before measuring the next batch.
+      const drain = async () => {
+        for (let i = 0; i <= docCount && release.length > 0; i++) {
+          release.splice(0).forEach(r => r())
+          await new Promise(resolve => setTimeout(resolve, 0)) // macrotask flush
+        }
+      }
+
+      // Adding one peer to every document fans out one resolution per document.
+      // The shared limiter admits its first batch synchronously, so the cap is
+      // observable immediately: at most SHARE_POLICY_CONCURRENCY in flight, the
+      // rest queued.
+      repo.synchronizer.addPeer("bob" as PeerId)
+      expect(active).toBe(SHARE_POLICY_CONCURRENCY)
+      await drain()
+      expect(peak).toBe(SHARE_POLICY_CONCURRENCY)
+      expect(active).toBe(0)
+
+      // The same limiter bounds the whole-collection re-evaluation.
+      peak = 0
+      repo.shareConfigChanged()
+      expect(active).toBe(SHARE_POLICY_CONCURRENCY)
+      await drain()
+      expect(peak).toBe(SHARE_POLICY_CONCURRENCY)
     })
 
     it("should stop sending changes to a peer who had access but was then removed", async () => {


### PR DESCRIPTION
## What

Resolving a peer's share policy runs a user `announce` / `access` callback, which may hit a DB or auth service. `CollectionSynchronizer` fans these out unbounded in two places:

- **`addPeer`** resolves the policy per peer, and the collection adds every peer to every document (`addPeer` loops all docs, `attach` loops all peers), so one peer connecting fires one resolution per document.
- **`reevaluateDocumentShare`** (on `shareConfigChanged`) re-resolves every peer on every document, i.e. `(docs x peers)` at once.

On a many-peer / many-document sync server, both fire that many callbacks simultaneously.

## Fix

One collection-owned `semaphore` routes **both** paths, so concurrent share-policy resolutions are capped across all peers and documents together (default `SHARE_POLICY_CONCURRENCY = 10`). Configurable via `RepoConfig.sharePolicyConcurrency`, which flows through to `AutomergeSyncConfig.sharePolicyConcurrency` and defaults when unset. `DocSynchronizer.addPeer` takes an optional `limit` (an unbounded passthrough default for standalone use); `reevaluateSharePolicy` keeps its per-call limiter default.

## Tests

A regression test asserts both the `addPeer` and `shareConfigChanged` fan-outs stay within the cap (deterministic deferreds plus a synchronous assertion via the limiter's synchronous-start, no fixed sleeps).

## Stacking

Stacked on #692 for the `semaphore` helper and its `Limit` type. **#692 should merge first**: the first commit shown here is #692's, and it drops out once #692 lands and this branch rebases onto `main`.

Sibling of #699, which bounds the `loadSyncState` storage-read fan-out driven by the same `addPeer` / `attach` loops (a separate limiter for a separate resource: storage reads vs auth/share-policy callbacks). The two touch the same files, so whichever merges second needs a trivial rebase.
