### PR TITLE
feat(storage): close the adapter on Repo shutdown

### DIFF
--- a/packages/automerge-repo-storage-indexeddb/src/index.ts
+++ b/packages/automerge-repo-storage-indexeddb/src/index.ts
@@ -151,4 +151,10 @@ export class IndexedDBStorageAdapter implements StorageAdapterInterface {
       }
     })
   }
+
+  /** Close the underlying database connection. */
+  async close(): Promise<void> {
+    const db = await this.dbPromise
+    db.close()
+  }
 }

--- a/packages/automerge-repo-storage-indexeddb/test/close.test.ts
+++ b/packages/automerge-repo-storage-indexeddb/test/close.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { IndexedDBStorageAdapter } from "../src/index.js"
+
+describe("IndexedDBStorageAdapter close", () => {
+  beforeEach(() => {
+    // The constructor opens IndexedDB; stub it when the env has none.
+    if (typeof globalThis.indexedDB === "undefined") {
+      globalThis.indexedDB = { open: () => ({}) } as unknown as IDBFactory
+    }
+  })
+
+  it("closes the underlying database connection", async () => {
+    const adapter = new IndexedDBStorageAdapter()
+    let closed = 0
+    ;(adapter as any).dbPromise = Promise.resolve({
+      close: () => {
+        closed++
+      },
+    })
+
+    await adapter.close()
+    expect(closed).toBe(1)
+  })
+})

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -708,6 +708,7 @@ export class Repo extends EventEmitter<RepoEvents> {
   async shutdown() {
     await this.flush()
     this.networkSubsystem.disconnect()
+    await this.storageSubsystem?.close()
   }
 
   metrics(): { documents: { [key: string]: any } } {

--- a/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
@@ -31,4 +31,12 @@ export interface StorageAdapterInterface {
 
   /** Remove all values with keys that start with `keyPrefix` */
   removeRange(keyPrefix: StorageKey): Promise<void>
+
+  /**
+   * Release any resources the adapter holds, such as an open database
+   * connection. Optional: {@link Repo.shutdown} calls it after the final flush.
+   * Adapters that hold no long-lived resource (in-memory, plain filesystem) can
+   * omit it.
+   */
+  close?(): void | Promise<void>
 }

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -55,6 +55,11 @@ export class StorageSubsystem extends EventEmitter<StorageSubsystemEvents> {
     this.#storageAdapter = storageAdapter
   }
 
+  /** Release the underlying storage adapter's resources, if it holds any. */
+  async close(): Promise<void> {
+    await this.#storageAdapter.close?.()
+  }
+
   async id(): Promise<StorageId> {
     const storedId = await this.#storageAdapter.load(["storage-adapter-id"])
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -485,6 +485,18 @@ describe("Repo", () => {
       )
     })
 
+    it("shutdown() closes the storage adapter", async () => {
+      let closed = 0
+      class ClosableStorage extends DummyStorageAdapter {
+        async close() {
+          closed++
+        }
+      }
+      const repo = new Repo({ storage: new ClosableStorage() })
+      await repo.shutdown()
+      assert.equal(closed, 1)
+    })
+
     it("exports a document", async () => {
       const { repo } = setup()
       const handle = repo.create<TestDoc>()


### PR DESCRIPTION
## What

The IndexedDB storage adapter opens one `IDBDatabase` connection in its constructor and never closes it. There was no way to release it: `StorageAdapterInterface` had no teardown hook, and `Repo.shutdown()` never touched the storage adapter.

## Severity

Low when there is a single `Repo` per page, since the connection is released on page unload regardless. It is worth dealing with for a long-lived SPA that creates and discards `Repo`s over time (a router that mounts a `Repo` per route, or a multi-document / multi-workspace app): the connections accumulate until the `IDBDatabase` is garbage-collected, and an open connection blocks `deleteDatabase` and version upgrades. A "clear local data" or sign-out that calls `indexedDB.deleteDatabase(...)` can then stall on `blocked` until those stale connections close. Calling `repo.shutdown()` on Repo disposal, which this PR makes effective, avoids that.

## Fix

- `StorageAdapterInterface` gains an optional `close?(): void | Promise<void>`.
- `StorageSubsystem.close()` forwards to the adapter's `close()`.
- `Repo.shutdown()` calls it after the final flush (and after disconnecting the network), so shutting a Repo down also releases its storage.
- `IndexedDBStorageAdapter.close()` calls `db.close()`.

The method is optional, so adapters that hold no long-lived resource (in-memory, plain filesystem) leave it unimplemented.

## Tests

- `Repo.shutdown()` invokes the adapter's `close()` (spy adapter).
- The IndexedDB adapter's `close()` closes the connection.

## Note

Touches the same file as #701 (the IndexedDB adapter) but different methods, so the two are independent and can merge in either order.
