### PR TITLE
fix(network): catch a Promise-returning connect() in addNetworkAdapter

### DIFF
--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -109,10 +109,10 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
       this.adapters = this.adapters.filter(a => a !== networkAdapter)
     })
 
+    // connect() is typed `void`, but a custom adapter may return a Promise;
+    // return it so its rejection chains into the .catch() below, not dropped.
     this.peerMetadata
-      .then(peerMetadata => {
-        networkAdapter.connect(this.peerId, peerMetadata)
-      })
+      .then(peerMetadata => networkAdapter.connect(this.peerId, peerMetadata))
       .catch(err => {
         this.#log.error("error connecting to network", err)
       })


### PR DESCRIPTION
`NetworkAdapterInterface.connect()` is typed to return `void`, but nothing prevents a custom adapter from implementing it as an `async` method that returns a `Promise`.

In `NetworkSubsystem.addNetworkAdapter`, `connect()` was invoked as a bare statement inside the `peerMetadata.then(...)` callback. For a Promise-returning `connect()` that detached the returned promise: a rejection escaped as an unhandled rejection rather than reaching the adjacent `.catch`, which only ever caught synchronous throws.

Returning `connect()`'s result from the `.then` callback chains its rejection into that `.catch` (which logs it). For a spec-compliant `void` `connect()` this is a no-op. The change is one line; the rest is a clarifying comment.
