### PR TITLE
fix: propagate signal.reason from abort-rejection paths

### DIFF
--- a/packages/automerge-repo/src/DocumentQuery.ts
+++ b/packages/automerge-repo/src/DocumentQuery.ts
@@ -3,7 +3,6 @@ import { DocHandle } from "./DocHandle.js"
 import { decodeHeads } from "./AutomergeUrl.js"
 import type { DocumentId, UrlHeads } from "./types.js"
 import type { Segment } from "./subdoc-handles/types.js"
-import { AbortError } from "./helpers/abortable.js"
 import { type FindProgress, queryStateToFindProgress } from "./_compat.js"
 
 /**
@@ -55,6 +54,11 @@ export interface DocumentProgress<T> {
   /**
    * Returns a promise that resolves with the DocHandle when the query reaches
    * the `ready` state. Rejects if the query fails or the signal is aborted.
+   *
+   * @remarks
+   * `options.signal` cancels only the await, not the underlying sources
+   * (storage load, sync), which may be serving other concurrent callers. An
+   * aborted wait rejects with `signal.reason`.
    */
   whenReady(options?: { signal?: AbortSignal }): Promise<DocHandle<T>>
 
@@ -164,7 +168,7 @@ export class DocumentQuery<T> implements DocumentProgress<T> {
 
   async whenReady(options?: { signal?: AbortSignal }): Promise<DocHandle<T>> {
     const signal = options?.signal
-    if (signal?.aborted) throw new AbortError()
+    signal?.throwIfAborted()
 
     // Already ready — return immediately
     if (this.#state.state === "ready") return this.#state.handle
@@ -180,7 +184,7 @@ export class DocumentQuery<T> implements DocumentProgress<T> {
     return new Promise<DocHandle<T>>((resolve, reject) => {
       const onAbort = () => {
         cleanup()
-        reject(new AbortError())
+        reject(signal!.reason)
       }
 
       const unsubscribe = this.subscribe(state => {
@@ -432,7 +436,7 @@ export function progressAtHeads<T>(
       return new Promise<DocHandle<T>>((resolve, reject) => {
         const onAbort = () => {
           cleanup()
-          reject(new AbortError())
+          reject(opts!.signal!.reason)
         }
         const onChange = () => {
           if (Automerge.hasHeads(upstream.fullDoc(), decoded)) {

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -36,7 +36,7 @@ import type {
   DocumentId,
   PeerId,
 } from "./types.js"
-import { AbortOptions, AbortError } from "./helpers/abortable.js"
+import { AbortOptions } from "./helpers/abortable.js"
 export type { FindProgressWithMethods, ProgressSignal } from "./_compat.js"
 import { Document } from "./Document.js"
 import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
@@ -540,6 +540,12 @@ export class Repo extends EventEmitter<RepoEvents> {
 
   /**
    * Look up a document by URL and wait for it to be ready.
+   *
+   * @remarks
+   * `options.signal` cancels the wait, not the load: the underlying
+   * {@link DocumentQuery} and its sources keep running (they may be serving
+   * other concurrent callers), so use {@link Repo.removeFromCache} to stop the
+   * load. An aborted wait rejects with `signal.reason`.
    */
   async find<T>(
     id: AnyDocumentId,
@@ -547,9 +553,7 @@ export class Repo extends EventEmitter<RepoEvents> {
   ): Promise<DocHandle<T>> {
     const { signal } = options
 
-    if (signal?.aborted) {
-      throw new AbortError()
-    }
+    signal?.throwIfAborted()
 
     // `findWithProgress` already applies any path suffix (`/a/@0/b`) and
     // fixed heads (`#h1|h2`) from the URL, so the ready handle is correctly

--- a/packages/automerge-repo/src/helpers/pause.ts
+++ b/packages/automerge-repo/src/helpers/pause.ts
@@ -1,6 +1,4 @@
 /* c8 ignore start */
-import { AbortError } from "./abortable.js"
-
 type AbortListener = (
   this: AbortSignal,
   ev: AbortSignalEventMap["abort"]
@@ -14,9 +12,9 @@ const abortEvent = "abort"
  *
  * @param milliseconds - The number of milliseconds to pause. Defaults to 0.
  * @param signal - An optional AbortSignal that can be used to cancel the pause.
- * @returns A Promise that resolves after the specified delay, or rejects with an AbortError if cancelled.
+ * @returns A Promise that resolves after the specified delay, or rejects with `signal.reason` if cancelled.
  *
- * @throws {AbortError} Thrown when the pause is cancelled via the AbortSignal.
+ * @throws {AbortError} Rejects with the signal's `reason` (an `AbortError` by default) when cancelled via the AbortSignal.
  *
  * @example
  * ```typescript
@@ -49,13 +47,13 @@ export const pause = (
   return new Promise<void>((resolve, reject) => {
     const { signal } = options ?? {}
     if (signal?.aborted) {
-      reject(new AbortError())
+      reject(signal.reason)
       return
     }
     const abortListener: AbortListener | undefined =
       signal &&
       ((): void => {
-        reject(new AbortError())
+        reject(signal.reason)
         clearTimeout(id)
       })
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -38,7 +38,7 @@ import { getRandomItem } from "./helpers/getRandomItem.js"
 import { TestDoc } from "./types.js"
 import { StorageId, StorageKey } from "../src/storage/types.js"
 import { DocumentProgress } from "../src/DocumentQuery.js"
-import { AbortError } from "../src/helpers/abortable.js"
+import { isAbortErrorLike } from "../src/helpers/abortable.js"
 
 describe("Repo", () => {
   describe("constructor", () => {
@@ -2534,7 +2534,7 @@ describe("Repo.find() abort behavior", () => {
 
     await expect(
       repo.find(generateAutomergeUrl(), { signal: controller.signal })
-    ).rejects.toThrow(AbortError)
+    ).rejects.toSatisfy(isAbortErrorLike)
   })
 
   it("can abort while waiting for ready state", async () => {
@@ -2548,14 +2548,19 @@ describe("Repo.find() abort behavior", () => {
     const findPromise = repo.find(url, { signal: controller.signal })
     controller.abort()
 
-    // Official specification just says to check `reason.name === "AbortError"`
-    // Using AbortError promotes correctness across different JS environments and provides a simpler check.
-    await expect(findPromise).rejects.toThrow(AbortError)
-    await expect(findPromise).rejects.rejects.toHaveProperty(
-      "name",
-      "AbortError"
-    )
-    await expect(findPromise).rejects.not.toThrow("unavailable")
+    await expect(findPromise).rejects.toSatisfy(isAbortErrorLike)
+  })
+
+  it("rejects with the provided abort reason", async () => {
+    const repo = new Repo()
+    const url = generateAutomergeUrl()
+    const controller = new AbortController()
+    const reason = new Error("caller cancelled")
+
+    const findPromise = repo.find(url, { signal: controller.signal })
+    controller.abort(reason)
+
+    await expect(findPromise).rejects.toBe(reason)
   })
 
   describe("creating a document with a custom ID factory", () => {

--- a/packages/automerge-repo/test/pause.test.ts
+++ b/packages/automerge-repo/test/pause.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { pause } from "../src/helpers/pause.js"
-import { AbortError } from "../src/helpers/abortable.js"
+import { isAbortErrorLike } from "../src/helpers/abortable.js"
 
 describe("pause", () => {
   beforeEach(() => {
@@ -45,12 +45,12 @@ describe("pause", () => {
 
       await expect(
         pause(1000, { signal: controller.signal })
-      ).rejects.toBeInstanceOf(AbortError)
+      ).rejects.toSatisfy(isAbortErrorLike)
       // The abort fast-path returned before setTimeout was reached.
       expect(vi.getTimerCount()).toBe(before)
     })
 
-    it("rejects with AbortError and clears the timer when the signal aborts mid-pause", async () => {
+    it("rejects with the abort reason and clears the timer when the signal aborts mid-pause", async () => {
       const before = vi.getTimerCount()
       const controller = new AbortController()
       const p = pause(1000, { signal: controller.signal })
@@ -59,9 +59,20 @@ describe("pause", () => {
       await vi.advanceTimersByTimeAsync(20)
       controller.abort()
 
-      await expect(p).rejects.toBeInstanceOf(AbortError)
+      await expect(p).rejects.toSatisfy(isAbortErrorLike)
       // The pending 1000ms timer was cleared by the abort listener.
       expect(vi.getTimerCount()).toBe(before)
+    })
+
+    it("rejects with the provided abort reason", async () => {
+      const controller = new AbortController()
+      const reason = new Error("caller cancelled")
+      const p = pause(1000, { signal: controller.signal })
+
+      await vi.advanceTimersByTimeAsync(20)
+      controller.abort(reason)
+
+      await expect(p).rejects.toBe(reason)
     })
 
     it("aborting after the pause already resolved does not throw or re-settle", async () => {
@@ -87,7 +98,7 @@ describe("pause", () => {
       await vi.advanceTimersByTimeAsync(20)
       c2.abort() // abort via the second source
 
-      await expect(p).rejects.toBeInstanceOf(AbortError)
+      await expect(p).rejects.toSatisfy(isAbortErrorLike)
     })
   })
 })


### PR DESCRIPTION
`Repo.find()`, `DocumentQuery.whenReady()`, and the internal `pause()` helper all accept an `AbortSignal`. When it fired they rejected with a fresh `AbortError`, discarding any reason passed to `controller.abort(reason)`.

They now reject with `signal.reason`, so a custom abort reason is propagated end to end. `find()` and `whenReady()` use `signal.throwIfAborted()` on the already-aborted fast path; `pause()` builds its promise synchronously, so it rejects with `signal.reason` directly rather than throwing.

`find()` and `whenReady()` also gain `@remarks` documenting that the signal cancels the wait, not the underlying load or sync (which may still be serving other concurrent callers).

Tests assert the rejection is abort-like across JS environments (a bare `controller.abort()` yields a platform `DOMException` named `AbortError`, not an instance of this package's `AbortError` class) and that a custom reason is preserved.
