### PR TITLE
docs: deprecate foreverPromise and warn against racing it

### DIFF
--- a/packages/automerge-repo/src/helpers/foreverPromise.ts
+++ b/packages/automerge-repo/src/helpers/foreverPromise.ts
@@ -1,6 +1,21 @@
 /* c8 ignore start */
 /**
- * A promise that never settles
+ * A promise that never settles.
+ *
+ * @deprecated A promise that never settles is undesirable: anything that awaits
+ * or races it is retained for the whole session (see @remarks). Only the
+ * deprecated `DocHandle.whenReady` still uses it, and it will be removed
+ * alongside it.
+ *
+ * @remarks
+ * Do NOT race this (e.g. `Promise.race([foreverPromise, x])` or
+ * `abortable(foreverPromise, signal)`): racing a never-settling singleton appends
+ * a reaction to it that is never released, so the race and everything it captures
+ * are retained for the whole session. To make a wait cancelable, derive the
+ * promise from the signal instead: from a `{ once: true }` `abort` listener,
+ * reject with `signal.reason` (handling the already-aborted case) so the promise
+ * can settle, and remove the listener once your wait resolves. {@link abortable}
+ * applies this to a single promise; for a deadline use {@link withTimeout}.
  */
 export const foreverPromise = new Promise<never>(() => {})
 /* c8 ignore end */


### PR DESCRIPTION
`foreverPromise` is a module-level promise that never settles. Racing it (`Promise.race([foreverPromise, x])`, or wrapping it in `abortable(foreverPromise, signal)`) appends a reaction that is never released, so the race and everything it captures are retained for the whole session.

This marks `foreverPromise` `@deprecated`: a never-settling promise is undesirable, and its only user, the already-`@deprecated` `DocHandle.whenReady`, will be removed together with it.

The `@remarks` document the footgun and the alternative: to make a wait cancelable, derive the promise from the signal (reject with `signal.reason` from a `{ once: true }` `abort` listener, handling the already-aborted case) so it can settle, then remove the listener once the wait resolves. `abortable()` applies this to a single promise; `withTimeout()` bounds a deadline.

Documentation only; no runtime change.
