### PR TITLE
Merge main into subductionjs and resolve conflicts

### DIFF
--- a/examples/react-remote-heads/src/SyncStatus.tsx
+++ b/examples/react-remote-heads/src/SyncStatus.tsx
@@ -124,7 +124,10 @@ export function SyncStatus({ url }: { url: AutomergeUrl }) {
           <span className="text-gray-300">local</span> {fmtHeads(localHeads)}
         </div>
         {peers.map(([id, r]) => (
-          <div key={id} className={cx(sameHeads(r.heads, localHeads) && "text-green-600")}>
+          <div
+            key={id}
+            className={cx(sameHeads(r.heads, localHeads) && "text-green-600")}
+          >
             <span className="text-gray-300">{id.slice(0, 6)}…</span>{" "}
             {fmtHeads(r.heads)}
           </div>

--- a/examples/react-remote-heads/src/main.tsx
+++ b/examples/react-remote-heads/src/main.tsx
@@ -21,7 +21,7 @@ initSync({ module: Uint8Array.from(atob(wasmBase64), c => c.charCodeAt(0)) })
 
 const repo = new Repo({
   storage: new IndexedDBStorageAdapter("automerge-repo-demo-remote-heads"),
-  subductionWebsocketEndpoints: ["wss://subduction.sync.inkandswitch.com"]
+  subductionWebsocketEndpoints: ["wss://subduction.sync.inkandswitch.com"],
 })
 
 declare global {

--- a/packages/automerge-repo-network-broadcastchannel/src/index.ts
+++ b/packages/automerge-repo-network-broadcastchannel/src/index.ts
@@ -15,11 +15,14 @@
  */
 
 import {
+  makeLogger,
   NetworkAdapter,
   type Message,
   type PeerId,
   type PeerMetadata,
 } from "@automerge/automerge-repo/slim"
+
+const log = makeLogger("automerge-repo:broadcastchannel")
 
 export type BroadcastChannelNetworkAdapterOptions = {
   /** BroadcastChannel name to use */
@@ -30,6 +33,9 @@ export type BroadcastChannelNetworkAdapterOptions = {
 
 export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
   #broadcastChannel: BroadcastChannel
+  // Held on the instance so disconnect() can remove it and connect() can avoid
+  // stacking duplicates.
+  #messageListener?: (e: { data: BroadcastChannelMessage }) => void
   #disconnected = false
   #ready = false
   // reassigned in constructor, but keeps TS from complaining
@@ -68,66 +74,75 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
   connect(peerId: PeerId, peerMetadata?: PeerMetadata) {
     this.peerId = peerId
     this.peerMetadata = peerMetadata
+
+    if (this.#disconnected) {
+      this.#broadcastChannel = new BroadcastChannel(this.#options.channelName)
+    } else if (this.#messageListener) {
+      this.#broadcastChannel.removeEventListener(
+        "message",
+        this.#messageListener
+      )
+    }
     this.#disconnected = false
 
-    this.#broadcastChannel.addEventListener(
-      "message",
-      (e: { data: BroadcastChannelMessage }) => {
-        const message = e.data
-        if ("targetId" in message && message.targetId !== this.peerId) {
-          return
-        }
-
-        if (this.#disconnected) {
-          return
-        }
-
-        const { senderId, type } = message
-
-        switch (type) {
-          case "arrive":
-            {
-              const { peerMetadata } = message as ArriveMessage
-              this.#broadcastChannel.postMessage({
-                senderId: this.peerId,
-                targetId: senderId,
-                type: "welcome",
-                peerMetadata: this.peerMetadata,
-              })
-              this.#announceConnection(senderId, peerMetadata)
-            }
-            break
-          case "welcome":
-            {
-              const { peerMetadata } = message as WelcomeMessage
-              this.#announceConnection(senderId, peerMetadata)
-            }
-            break
-          case "leave":
-            this.#connectedPeers = this.#connectedPeers.filter(
-              p => p !== senderId
-            )
-            this.emit("peer-disconnected", { peerId: senderId })
-            break
-          default:
-            if (!("data" in message)) {
-              this.emit("message", message)
-            } else {
-              if (!message.data) {
-                throw new Error(
-                  "We got a message without data, we can't send this."
-                )
-              }
-              const data = message.data
-              this.emit("message", {
-                ...message,
-                data: new Uint8Array(data),
-              })
-            }
-            break
-        }
+    this.#messageListener = (e: { data: BroadcastChannelMessage }) => {
+      const message = e.data
+      if ("targetId" in message && message.targetId !== this.peerId) {
+        return
       }
-    )
+
+      if (this.#disconnected) {
+        return
+      }
+
+      const { senderId, type } = message
+
+      switch (type) {
+        case "arrive":
+          {
+            const { peerMetadata } = message as ArriveMessage
+            this.#broadcastChannel.postMessage({
+              senderId: this.peerId,
+              targetId: senderId,
+              type: "welcome",
+              peerMetadata: this.peerMetadata,
+            })
+            this.#announceConnection(senderId, peerMetadata)
+          }
+          break
+        case "welcome":
+          {
+            const { peerMetadata } = message as WelcomeMessage
+            this.#announceConnection(senderId, peerMetadata)
+          }
+          break
+        case "leave":
+          this.#connectedPeers = this.#connectedPeers.filter(
+            p => p !== senderId
+          )
+          this.emit("peer-disconnected", { peerId: senderId })
+          break
+        default:
+          if (!("data" in message)) {
+            this.emit("message", message)
+          } else {
+            if (!message.data) {
+              // A throw inside this "message" listener escapes dispatch and can
+              // crash the process under Node, so log and drop the malformed
+              // message.
+              log.warn("dropping a data message with no data from %o", senderId)
+              return
+            }
+            const data = message.data
+            this.emit("message", {
+              ...message,
+              data: new Uint8Array(data),
+            })
+          }
+          break
+      }
+    }
+    this.#broadcastChannel.addEventListener("message", this.#messageListener)
 
     this.#broadcastChannel.postMessage({
       senderId: this.peerId,
@@ -162,6 +177,9 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
   }
 
   disconnect() {
+    if (this.#disconnected) {
+      return
+    }
     this.#broadcastChannel.postMessage({
       senderId: this.peerId,
       type: "leave",
@@ -170,6 +188,17 @@ export class BroadcastChannelNetworkAdapter extends NetworkAdapter {
       this.emit("peer-disconnected", { peerId })
     }
     this.#disconnected = true
+
+    // Detach the listener and close the channel so nothing is retained after
+    // disconnect; connect() reopens a fresh channel.
+    if (this.#messageListener) {
+      this.#broadcastChannel.removeEventListener(
+        "message",
+        this.#messageListener
+      )
+      this.#messageListener = undefined
+    }
+    this.#broadcastChannel.close()
   }
 }
 

--- a/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
+++ b/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
@@ -1,5 +1,5 @@
 import { PeerId } from "@automerge/automerge-repo"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   runNetworkAdapterTests,
   type SetupFn,
@@ -63,5 +63,33 @@ describe("BroadcastChannel", () => {
     })
     await pause(10)
     expect(a.isReady()).toBe(true)
+  })
+
+  it("removes its listener and closes its channel on disconnect, and is idempotent", () => {
+    const channelName = `broadcast-${Math.random().toString(36).slice(2)}`
+    // Spy on the prototype and assert on deltas so other adapters in the
+    // process don't perturb the counts.
+    const removeSpy = vi.spyOn(
+      BroadcastChannel.prototype,
+      "removeEventListener"
+    )
+    const closeSpy = vi.spyOn(BroadcastChannel.prototype, "close")
+    try {
+      const a = new BroadcastChannelNetworkAdapter({ channelName })
+      a.connect("a-peer" as PeerId)
+
+      const removesBefore = removeSpy.mock.calls.length
+      const closesBefore = closeSpy.mock.calls.length
+
+      a.disconnect()
+      expect(removeSpy.mock.calls.length).toBe(removesBefore + 1)
+      expect(closeSpy.mock.calls.length).toBe(closesBefore + 1)
+
+      expect(() => a.disconnect()).not.toThrow()
+      expect(closeSpy.mock.calls.length).toBe(closesBefore + 1)
+    } finally {
+      removeSpy.mockRestore()
+      closeSpy.mockRestore()
+    }
   })
 })

--- a/packages/automerge-repo-network-messagechannel/package.json
+++ b/packages/automerge-repo-network-messagechannel/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@automerge/automerge-repo": "workspace:*",
-    "debug": "catalog:",
     "eventemitter3": "catalog:"
   },
   "devDependencies": {

--- a/packages/automerge-repo-network-messagechannel/src/index.ts
+++ b/packages/automerge-repo-network-messagechannel/src/index.ts
@@ -7,6 +7,7 @@
  */
 import {
   type RepoMessage,
+  makeLogger,
   NetworkAdapter,
   type PeerId,
   type Message,
@@ -16,8 +17,7 @@ import { MessagePortRef } from "./MessagePortRef.js"
 import { StrongMessagePortRef } from "./StrongMessagePortRef.js"
 import { WeakMessagePortRef } from "./WeakMessagePortRef.js"
 
-import debug from "debug"
-const log = debug("automerge-repo:messagechannel")
+const log = makeLogger("automerge-repo:messagechannel")
 
 export class MessageChannelNetworkAdapter extends NetworkAdapter {
   channels = {}
@@ -60,7 +60,7 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
   }
 
   connect(peerId: PeerId, peerMetadata?: PeerMetadata) {
-    log("messageport connecting")
+    log.debug("messageport connecting")
     this.peerId = peerId
     this.peerMetadata = peerMetadata
 
@@ -68,13 +68,19 @@ export class MessageChannelNetworkAdapter extends NetworkAdapter {
     this.messagePortRef.addListener(
       "message",
       (e: { data: MessageChannelMessage }) => {
-        log("message port received %o", e.data)
+        log.debug("message port received %o", e.data)
 
         const message = e.data
         if ("targetId" in message && message.targetId !== this.peerId) {
-          throw new Error(
-            "MessagePortNetwork should never receive messages for a different peer."
+          // A throw inside this "message" listener escapes dispatch and can
+          // terminate the process under Node, so log and drop a message
+          // addressed to another peer.
+          log.warn(
+            "ignoring a message addressed to a different peer (targetId %o, ours %o)",
+            message.targetId,
+            this.peerId
           )
+          return
         }
 
         const { senderId, type } = message

--- a/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
@@ -45,6 +45,9 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   #retryIntervalId?: TimeoutId
+  #reconnectTimeoutId?: TimeoutId
+  #forceReadyTimeoutId?: TimeoutId
+  #disconnected = false
   #log = debug("automerge-repo:websocket:browser")
 
   remotePeerId?: PeerId // this adapter only connects to one remote client at a time
@@ -58,6 +61,7 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   connect(peerId: PeerId, peerMetadata?: PeerMetadata) {
+    this.#disconnected = false
     if (!this.socket || !this.peerId) {
       // first time connecting
       this.#log("connecting")
@@ -89,8 +93,10 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
 
     // Mark this adapter as ready if we haven't received an ack in 1 second.
     // We might hear back from the other end at some point but we shouldn't
-    // hold up marking things as unavailable for any longer
-    setTimeout(() => this.#forceReady(), 1000)
+    // hold up marking things as unavailable for any longer. Clear any pending
+    // fallback so reconnects don't accumulate timers.
+    clearTimeout(this.#forceReadyTimeoutId)
+    this.#forceReadyTimeoutId = setTimeout(() => this.#forceReady(), 1000)
     this.join()
   }
 
@@ -109,7 +115,9 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
 
     if (this.retryInterval > 0 && !this.#retryIntervalId)
       // try to reconnect
-      setTimeout(() => {
+      this.#reconnectTimeoutId = setTimeout(() => {
+        // Skip the reconnect if disconnect() ran after it was scheduled.
+        if (this.#disconnected) return
         assert(this.peerId)
         return this.connect(this.peerId, this.peerMetadata)
       }, this.retryInterval)
@@ -138,8 +146,10 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
   }
 
   disconnect() {
+    if (this.#disconnected) return
     assert(this.peerId)
     assert(this.socket)
+    this.#disconnected = true
     const socket = this.socket
     if (socket) {
       socket.removeEventListener("open", this.onOpen)
@@ -149,6 +159,11 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
       socket.close()
     }
     clearInterval(this.#retryIntervalId)
+    this.#retryIntervalId = undefined
+    clearTimeout(this.#reconnectTimeoutId)
+    this.#reconnectTimeoutId = undefined
+    clearTimeout(this.#forceReadyTimeoutId)
+    this.#forceReadyTimeoutId = undefined
     if (this.remotePeerId)
       this.emit("peer-disconnected", { peerId: this.remotePeerId })
     this.socket = undefined

--- a/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketServerAdapter.ts
@@ -44,6 +44,14 @@ export class WebSocketServerAdapter extends NetworkAdapter {
     }
   }
 
+  // Server-level wiring registered in connect(), held on the instance so
+  // disconnect() can clear the keepalive interval and remove the listeners we
+  // add to the long-lived WebSocketServer, and so a repeated connect() does not
+  // stack duplicates.
+  #keepAliveId?: ReturnType<typeof setInterval>
+  #onServerClose?: () => void
+  #onServerConnection?: (socket: WebSocketWithIsAlive) => void
+
   constructor(
     private server: WebSocketServer,
     private keepAliveInterval = 5000
@@ -55,12 +63,16 @@ export class WebSocketServerAdapter extends NetworkAdapter {
     this.peerId = peerId
     this.peerMetadata = peerMetadata
 
-    this.server.on("close", () => {
-      clearInterval(keepAliveId)
-      this.disconnect()
-    })
+    // Detach any wiring from an earlier connect() so repeated calls don't stack
+    // listeners or intervals on the shared server.
+    this.#teardownServerWiring()
 
-    this.server.on("connection", (socket: WebSocketWithIsAlive) => {
+    this.#onServerClose = () => {
+      this.disconnect()
+    }
+    this.server.on("close", this.#onServerClose)
+
+    this.#onServerConnection = (socket: WebSocketWithIsAlive) => {
       // When a socket closes, or disconnects, remove it from our list
       socket.on("close", () => {
         this.#removeSocket(socket)
@@ -75,9 +87,10 @@ export class WebSocketServerAdapter extends NetworkAdapter {
       socket.on("pong", () => (socket.isAlive = true))
 
       this.#forceReady()
-    })
+    }
+    this.server.on("connection", this.#onServerConnection)
 
-    const keepAliveId = setInterval(() => {
+    this.#keepAliveId = setInterval(() => {
       // Terminate connections to lost clients
       const clients = this.server.clients as Set<WebSocketWithIsAlive>
       clients.forEach(socket => {
@@ -93,11 +106,28 @@ export class WebSocketServerAdapter extends NetworkAdapter {
   }
 
   disconnect() {
+    this.#teardownServerWiring()
+
     const clients = this.server.clients as Set<WebSocketWithIsAlive>
     clients.forEach(socket => {
       this.#terminate(socket)
       this.#removeSocket(socket)
     })
+  }
+
+  #teardownServerWiring() {
+    if (this.#keepAliveId !== undefined) {
+      clearInterval(this.#keepAliveId)
+      this.#keepAliveId = undefined
+    }
+    if (this.#onServerClose) {
+      this.server.off("close", this.#onServerClose)
+      this.#onServerClose = undefined
+    }
+    if (this.#onServerConnection) {
+      this.server.off("connection", this.#onServerConnection)
+      this.#onServerConnection = undefined
+    }
   }
 
   send(message: FromServerMessage) {

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -15,7 +15,7 @@ import { runNetworkAdapterTests } from "@automerge/automerge-repo/helpers/tests/
 import { DummyStorageAdapter } from "@automerge/automerge-repo/helpers/DummyStorageAdapter.js"
 import assert from "assert"
 import * as CBOR from "cbor-x"
-import { once } from "events"
+import { EventEmitter, once } from "events"
 import http from "http"
 import { getPortPromise as getAvailablePort } from "portfinder"
 import { afterEach, describe, it, vi } from "vitest"
@@ -167,6 +167,33 @@ describe("Websocket adapters", () => {
         //  The browserAdapter reconnects on its own
         await eventPromise(browser, "peer-candidate")
       }
+    })
+
+    it("should be safe to disconnect more than once", async () => {
+      const port = await getPort()
+      const browser = await setupClient({ port })
+      const { server, serverSocket, serverAdapter } = await setupServer({
+        port,
+      })
+
+      const _browserRepo = new Repo({
+        network: [browser],
+        peerId: browserPeerId,
+      })
+      const _serverRepo = new Repo({
+        network: [serverAdapter],
+        peerId: serverPeerId,
+      })
+
+      await eventPromise(browser, "peer-candidate")
+
+      browser.disconnect()
+      // A repeat disconnect (e.g. React StrictMode double-invokes the effect
+      // cleanup that runs repo.shutdown()) must be a no-op, not throw.
+      assert.doesNotThrow(() => browser.disconnect())
+
+      server.close()
+      serverSocket.close()
     })
 
     it("should throw an error if asked to send a zero-length message", async () => {
@@ -829,6 +856,53 @@ describe("Websocket adapters", () => {
       if (!headsAreSame(encodeHeads(localHeads), remoteHeads)) {
         throw new Error("heads not equal")
       }
+    })
+
+    describe("teardown (resource-leak regressions)", () => {
+      // A stand-in for `ws`'s WebSocketServer: an EventEmitter that also exposes
+      // the `clients` set the keepalive sweep reads. Lets us assert listener and
+      // timer hygiene without opening a real socket.
+      class FakeServer extends EventEmitter {
+        clients = new Set()
+      }
+
+      it("removes the listeners it added to the shared server on disconnect, and does not stack them across repeated connect() calls", () => {
+        const server = new FakeServer()
+        const adapter = new WebSocketServerAdapter(
+          server as unknown as WebSocketServer
+        )
+
+        adapter.connect(serverPeerId)
+        adapter.connect(serverPeerId) // a second connect() must not stack listeners
+
+        assert.equal(server.listenerCount("connection"), 1)
+        assert.equal(server.listenerCount("close"), 1)
+
+        adapter.disconnect()
+
+        assert.equal(server.listenerCount("connection"), 0)
+        assert.equal(server.listenerCount("close"), 0)
+      })
+
+      it("clears the keepalive interval on disconnect", () => {
+        // Fake only the interval timers the adapter owns; leave setTimeout real.
+        vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] })
+        try {
+          const server = new FakeServer()
+          const adapter = new WebSocketServerAdapter(
+            server as unknown as WebSocketServer
+          )
+
+          adapter.connect(serverPeerId)
+          // The only interval this bare adapter arms is the keepalive sweep.
+          assert.equal(vi.getTimerCount(), 1)
+
+          adapter.disconnect()
+          assert.equal(vi.getTimerCount(), 0)
+        } finally {
+          vi.useRealTimers()
+        }
+      })
     })
   })
 })

--- a/packages/automerge-repo-react-hooks/src/useDocHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocHandle.ts
@@ -75,14 +75,25 @@ export function useDocHandle<T>(
     if (currentHandle || suspense || !wrapper) {
       return
     }
+    // Stays true until this effect run is torn down (unmount or id change); a
+    // result that arrives after that must not setState for a stale id.
+    let active = true
     wrapper.promise
       .then(handle => {
-        setHandle(handle as DocHandle<T>)
+        if (active) setHandle(handle as DocHandle<T>)
       })
       .catch(() => {
-        setHandle(undefined)
+        // Drop the failed wrapper so a later render retries instead of reusing
+        // the rejection.
+        if (id && wrapperCache.get(id) === wrapper) {
+          wrapperCache.delete(id)
+        }
+        if (active) setHandle(undefined)
       })
-  }, [currentHandle, suspense, wrapper])
+    return () => {
+      active = false
+    }
+  }, [currentHandle, suspense, wrapper, id])
 
   if (currentHandle || !suspense || !wrapper) {
     return currentHandle

--- a/packages/automerge-repo-react-hooks/src/useDocHandles.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocHandles.ts
@@ -73,9 +73,14 @@ export function useDocHandles<T>(
   // Suspense is handled quasi-synchronously below by throwing if we still have
   // unresolved promises.
   useEffect(() => {
+    // Stays true until this effect run is torn down; if idSet changes (or we
+    // unmount) before these finds settle, the now-stale map must not overwrite
+    // a newer one.
+    let active = true
     if (pendingPromises.length > 0) {
       void Promise.allSettled(pendingPromises.map(p => p.promise)).then(
         handles => {
+          if (!active) return
           handles.forEach(r => {
             if (r.status === "fulfilled") {
               const h = r.value as DocHandle<T>
@@ -87,6 +92,9 @@ export function useDocHandles<T>(
       )
     } else {
       setHandleMap(nextHandleMap)
+    }
+    return () => {
+      active = false
     }
   }, [suspense, idSet])
 

--- a/packages/automerge-repo-react-hooks/test/useDocHandle.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocHandle.test.tsx
@@ -8,7 +8,7 @@ import { render, screen, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
 
 import { describe, expect, it, vi } from "vitest"
-import { useDocHandle } from "../src/useDocHandle"
+import { useDocHandle, wrapperCache } from "../src/useDocHandle"
 import { ErrorBoundary } from "react-error-boundary"
 import { setup, setupPairedRepos } from "./testSetup"
 import { pause } from "../src/helpers/DummyNetworkAdapter"
@@ -249,6 +249,35 @@ describe("useDocHandle", () => {
       // Should continue to return undefined after attempted load
       await waitFor(() => {
         expect(onHandle).toHaveBeenLastCalledWith(undefined)
+      })
+    })
+
+    it("evicts a rejected wrapper so a later attempt can retry", async () => {
+      const { wrapper } = await setup()
+      const url = generateAutomergeUrl() // unavailable document
+      const onHandle = vi.fn()
+
+      const NonSuspenseComponent = ({
+        url,
+        onHandle,
+      }: {
+        url: AutomergeUrl
+        onHandle: (handle: DocHandle<unknown> | undefined) => void
+      }) => {
+        const handle = useDocHandle(url, { suspense: false })
+        onHandle(handle)
+        return null
+      }
+
+      render(<NonSuspenseComponent url={url} onHandle={onHandle} />, {
+        wrapper,
+      })
+
+      // Once the unavailable find rejects, the cached wrapper is dropped, so a
+      // later render re-fetches instead of replaying the stored rejection.
+      await waitFor(() => {
+        expect(onHandle).toHaveBeenLastCalledWith(undefined)
+        expect(wrapperCache.has(url)).toBe(false)
       })
     })
 

--- a/packages/automerge-repo-react-hooks/test/useDocHandles.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocHandles.test.tsx
@@ -293,5 +293,28 @@ describe("useDocHandles", () => {
       expect(result2?.size).toBe(1)
       expect(result2?.get(handleB.url)?.url).toEqual(handleB.url)
     })
+
+    it("does not let a superseded url set overwrite the current one", async () => {
+      const { repoCreator, repoFinder, wrapper } = await setupPairedRepos()
+      const handleA = repoCreator.create({ foo: "A" })
+      const handleB = repoFinder.create({ foo: "B" })
+      const onHandles = mockOnHandles()
+
+      const { rerender } = render(
+        <Component urls={[handleA.url]} onHandles={onHandles} />,
+        { wrapper }
+      )
+
+      // Switch to B before A resolves.
+      rerender(<Component urls={[handleB.url]} onHandles={onHandles} />)
+
+      // The committed map settles on B; A's superseded find must not overwrite
+      // it back in.
+      await waitFor(() => {
+        const result = onHandles.mock.lastCall?.at(0)
+        expect(result?.get(handleB.url)?.url).toEqual(handleB.url)
+      })
+      expect(onHandles.mock.lastCall?.at(0)?.has(handleA.url)).toBe(false)
+    })
   })
 })

--- a/packages/automerge-repo-storage-indexeddb/src/IndexedDBWorkerStorageAdapter.ts
+++ b/packages/automerge-repo-storage-indexeddb/src/IndexedDBWorkerStorageAdapter.ts
@@ -129,18 +129,18 @@ class WorkerBackedIndexedDB implements StorageAdapterInterface {
     await this.#call("saveBatch", [entries])
   }
 
-  dispose(): void {
+  close(): void {
     this.#worker.removeEventListener("message", this.#onMessage)
     this.#worker.removeEventListener("error", this.#onError)
     this.#worker.removeEventListener("messageerror", this.#onError)
-    this.#fail(new WorkerStorageError("IndexedDB storage adapter disposed"))
+    this.#fail(new WorkerStorageError("IndexedDB storage adapter closed"))
     if (this.#ownsWorker) this.#worker.terminate()
   }
 }
 
 export class IndexedDBWorkerStorageAdapter implements StorageAdapterInterface {
   #impl: StorageAdapterInterface
-  #disposed = false
+  #closed = false
 
   /**
    * @param worker - an existing Worker to reuse; otherwise one is spawned.
@@ -191,11 +191,9 @@ export class IndexedDBWorkerStorageAdapter implements StorageAdapterInterface {
   }
 
   /** Terminate the internal worker (only if this adapter created it). */
-  dispose(): void {
-    if (this.#disposed) return
-    this.#disposed = true
-    ;(
-      this.#impl as StorageAdapterInterface & { dispose?: () => void }
-    ).dispose?.()
+  async close(): Promise<void> {
+    if (this.#closed) return
+    this.#closed = true
+    await this.#impl.close?.()
   }
 }

--- a/packages/automerge-repo-storage-indexeddb/src/index.ts
+++ b/packages/automerge-repo-storage-indexeddb/src/index.ts
@@ -151,4 +151,10 @@ export class IndexedDBStorageAdapter implements StorageAdapterInterface {
       }
     })
   }
+
+  /** Close the underlying database connection. */
+  async close(): Promise<void> {
+    const db = await this.dbPromise
+    db.close()
+  }
 }

--- a/packages/automerge-repo-storage-indexeddb/test/IndexedDBWorkerStorageAdapter.test.ts
+++ b/packages/automerge-repo-storage-indexeddb/test/IndexedDBWorkerStorageAdapter.test.ts
@@ -82,7 +82,7 @@ const makeAdapter = (database: string, worker = new FakeStorageWorker()) => {
 }
 
 afterEach(() => {
-  for (const a of created.splice(0)) a.dispose()
+  for (const a of created.splice(0)) a.close()
 })
 
 describe("IndexedDBWorkerStorageAdapter (worker-RPC proxy)", () => {
@@ -179,13 +179,13 @@ describe("IndexedDBWorkerStorageAdapter (worker-RPC proxy)", () => {
     await expect(adapter.load(["k"])).rejects.toBeInstanceOf(WorkerStorageError)
   })
 
-  it("rejects in-flight calls on dispose", async () => {
-    const { adapter, worker } = makeAdapter("idb-dispose")
+  it("rejects in-flight calls on close", async () => {
+    const { adapter, worker } = makeAdapter("idb-close")
     await adapter.save(["k"], PAYLOAD_A())
     worker.dropReplies = true
     const inflight = adapter.load(["k"])
     await tick()
-    adapter.dispose()
+    adapter.close()
     await expect(inflight).rejects.toBeInstanceOf(WorkerStorageError)
   })
 

--- a/packages/automerge-repo-storage-indexeddb/test/StorageBench.browser.test.ts
+++ b/packages/automerge-repo-storage-indexeddb/test/StorageBench.browser.test.ts
@@ -29,7 +29,7 @@ const REPEATS = Number.parseInt(__BENCH_REPEATS__, 10)
 const CONTENTION_MS = Number.parseInt(__BENCH_CONTENTION_MS__, 10)
 const BATCH = Number.parseInt(__BENCH_BATCH__, 10)
 
-type DisposableAdapter = StorageAdapterInterface & { dispose?(): void }
+type DisposableAdapter = StorageAdapterInterface
 
 const dbName = () => "bench-" + Math.random().toString(36).slice(2)
 
@@ -100,7 +100,7 @@ async function benchVariant(
         await prepare?.(adapter)
         runs.push(await run(adapter))
       } finally {
-        adapter.dispose?.()
+        adapter.close?.()
       }
     }
     results.push(summarize(label, runs))

--- a/packages/automerge-repo-storage-indexeddb/test/close.test.ts
+++ b/packages/automerge-repo-storage-indexeddb/test/close.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { IndexedDBStorageAdapter } from "../src/index.js"
+
+describe("IndexedDBStorageAdapter close", () => {
+  beforeEach(() => {
+    // The constructor opens IndexedDB; stub it when the env has none.
+    if (typeof globalThis.indexedDB === "undefined") {
+      globalThis.indexedDB = { open: () => ({}) } as unknown as IDBFactory
+    }
+  })
+
+  it("closes the underlying database connection", async () => {
+    const adapter = new IndexedDBStorageAdapter()
+    let closed = 0
+    ;(adapter as any).dbPromise = Promise.resolve({
+      close: () => {
+        closed++
+      },
+    })
+
+    await adapter.close()
+    expect(closed).toBe(1)
+  })
+})

--- a/packages/automerge-repo/src/DocumentQuery.ts
+++ b/packages/automerge-repo/src/DocumentQuery.ts
@@ -3,7 +3,6 @@ import { DocHandle } from "./DocHandle.js"
 import { decodeHeads } from "./AutomergeUrl.js"
 import type { DocumentId, UrlHeads } from "./types.js"
 import type { Segment } from "./subdoc-handles/types.js"
-import { AbortError } from "./helpers/abortable.js"
 import { type FindProgress, queryStateToFindProgress } from "./_compat.js"
 
 /**
@@ -55,6 +54,11 @@ export interface DocumentProgress<T> {
   /**
    * Returns a promise that resolves with the DocHandle when the query reaches
    * the `ready` state. Rejects if the query fails or the signal is aborted.
+   *
+   * @remarks
+   * `options.signal` cancels only the await, not the underlying sources
+   * (storage load, sync), which may be serving other concurrent callers. An
+   * aborted wait rejects with `signal.reason`.
    */
   whenReady(options?: { signal?: AbortSignal }): Promise<DocHandle<T>>
 
@@ -164,7 +168,7 @@ export class DocumentQuery<T> implements DocumentProgress<T> {
 
   async whenReady(options?: { signal?: AbortSignal }): Promise<DocHandle<T>> {
     const signal = options?.signal
-    if (signal?.aborted) throw new AbortError()
+    signal?.throwIfAborted()
 
     // Already ready — return immediately
     if (this.#state.state === "ready") return this.#state.handle
@@ -180,7 +184,7 @@ export class DocumentQuery<T> implements DocumentProgress<T> {
     return new Promise<DocHandle<T>>((resolve, reject) => {
       const onAbort = () => {
         cleanup()
-        reject(new AbortError())
+        reject(signal!.reason)
       }
 
       const unsubscribe = this.subscribe(state => {
@@ -432,7 +436,7 @@ export function progressAtHeads<T>(
       return new Promise<DocHandle<T>>((resolve, reject) => {
         const onAbort = () => {
           cleanup()
-          reject(new AbortError())
+          reject(opts!.signal!.reason)
         }
         const onChange = () => {
           if (Automerge.hasHeads(upstream.fullDoc(), decoded)) {

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -112,8 +112,6 @@ export class Repo extends EventEmitter<RepoEvents> {
   #subductionEphemeralCount = 0
   #idFactory: ((initialHeads: Heads) => Promise<Uint8Array>) | null
   #peerId: PeerId
-  /** Retained so {@link shutdown} can `dispose` it (e.g. a worker-backed adapter). */
-  #storage: (StorageAdapterInterface & { dispose?: () => void }) | undefined
 
   constructor({
     storage,
@@ -153,7 +151,6 @@ export class Repo extends EventEmitter<RepoEvents> {
     }
 
     // STORAGE
-    this.#storage = storage
     const storageSubsystem = storage ? new StorageSubsystem(storage) : undefined
     if (storageSubsystem) {
       storageSubsystem.on("document-loaded", event =>
@@ -950,11 +947,10 @@ export class Repo extends EventEmitter<RepoEvents> {
       this.#log.warn("flush() during shutdown failed", { err: e })
     }
 
-    // Release the storage adapter after the flush. Run both teardown paths so
-    // neither is lost: StorageSubsystem.close() forwards to adapter.close?(),
-    // and #storage.dispose?.() terminates a worker-backed adapter.
+    // Release the storage adapter after the flush. StorageSubsystem.close()
+    // forwards to the adapter's close?(), which terminates a worker-backed
+    // adapter's worker.
     await this.storageSubsystem?.close()
-    this.#storage?.dispose?.()
   }
 
   metrics(): { documents: { [key: string]: any } } {

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -36,7 +36,7 @@ import type {
   DocumentId,
   PeerId,
 } from "./types.js"
-import { AbortOptions, AbortError } from "./helpers/abortable.js"
+import { AbortOptions } from "./helpers/abortable.js"
 export type { FindProgressWithMethods, ProgressSignal } from "./_compat.js"
 import { Document } from "./Document.js"
 import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
@@ -540,6 +540,12 @@ export class Repo extends EventEmitter<RepoEvents> {
 
   /**
    * Look up a document by URL and wait for it to be ready.
+   *
+   * @remarks
+   * `options.signal` cancels the wait, not the load: the underlying
+   * {@link DocumentQuery} and its sources keep running (they may be serving
+   * other concurrent callers), so use {@link Repo.removeFromCache} to stop the
+   * load. An aborted wait rejects with `signal.reason`.
    */
   async find<T>(
     id: AnyDocumentId,
@@ -547,9 +553,7 @@ export class Repo extends EventEmitter<RepoEvents> {
   ): Promise<DocHandle<T>> {
     const { signal } = options
 
-    if (signal?.aborted) {
-      throw new AbortError()
-    }
+    signal?.throwIfAborted()
 
     // `findWithProgress` already applies any path suffix (`/a/@0/b`) and
     // fixed heads (`#h1|h2`) from the URL, so the ready handle is correctly

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -42,6 +42,7 @@ import { Document } from "./Document.js"
 import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
 import { isPlainObject } from "./helpers/isPlainObject.js"
 import { hasAtLeastOneKey } from "./helpers/has-at-least-one-key.js"
+import { noop } from "./helpers/noop.js"
 
 export type { DocumentProgress } from "./DocumentQuery.js"
 export { DocumentQuery } from "./DocumentQuery.js"
@@ -171,7 +172,16 @@ export class Repo extends EventEmitter<RepoEvents> {
           if (!storageId || isEph) return
           return this.storageSubsystem.loadSyncState(documentId, storageId)
         },
-        networkReady: networkSubsystem.whenReady().then(() => {}),
+        // Resolve to void once the adapters are ready, or on adapter failure
+        // (logged): networkReady gates "peers have had their chance to connect",
+        // so a failed network should let documents settle rather than hang, and
+        // it must never reject (no consumer acts on the rejection, and an
+        // unhandled one would surface before any DocSynchronizer attaches).
+        networkReady: networkSubsystem
+          .whenReady()
+          .then(noop, err =>
+            this.#log.error("network adapters failed to become ready", err)
+          ),
       },
       denylist
     )

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -712,6 +712,7 @@ export class Repo extends EventEmitter<RepoEvents> {
   async shutdown() {
     await this.flush()
     this.networkSubsystem.disconnect()
+    await this.storageSubsystem?.close()
   }
 
   metrics(): { documents: { [key: string]: any } } {

--- a/packages/automerge-repo/src/StorageSource.ts
+++ b/packages/automerge-repo/src/StorageSource.ts
@@ -89,8 +89,24 @@ export class StorageSource implements DocumentSource {
     let fn = this.#saveFns[documentId]
     if (!fn) {
       fn = this.#saveFns[documentId] = asyncThrottle(
-        ({ doc, handle }: DocHandleEncodedChangePayload<any>): Promise<void> =>
-          this.#storage.saveDoc(handle.documentId, doc),
+        async ({
+          doc,
+          handle,
+        }: DocHandleEncodedChangePayload<any>): Promise<void> => {
+          try {
+            await this.#storage.saveDoc(handle.documentId, doc)
+          } catch (err) {
+            // This save runs fire-and-forget from a "heads-changed" listener,
+            // so a rejection would surface as an unhandled rejection and, in
+            // Node, exit the process by default. Catch and log it; the change
+            // stays in memory and a later save or reload can re-persist it.
+            // See https://nodejs.org/api/process.html#event-unhandledrejection
+            this.#log.error(
+              `Error saving document ${handle.documentId} to storage`,
+              err
+            )
+          }
+        },
         this.#saveDebounceRate
       )
     }

--- a/packages/automerge-repo/src/SyncStateTracker.ts
+++ b/packages/automerge-repo/src/SyncStateTracker.ts
@@ -1,6 +1,7 @@
 import { encodeHeads } from "./AutomergeUrl.js"
 import type { DocHandle, SyncInfo } from "./DocHandle.js"
 import { headsAreSame } from "./helpers/headsAreSame.js"
+import { makeLogger } from "./Logger.js"
 import type { PeerMetadata } from "./network/NetworkAdapterInterface.js"
 import type { StorageSubsystem } from "./storage/StorageSubsystem.js"
 import type { StorageId } from "./storage/types.js"
@@ -29,6 +30,7 @@ export class SyncStateTracker {
     StorageId,
     (payload: SyncStatePayload) => Promise<void>
   > = {}
+  #log = makeLogger("automerge-repo:sync-state-tracker")
 
   constructor(storage: StorageSubsystem | undefined, saveDebounceRate: number) {
     this.#storage = storage
@@ -148,8 +150,20 @@ export class SyncStateTracker {
     let handler = this.#throttledSaveSyncStateHandlers[storageId]
     if (!handler) {
       handler = this.#throttledSaveSyncStateHandlers[storageId] = asyncThrottle(
-        ({ documentId, syncState }: SyncStatePayload) =>
-          this.#storage!.saveSyncState(documentId, storageId, syncState),
+        async ({ documentId, syncState }: SyncStatePayload) => {
+          try {
+            await this.#storage!.saveSyncState(documentId, storageId, syncState)
+          } catch (err) {
+            // Fire-and-forget (the result is discarded below): catch and log a
+            // failed write instead of letting it surface as an unhandled
+            // rejection. Sync state is re-derived from the next sync exchange,
+            // so a dropped save is recoverable.
+            this.#log.error(
+              `Error saving sync state for ${documentId} to ${storageId}`,
+              err
+            )
+          }
+        },
         this.#saveDebounceRate
       )
     }

--- a/packages/automerge-repo/src/helpers/foreverPromise.ts
+++ b/packages/automerge-repo/src/helpers/foreverPromise.ts
@@ -1,6 +1,21 @@
 /* c8 ignore start */
 /**
- * A promise that never settles
+ * A promise that never settles.
+ *
+ * @deprecated A promise that never settles is undesirable: anything that awaits
+ * or races it is retained for the whole session (see @remarks). Only the
+ * deprecated `DocHandle.whenReady` still uses it, and it will be removed
+ * alongside it.
+ *
+ * @remarks
+ * Do NOT race this (e.g. `Promise.race([foreverPromise, x])` or
+ * `abortable(foreverPromise, signal)`): racing a never-settling singleton appends
+ * a reaction to it that is never released, so the race and everything it captures
+ * are retained for the whole session. To make a wait cancelable, derive the
+ * promise from the signal instead: from a `{ once: true }` `abort` listener,
+ * reject with `signal.reason` (handling the already-aborted case) so the promise
+ * can settle, and remove the listener once your wait resolves. {@link abortable}
+ * applies this to a single promise; for a deadline use {@link withTimeout}.
  */
 export const foreverPromise = new Promise<never>(() => {})
 /* c8 ignore end */

--- a/packages/automerge-repo/src/helpers/pause.ts
+++ b/packages/automerge-repo/src/helpers/pause.ts
@@ -1,6 +1,4 @@
 /* c8 ignore start */
-import { AbortError } from "./abortable.js"
-
 type AbortListener = (
   this: AbortSignal,
   ev: AbortSignalEventMap["abort"]
@@ -14,9 +12,9 @@ const abortEvent = "abort"
  *
  * @param milliseconds - The number of milliseconds to pause. Defaults to 0.
  * @param signal - An optional AbortSignal that can be used to cancel the pause.
- * @returns A Promise that resolves after the specified delay, or rejects with an AbortError if cancelled.
+ * @returns A Promise that resolves after the specified delay, or rejects with `signal.reason` if cancelled.
  *
- * @throws {AbortError} Thrown when the pause is cancelled via the AbortSignal.
+ * @throws {AbortError} Rejects with the signal's `reason` (an `AbortError` by default) when cancelled via the AbortSignal.
  *
  * @example
  * ```typescript
@@ -49,13 +47,13 @@ export const pause = (
   return new Promise<void>((resolve, reject) => {
     const { signal } = options ?? {}
     if (signal?.aborted) {
-      reject(new AbortError())
+      reject(signal.reason)
       return
     }
     const abortListener: AbortListener | undefined =
       signal &&
       ((): void => {
-        reject(new AbortError())
+        reject(signal.reason)
         clearTimeout(id)
       })
 

--- a/packages/automerge-repo/src/helpers/throttle.ts
+++ b/packages/automerge-repo/src/helpers/throttle.ts
@@ -50,6 +50,8 @@ export const throttle = <F extends (...args: Parameters<F>) => ReturnType<F>>(
  * - Previous calls complete before new ones start (so there is no race with previous calls)
  * - There's always a minimum delay between executions
  * - The latest call always runs (canceling previous pending calls)
+ * - Superseded calls still settle — every coalesced caller resolves (or rejects)
+ *   with the winning run's result rather than being left with an orphaned promise
  * - Each call waits for the previous execution to complete
  *
  * This creates a batching behavior that prevents flooding while ensuring
@@ -90,6 +92,11 @@ export const asyncThrottle = <TArgs extends unknown[], TReturn>(
   let lastCall = Date.now()
   let timeout: ReturnType<typeof setTimeout> | undefined
   let currentPromise: Promise<TReturn> | undefined
+  // A deferred shared by every call coalesced into the next run. Sharing it is
+  // what keeps a superseded call from being orphaned: when a later call clears
+  // the pending timeout below, the earlier call still settles with the run's
+  // result (or error) instead of hanging forever.
+  let pending: PromiseWithResolvers<TReturn> | undefined
 
   return async function (...args: TArgs): Promise<TReturn> {
     // Wait for any previous call to settle, so that there is not a race with
@@ -102,6 +109,11 @@ export const asyncThrottle = <TArgs extends unknown[], TReturn>(
       }
     }
 
+    // Join (or open) the batch waiting on the next run. Every caller shares this
+    // deferred; the run itself uses the latest call's args, captured below.
+    pending ??= Promise.withResolvers<TReturn>()
+    const deferred = pending
+
     // Clear any pending timeout
     if (timeout) {
       clearTimeout(timeout)
@@ -110,19 +122,20 @@ export const asyncThrottle = <TArgs extends unknown[], TReturn>(
     // Clamp to 0: passing a negative delay to setTimeout warns on some runtimes.
     const wait = Math.max(0, lastCall + delay - Date.now()) //if negative, executes immediately
 
-    return new Promise<TReturn>((resolve, reject) => {
-      timeout = setTimeout(async () => {
-        try {
-          currentPromise = fn(...args)
-          resolve(await currentPromise)
-        } catch (error) {
-          reject(error)
-        } finally {
-          lastCall = Date.now()
-          currentPromise = undefined
-          timeout = undefined
-        }
-      }, wait)
-    })
+    timeout = setTimeout(async () => {
+      pending = undefined
+      timeout = undefined
+      try {
+        currentPromise = fn(...args)
+        deferred.resolve(await currentPromise)
+      } catch (error) {
+        deferred.reject(error)
+      } finally {
+        lastCall = Date.now()
+        currentPromise = undefined
+      }
+    }, wait)
+
+    return deferred.promise
   }
 }

--- a/packages/automerge-repo/src/network/NetworkAdapter.ts
+++ b/packages/automerge-repo/src/network/NetworkAdapter.ts
@@ -9,6 +9,7 @@ import {
   NetworkAdapterInterface,
 } from "./NetworkAdapterInterface.js"
 import { AdapterStateSignal } from "./AdapterStateSignal.js"
+import { noop } from "../helpers/noop.js"
 
 /** An interface representing some way to connect to other peers
  *
@@ -34,9 +35,15 @@ export abstract class NetworkAdapter
     // Defer to a microtask so subclass field initializers (which run after
     // super() returns) have completed before we call the overridden whenReady().
     queueMicrotask(() => {
-      void this.whenReady().then(() => {
-        this.#adapterState.set("ready")
-      })
+      void this.whenReady().then(
+        () => {
+          this.#adapterState.set("ready")
+        },
+        // whenReady() rejected: the adapter never became ready, so leave the
+        // state at "connecting". Swallow so a failing adapter does not surface
+        // as an unhandled rejection (Repo logs readiness failures separately).
+        noop
+      )
     })
   }
 

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -109,10 +109,10 @@ export class NetworkSubsystem extends EventEmitter<NetworkSubsystemEvents> {
       this.adapters = this.adapters.filter(a => a !== networkAdapter)
     })
 
+    // connect() is typed `void`, but a custom adapter may return a Promise;
+    // return it so its rejection chains into the .catch() below, not dropped.
     this.peerMetadata
-      .then(peerMetadata => {
-        networkAdapter.connect(this.peerId, peerMetadata)
-      })
+      .then(peerMetadata => networkAdapter.connect(this.peerId, peerMetadata))
       .catch(err => {
         this.#log.error("error connecting to network", err)
       })

--- a/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
+++ b/packages/automerge-repo/src/storage/StorageAdapterInterface.ts
@@ -31,4 +31,12 @@ export interface StorageAdapterInterface {
 
   /** Remove all values with keys that start with `keyPrefix` */
   removeRange(keyPrefix: StorageKey): Promise<void>
+
+  /**
+   * Release any resources the adapter holds, such as an open database
+   * connection. Optional: {@link Repo.shutdown} calls it after the final flush.
+   * Adapters that hold no long-lived resource (in-memory, plain filesystem) can
+   * omit it.
+   */
+  close?(): void | Promise<void>
 }

--- a/packages/automerge-repo/src/storage/StorageSubsystem.ts
+++ b/packages/automerge-repo/src/storage/StorageSubsystem.ts
@@ -55,6 +55,11 @@ export class StorageSubsystem extends EventEmitter<StorageSubsystemEvents> {
     this.#storageAdapter = storageAdapter
   }
 
+  /** Release the underlying storage adapter's resources, if it holds any. */
+  async close(): Promise<void> {
+    await this.#storageAdapter.close?.()
+  }
+
   async id(): Promise<StorageId> {
     const storedId = await this.#storageAdapter.load(["storage-adapter-id"])
 

--- a/packages/automerge-repo/src/subduction/SubductionConnections.ts
+++ b/packages/automerge-repo/src/subduction/SubductionConnections.ts
@@ -14,7 +14,9 @@ const RECONNECT_MAX_MS = 30000
  * debug-gated; these are not).
  */
 function lifecycle(text: string, level: "info" | "warn" = "info"): void {
-  console[level](`[lifecycle] ${new Date().toISOString()} subduction ws ${text}`)
+  console[level](
+    `[lifecycle] ${new Date().toISOString()} subduction ws ${text}`
+  )
 }
 
 export class SubductionConnections implements ConnectionManager {

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -420,7 +420,13 @@ export class SubductionSource implements DocumentSource {
       // raw subduction CommitId hex would never compare equal to a doc's
       // own heads).
       const urlHeads = encodeHeads(heads.map(h => h.toHexString()))
-      this.#surfaceRemoteHeads(sedimentreeId, storageId, urlHeads, Date.now(), true)
+      this.#surfaceRemoteHeads(
+        sedimentreeId,
+        storageId,
+        urlHeads,
+        Date.now(),
+        true
+      )
     }
 
     // Construct without hydrating: skip preloading persisted sedimentrees
@@ -1157,8 +1163,7 @@ export class SubductionSource implements DocumentSource {
             entry.query.documentId,
             "",
             blob,
-            (id: string) =>
-              this.#storage.loadBlobById(entry.sedimentreeId, id),
+            (id: string) => this.#storage.loadBlobById(entry.sedimentreeId, id)
           )
           if (result) {
             transformed.push(result)

--- a/packages/automerge-repo/src/subduction/storage.ts
+++ b/packages/automerge-repo/src/subduction/storage.ts
@@ -309,7 +309,12 @@ export class SubductionStorageBridge implements SedimentreeStorage {
     sedimentreeId: SedimentreeId,
     commitIdHex: string
   ): Promise<Uint8Array | null> {
-    const blobKey = [this.prefix, BLOBS_PREFIX, sedimentreeId.toString(), commitIdHex]
+    const blobKey = [
+      this.prefix,
+      BLOBS_PREFIX,
+      sedimentreeId.toString(),
+      commitIdHex,
+    ]
     return (await this.adapter.load(blobKey)) ?? null
   }
 

--- a/packages/automerge-repo/test/NetworkAdapter.test.ts
+++ b/packages/automerge-repo/test/NetworkAdapter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { NetworkAdapter } from "../src/index.js"
+import { DummyNetworkAdapter } from "../src/helpers/DummyNetworkAdapter.js"
+
+// Flush microtasks (via a macrotask hop) so the constructor's deferred
+// readiness wiring has settled before asserting on state.
+const settle = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+/** A NetworkAdapter whose whenReady() rejects, i.e. it never becomes ready. */
+class RejectingNetworkAdapter extends NetworkAdapter {
+  isReady() {
+    return false
+  }
+  whenReady() {
+    return Promise.reject(new Error("adapter failed to become ready"))
+  }
+  connect() {}
+  send() {}
+  disconnect() {}
+}
+
+describe("NetworkAdapter", () => {
+  it("stays connecting and surfaces no unhandled rejection when whenReady() rejects", async () => {
+    const unhandled: unknown[] = []
+    const capture = (reason: unknown) => unhandled.push(reason)
+    process.on("unhandledRejection", capture)
+    try {
+      const adapter = new RejectingNetworkAdapter()
+      await settle()
+      expect(adapter.state().value).toBe("connecting")
+      expect(unhandled).toEqual([])
+    } finally {
+      process.off("unhandledRejection", capture)
+    }
+  })
+
+  it("transitions to ready when whenReady() resolves", async () => {
+    const adapter = new DummyNetworkAdapter({ startReady: true })
+    await settle()
+    expect(adapter.state().value).toBe("ready")
+  })
+})

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -68,6 +68,30 @@ describe("Repo", () => {
       assert(repo.storageSubsystem)
     })
 
+    it("logs and does not leak when a network adapter fails to become ready", async () => {
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      try {
+        const networkAdapter = new DummyNetworkAdapter({ startReady: false })
+        networkAdapter.whenReady = () =>
+          Promise.reject(new Error("adapter boom"))
+        // No documents are open, so nothing attaches to networkReady; a
+        // rejection there must be handled at the source, not left to float.
+        const _repo = new Repo({ network: [networkAdapter] })
+        await vi.waitFor(() =>
+          assert.ok(
+            errSpy.mock.calls.some(call =>
+              call.some(arg =>
+                String(arg).includes("network adapters failed to become ready")
+              )
+            ),
+            "the adapter failure should be caught and logged"
+          )
+        )
+      } finally {
+        errSpy.mockRestore()
+      }
+    })
+
     it("can create a document", () => {
       const { repo } = setup()
       const handle = repo.create()

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -485,6 +485,18 @@ describe("Repo", () => {
       )
     })
 
+    it("shutdown() closes the storage adapter", async () => {
+      let closed = 0
+      class ClosableStorage extends DummyStorageAdapter {
+        async close() {
+          closed++
+        }
+      }
+      const repo = new Repo({ storage: new ClosableStorage() })
+      await repo.shutdown()
+      assert.equal(closed, 1)
+    })
+
     it("exports a document", async () => {
       const { repo } = setup()
       const handle = repo.create<TestDoc>()

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -38,7 +38,7 @@ import { getRandomItem } from "./helpers/getRandomItem.js"
 import { TestDoc } from "./types.js"
 import { StorageId, StorageKey } from "../src/storage/types.js"
 import { DocumentProgress } from "../src/DocumentQuery.js"
-import { AbortError } from "../src/helpers/abortable.js"
+import { isAbortErrorLike } from "../src/helpers/abortable.js"
 
 describe("Repo", () => {
   describe("constructor", () => {
@@ -2534,7 +2534,7 @@ describe("Repo.find() abort behavior", () => {
 
     await expect(
       repo.find(generateAutomergeUrl(), { signal: controller.signal })
-    ).rejects.toThrow(AbortError)
+    ).rejects.toSatisfy(isAbortErrorLike)
   })
 
   it("can abort while waiting for ready state", async () => {
@@ -2548,14 +2548,19 @@ describe("Repo.find() abort behavior", () => {
     const findPromise = repo.find(url, { signal: controller.signal })
     controller.abort()
 
-    // Official specification just says to check `reason.name === "AbortError"`
-    // Using AbortError promotes correctness across different JS environments and provides a simpler check.
-    await expect(findPromise).rejects.toThrow(AbortError)
-    await expect(findPromise).rejects.rejects.toHaveProperty(
-      "name",
-      "AbortError"
-    )
-    await expect(findPromise).rejects.not.toThrow("unavailable")
+    await expect(findPromise).rejects.toSatisfy(isAbortErrorLike)
+  })
+
+  it("rejects with the provided abort reason", async () => {
+    const repo = new Repo()
+    const url = generateAutomergeUrl()
+    const controller = new AbortController()
+    const reason = new Error("caller cancelled")
+
+    const findPromise = repo.find(url, { signal: controller.signal })
+    controller.abort(reason)
+
+    await expect(findPromise).rejects.toBe(reason)
   })
 
   describe("creating a document with a custom ID factory", () => {

--- a/packages/automerge-repo/test/StorageSource.test.ts
+++ b/packages/automerge-repo/test/StorageSource.test.ts
@@ -111,4 +111,40 @@ describe("StorageSource", () => {
       vi.useRealTimers()
     }
   })
+
+  it("logs a failed save instead of leaking an unhandled rejection", async () => {
+    // A save runs fire-and-forget from the "heads-changed" listener. If the
+    // storage write rejects, the rejection must be caught and logged, not left
+    // to surface as an unhandled rejection.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      const documentId = parseAutomergeUrl(generateAutomergeUrl()).documentId
+
+      // An adapter whose save() always rejects (disk/IO error, quota, ...).
+      const adapter = new DummyStorageAdapter()
+      adapter.save = async () => {
+        throw new Error("simulated storage write failure")
+      }
+
+      const source = new StorageSource(new StorageSubsystem(adapter), 10)
+      const query = createTestQuery<TestDoc>(documentId)
+      source.attach(query as DocumentQuery<unknown>)
+
+      // A change triggers the throttled save, whose saveDoc rejects.
+      const changed = A.from({ foo: "bar" }) as A.Doc<unknown>
+      query.handle.update(() => changed)
+
+      // The failure must be caught and logged, not floated as a rejection.
+      await vi.waitFor(() =>
+        assert.ok(
+          errSpy.mock.calls.some(call =>
+            call.some(arg => String(arg).includes("Error saving document"))
+          ),
+          "the failed save should be caught and logged"
+        )
+      )
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
 })

--- a/packages/automerge-repo/test/SyncStateTracker.test.ts
+++ b/packages/automerge-repo/test/SyncStateTracker.test.ts
@@ -1,0 +1,57 @@
+import { next as A } from "@automerge/automerge"
+import assert from "assert"
+import { describe, it, vi } from "vitest"
+import { generateAutomergeUrl, parseAutomergeUrl } from "../src/AutomergeUrl.js"
+import type { DocHandle } from "../src/DocHandle.js"
+import { SyncStateTracker } from "../src/SyncStateTracker.js"
+import { StorageSubsystem } from "../src/storage/StorageSubsystem.js"
+import { DummyStorageAdapter } from "../src/helpers/DummyStorageAdapter.js"
+import type { StorageId } from "../src/storage/types.js"
+import type { SyncStatePayload } from "../src/synchronizer/Synchronizer.js"
+import type { PeerId } from "../src/types.js"
+
+describe("SyncStateTracker", () => {
+  it("logs a failed sync-state save instead of leaking an unhandled rejection", async () => {
+    // The throttled sync-state save runs fire-and-forget (its promise is
+    // discarded). If the storage write rejects, the rejection must be caught
+    // and logged, not left to surface as an unhandled rejection (which exits a
+    // Node sync server by default). Mirrors StorageSource's save path.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      // An adapter whose save() always rejects (disk/IO error, quota, ...).
+      const adapter = new DummyStorageAdapter()
+      adapter.save = async () => {
+        throw new Error("simulated storage write failure")
+      }
+
+      const tracker = new SyncStateTracker(new StorageSubsystem(adapter), 10)
+
+      // handleSyncState only touches `handle` to emit "remote-heads" after the
+      // save is scheduled, so a minimal stub is enough to exercise the save path.
+      const handle = { emit: () => true } as unknown as DocHandle<unknown>
+      const message: SyncStatePayload = {
+        peerId: "peer-1" as PeerId,
+        documentId: parseAutomergeUrl(generateAutomergeUrl()).documentId,
+        syncState: A.initSyncState(),
+      }
+      const peerMetadata = {
+        storageId: "storage-1" as StorageId,
+        isEphemeral: false,
+      }
+
+      tracker.handleSyncState(message, peerMetadata, handle)
+
+      // The failure must be caught and logged, not floated as a rejection.
+      await vi.waitFor(() =>
+        assert.ok(
+          errSpy.mock.calls.some(call =>
+            call.some(arg => String(arg).includes("Error saving sync state"))
+          ),
+          "the failed sync-state save should be caught and logged"
+        )
+      )
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
+})

--- a/packages/automerge-repo/test/pause.test.ts
+++ b/packages/automerge-repo/test/pause.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { pause } from "../src/helpers/pause.js"
-import { AbortError } from "../src/helpers/abortable.js"
+import { isAbortErrorLike } from "../src/helpers/abortable.js"
 
 describe("pause", () => {
   beforeEach(() => {
@@ -45,12 +45,12 @@ describe("pause", () => {
 
       await expect(
         pause(1000, { signal: controller.signal })
-      ).rejects.toBeInstanceOf(AbortError)
+      ).rejects.toSatisfy(isAbortErrorLike)
       // The abort fast-path returned before setTimeout was reached.
       expect(vi.getTimerCount()).toBe(before)
     })
 
-    it("rejects with AbortError and clears the timer when the signal aborts mid-pause", async () => {
+    it("rejects with the abort reason and clears the timer when the signal aborts mid-pause", async () => {
       const before = vi.getTimerCount()
       const controller = new AbortController()
       const p = pause(1000, { signal: controller.signal })
@@ -59,9 +59,20 @@ describe("pause", () => {
       await vi.advanceTimersByTimeAsync(20)
       controller.abort()
 
-      await expect(p).rejects.toBeInstanceOf(AbortError)
+      await expect(p).rejects.toSatisfy(isAbortErrorLike)
       // The pending 1000ms timer was cleared by the abort listener.
       expect(vi.getTimerCount()).toBe(before)
+    })
+
+    it("rejects with the provided abort reason", async () => {
+      const controller = new AbortController()
+      const reason = new Error("caller cancelled")
+      const p = pause(1000, { signal: controller.signal })
+
+      await vi.advanceTimersByTimeAsync(20)
+      controller.abort(reason)
+
+      await expect(p).rejects.toBe(reason)
     })
 
     it("aborting after the pause already resolved does not throw or re-settle", async () => {
@@ -87,7 +98,7 @@ describe("pause", () => {
       await vi.advanceTimersByTimeAsync(20)
       c2.abort() // abort via the second source
 
-      await expect(p).rejects.toBeInstanceOf(AbortError)
+      await expect(p).rejects.toSatisfy(isAbortErrorLike)
     })
   })
 })

--- a/packages/automerge-repo/test/subduction/RemoteHeads.test.ts
+++ b/packages/automerge-repo/test/subduction/RemoteHeads.test.ts
@@ -58,13 +58,19 @@ describe("subduction remote-heads forwarding", () => {
       storage: new DummyStorageAdapter(),
       network: [],
       subductionAdapters: [
-        { adapter: serverAdapter, serviceName: `localhost:${port}`, role: "accept" },
+        {
+          adapter: serverAdapter,
+          serviceName: `localhost:${port}`,
+          role: "accept",
+        },
       ],
       sharePolicy: async () => true,
     })
     cleanups.push(async () => {
       serverAdapter.disconnect()
-      await new Promise<void>((res, rej) => wss.close(e => (e ? rej(e) : res())))
+      await new Promise<void>((res, rej) =>
+        wss.close(e => (e ? rej(e) : res()))
+      )
     })
     return { repo, url: `ws://localhost:${port}` }
   }
@@ -96,10 +102,17 @@ describe("subduction remote-heads forwarding", () => {
       d.alice = "a"
     })
 
-    const events: Array<{ storageId: string; heads: UrlHeads; timestamp: number }> =
-      []
+    const events: Array<{
+      storageId: string
+      heads: UrlHeads
+      timestamp: number
+    }> = []
     aliceHandle.on("remote-heads", e =>
-      events.push({ storageId: e.storageId, heads: e.heads, timestamp: e.timestamp })
+      events.push({
+        storageId: e.storageId,
+        heads: e.heads,
+        timestamp: e.timestamp,
+      })
     )
 
     // Bob finds the doc, then makes a change. That change propagates

--- a/packages/automerge-repo/test/subduction/SubductionEvents.test.ts
+++ b/packages/automerge-repo/test/subduction/SubductionEvents.test.ts
@@ -98,7 +98,8 @@ describe("Subduction Repo events (sync-indicator surface)", () => {
 
     await waitFor(() => repo.isSubductionConnected(), 6000)
     await waitFor(
-      async () => (await repo.connectedSubductionPeerIds()).includes(server.peerId),
+      async () =>
+        (await repo.connectedSubductionPeerIds()).includes(server.peerId),
       6000
     )
     const peers = await repo.connectedSubductionPeerIds()
@@ -178,7 +179,7 @@ describe("Subduction Repo events (sync-indicator surface)", () => {
       subductionWebsocketEndpoints: [server.url],
     })
 
-    const events: Array<{ documentId: string; heads: string[] }> = [];
+    const events: Array<{ documentId: string; heads: string[] }> = []
     repo.on("subduction-remote-heads", e =>
       events.push({ documentId: e.documentId, heads: [...e.heads] })
     )
@@ -290,5 +291,7 @@ describe("Subduction Repo events (sync-indicator surface)", () => {
 })
 
 function sameHeadList(a: readonly string[], b: readonly string[]): boolean {
-  return a.length === b.length && [...a].sort().join("|") === [...b].sort().join("|")
+  return (
+    a.length === b.length && [...a].sort().join("|") === [...b].sort().join("|")
+  )
 }

--- a/packages/automerge-repo/test/throttle.test.ts
+++ b/packages/automerge-repo/test/throttle.test.ts
@@ -149,6 +149,32 @@ describe("asyncThrottle", () => {
     expect(ranWith).not.toContain(1) // fn(1) never ran — its pending timeout was cleared
     expect(ranWith).toEqual([2]) // ...and fn(2) ran in its place
   })
+
+  it("settles a superseded call's promise instead of orphaning it", async () => {
+    // Regression: previously a call whose pending timeout was cleared by a later
+    // call had its returned promise dropped — awaiting it hung forever. Now every
+    // coalesced caller (1 and 2, superseded by 3) settles with the winning run's
+    // result.
+    const throttled = asyncThrottle(async (x: number) => x * 10, 30)
+    const p1 = throttled(1) // superseded
+    const p2 = throttled(2) // superseded
+    const p3 = throttled(3) // wins
+    await vi.advanceTimersByTimeAsync(30)
+
+    expect(await Promise.all([p1, p2, p3])).toEqual([30, 30, 30])
+  })
+
+  it("propagates a rejection to every superseded caller", async () => {
+    const throttled = asyncThrottle(async (_x: number) => {
+      throw new Error("boom")
+    }, 30)
+    // Attach the rejection assertions synchronously (see the note in the
+    // "rejects" test above) so both handlers are in place before the fn runs.
+    const a1 = expect(throttled(1)).rejects.toThrow("boom")
+    const a2 = expect(throttled(2)).rejects.toThrow("boom")
+    await vi.advanceTimersByTimeAsync(30)
+    await Promise.all([a1, a2])
+  })
 })
 
 // -- Concurrency property ----------------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,9 +425,6 @@ importers:
       '@automerge/automerge-repo':
         specifier: workspace:*
         version: link:../automerge-repo
-      debug:
-        specifier: 'catalog:'
-        version: 4.4.3
       eventemitter3:
         specifier: 'catalog:'
         version: 5.0.4


### PR DESCRIPTION
Hi @expede, I put this together to merge the latest `main` into `subductionjs` and resolve the conflicts. Mostly I wanted to be helpful and to make sure the conflicts with my recent `main` changes landed in the spirit I intended, rather than getting resolved later without that context.

## What this does

Merges `main` into `subductionjs`. Only three files conflicted; everything else auto-merged.

**Conflict resolutions (kept both sides' intent):**

- `storage/StorageAdapterInterface.ts`: keep both subduction's `saveBatch()` and main's optional `close?()`. Independent additions; the conflict was positional.
- `Repo.ts` imports: drop the now-unused `AbortError` (`find()` picked up main's `signal.throwIfAborted()`, which auto-merged) and keep subduction's imports.
- `test/Repo.test.ts` imports: use main's `isAbortErrorLike` (the abort tests auto-merged to the new assertions) and keep subduction's `toSedimentreeId`.
- `Repo.ts` `shutdown()`: reconciled, see below.

**Two follow-on fixes so the merge is sound:**

1. **Storage teardown unified on `close?()`.** The merge left two teardown contracts: subduction's `Repo.#storage.dispose()` and main's `StorageSubsystem.close()` (which forwards to `adapter.close?()`). I unified on the interface method: `IndexedDBWorkerStorageAdapter` (and its inner worker-backed impl) now implement `close()` instead of `dispose()`, and `Repo.shutdown()` releases storage solely through `storageSubsystem.close()`.
2. **NetworkAdapter readiness rejection.** `NetworkAdapter`'s constructor wires `void this.whenReady().then(() => set("ready"))` with no rejection handler, so an adapter whose `whenReady()` rejects produced an unhandled rejection (a crash in Node). Bringing `main` in added the readiness regression test, which exposed it. Handled it with `noop` (the same shape as the Repo-side handling on `main`); the adapter stays `"connecting"` and the failure is surfaced separately. I also added a direct base-class regression test (`test/NetworkAdapter.test.ts`): a subclass whose `whenReady()` rejects stays `"connecting"` with no unhandled rejection, complementing the repo-level test from `main` that surfaced the leak.

**Housekeeping:**

- Formatted a handful of files that predated the `oxfmt --check` lint step this merge brings in (three subduction sources/tests and two react-remote-heads examples) so `pnpm lint` is green. Pure formatting, no code change, in a separate `style:` commit.

## Validation

`tsc` build plus `oxlint`/`oxfmt` are clean; `Repo.test.ts` (114), the new `NetworkAdapter.test.ts`, the worker-adapter tests, and `StorageSubsystem` tests pass with no unhandled rejection. I have not run the full `test/subduction/*` suite locally, so please lean on CI for that.

## Follow-up

Two follow-ups build on this branch (both draft and stacked on this PR, so it should merge first):

- #709 strengthens the subduction tests, replacing fixed `pause()` sleeps with event-driven waits.
- #710 bounds the compaction delete fan-out with a configurable `semaphore`.

Questions or comments, let me know. Happy to adjust any of these if they do not match how you would want them resolved.
