### PR TITLE
test(subduction): wait on signals instead of fixed sleeps (test-robustness pass)

### DIFF
--- a/packages/automerge-repo/test/helpers/awaitDoc.ts
+++ b/packages/automerge-repo/test/helpers/awaitDoc.ts
@@ -1,0 +1,20 @@
+import type { DocHandle } from "../../src/DocHandle.js"
+import { awaitEvent } from "./awaitEvent.js"
+
+/**
+ * Resolve once the handle's document satisfies `predicate`, driven by the
+ * handle's `heads-changed` event rather than a fixed sleep. Returns immediately
+ * if the predicate already holds. Pass `timeout` to bound the wait and reject
+ * with a clear error if it never holds; omit it to fall back on the enclosing
+ * test's own timeout.
+ */
+export async function awaitDoc<T>(
+  handle: DocHandle<T>,
+  predicate: (handle: DocHandle<T>) => boolean,
+  { timeout }: { timeout?: number } = {}
+): Promise<void> {
+  if (predicate(handle)) return
+  await awaitEvent(handle, "heads-changed", () => predicate(handle), {
+    timeout,
+  })
+}

--- a/packages/automerge-repo/test/helpers/awaitEvent.ts
+++ b/packages/automerge-repo/test/helpers/awaitEvent.ts
@@ -1,0 +1,34 @@
+/**
+ * Resolve when `emitter` fires `eventName` with an argument satisfying
+ * `predicate` (default: the next occurrence), returning that argument. This is
+ * the event-driven primitive the test waits should prefer: key off the signal
+ * the code already emits rather than polling for its effect.
+ *
+ * Pass `timeout` to bound the wait and reject with a clear error if no matching
+ * event arrives; omit it to fall back on the enclosing test's own timeout.
+ */
+export async function awaitEvent<T = unknown>(
+  emitter: { on(...args: any[]): void; off(...args: any[]): void },
+  eventName: string,
+  predicate: (arg: T) => boolean = () => true,
+  { timeout }: { timeout?: number } = {}
+): Promise<T> {
+  const { promise, resolve, reject } = Promise.withResolvers<T>()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const onEvent = (arg: T) => {
+    if (!predicate(arg)) return
+    emitter.off(eventName, onEvent)
+    if (timer != null) clearTimeout(timer)
+    resolve(arg)
+  }
+  emitter.on(eventName, onEvent)
+  if (timeout != null) {
+    timer = setTimeout(() => {
+      emitter.off(eventName, onEvent)
+      reject(
+        new Error(`awaitEvent("${eventName}") timed out after ${timeout}ms`)
+      )
+    }, timeout)
+  }
+  return promise
+}

--- a/packages/automerge-repo/test/helpers/awaitProgress.ts
+++ b/packages/automerge-repo/test/helpers/awaitProgress.ts
@@ -1,0 +1,38 @@
+import type { DocumentProgress } from "../../src/DocumentQuery.js"
+
+/**
+ * Resolve once a `findWithProgress` result satisfies `predicate`, driven by the
+ * progress object's `subscribe()` callbacks rather than polling `peek()`.
+ *
+ * Unlike `find()` / `whenReady()`, this tolerates a transient "unavailable"
+ * while a peer is still delivering the document: it simply keeps waiting for a
+ * later state that satisfies the predicate (e.g. "ready"). Pass `timeout` to
+ * bound the wait and reject with a clear error; omit it to fall back on the
+ * enclosing test's own timeout.
+ */
+export async function awaitProgress<T>(
+  progress: DocumentProgress<T>,
+  predicate: (state: ReturnType<DocumentProgress<T>["peek"]>) => boolean,
+  { timeout }: { timeout?: number } = {}
+): Promise<void> {
+  if (predicate(progress.peek())) return
+  const { promise, resolve, reject } = Promise.withResolvers<void>()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let unsubscribe = () => {}
+  const finish = (err?: Error) => {
+    unsubscribe()
+    if (timer != null) clearTimeout(timer)
+    if (err) reject(err)
+    else resolve()
+  }
+  unsubscribe = progress.subscribe(state => {
+    if (predicate(state)) finish()
+  })
+  if (timeout != null) {
+    timer = setTimeout(
+      () => finish(new Error(`awaitProgress timed out after ${timeout}ms`)),
+      timeout
+    )
+  }
+  await promise
+}

--- a/packages/automerge-repo/test/helpers/awaitSubductionConnected.ts
+++ b/packages/automerge-repo/test/helpers/awaitSubductionConnected.ts
@@ -1,0 +1,24 @@
+import type { Repo } from "../../src/Repo.js"
+import { awaitEvent } from "./awaitEvent.js"
+
+/**
+ * Resolve once the repo's subduction link is up, driven by the
+ * "subduction-connection" event rather than polling. Returns immediately if it
+ * is already connected.
+ *
+ * Only the connected case is offered: there is no prompt disconnect signal
+ * (clients reconnect lazily, so isSubductionConnected() does not flip promptly
+ * on a server outage), so awaiting a disconnect would be unreliable.
+ */
+export async function awaitSubductionConnected(
+  repo: Repo,
+  { timeout }: { timeout?: number } = {}
+): Promise<void> {
+  if (repo.isSubductionConnected()) return
+  await awaitEvent<{ connected: boolean }>(
+    repo,
+    "subduction-connection",
+    e => e.connected,
+    { timeout }
+  )
+}

--- a/packages/automerge-repo/test/helpers/awaitSyncedHandle.ts
+++ b/packages/automerge-repo/test/helpers/awaitSyncedHandle.ts
@@ -1,0 +1,28 @@
+import type { DocHandle } from "../../src/DocHandle.js"
+import type { DocumentProgress } from "../../src/DocumentQuery.js"
+import { awaitDoc } from "./awaitDoc.js"
+import { awaitProgress } from "./awaitProgress.js"
+
+/**
+ * Open a document that is still arriving from a peer and resolve once it is
+ * ready and its content satisfies `predicate`, returning the ready handle.
+ *
+ * Two steps, because they observe different signals: `progress.subscribe()`
+ * fires on query-state transitions (so it sees loading→ready and tolerates a
+ * transient "unavailable"), but not on doc-content changes once "ready" — so
+ * the content must be awaited on the handle's heads-changed event instead.
+ * Using `find()` here would instead reject on the transient "unavailable".
+ */
+export async function awaitSyncedHandle<T>(
+  progress: DocumentProgress<T>,
+  predicate: (handle: DocHandle<T>) => boolean = () => true,
+  { timeout }: { timeout?: number } = {}
+): Promise<DocHandle<T>> {
+  await awaitProgress(progress, s => s.state === "ready", { timeout })
+  const state = progress.peek()
+  if (state.state !== "ready") {
+    throw new Error(`expected "ready", got "${state.state}"`)
+  }
+  await awaitDoc(state.handle, predicate, { timeout })
+  return state.handle
+}

--- a/packages/automerge-repo/test/helpers/waitFor.ts
+++ b/packages/automerge-repo/test/helpers/waitFor.ts
@@ -1,11 +1,36 @@
-export async function waitFor(callback: () => void) {
+/**
+ * Poll `callback` until it runs without throwing, then resolve.
+ *
+ * The callback is the predicate: a thrown assertion (e.g. a failing `expect`)
+ * means "not ready yet", so it is caught and retried with backoff. When
+ * `timeout` is given, the wait is bounded and rejects on expiry with the last
+ * assertion's message (and `cause`), so a stuck wait fails fast and explains
+ * why. Omit `timeout` to keep the original unbounded behavior (the enclosing
+ * test's own timeout then applies).
+ */
+export async function waitFor(
+  callback: () => void | Promise<void>,
+  timeout?: number
+) {
+  const deadline = timeout == null ? undefined : Date.now() + timeout
   let sleepMs = 10
+  let lastError: unknown
   while (true) {
     try {
-      callback()
+      await callback()
       break
     } catch (e) {
-      sleepMs *= 2
+      lastError = e
+      if (deadline != null && Date.now() >= deadline) {
+        const reason =
+          lastError instanceof Error ? lastError.message : String(lastError)
+        throw new Error(`waitFor timed out after ${timeout}ms: ${reason}`, {
+          cause: lastError,
+        })
+      }
+      // Uncapped backoff when untimed (the original behavior other suites rely
+      // on); capped when bounded so the deadline is honored within ~100ms.
+      sleepMs = deadline == null ? sleepMs * 2 : Math.min(sleepMs * 2, 100)
       await new Promise(resolve => {
         setTimeout(resolve, sleepMs)
       })

--- a/packages/automerge-repo/test/subduction/AdapterTopology.test.ts
+++ b/packages/automerge-repo/test/subduction/AdapterTopology.test.ts
@@ -23,7 +23,11 @@ import { Repo } from "../../src/Repo.js"
 import { generateAutomergeUrl } from "../../src/AutomergeUrl.js"
 import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
 import { type PeerId } from "../../src/types.js"
-import { pause } from "../../src/helpers/pause.js"
+import { awaitDoc } from "../helpers/awaitDoc.js"
+import { awaitProgress } from "../helpers/awaitProgress.js"
+import { awaitSubductionConnected } from "../helpers/awaitSubductionConnected.js"
+import { awaitSyncedHandle } from "../helpers/awaitSyncedHandle.js"
+import { wait } from "../helpers/wait.js"
 import type { Policy } from "@automerge/automerge-subduction"
 
 // ── Test helpers ──────────────────────────────────────────────────────
@@ -137,19 +141,6 @@ function createClient(name: string, serverUrl: string): ClientPair {
   return { repo, adapter: clientAdapter }
 }
 
-async function waitForCondition(
-  fn: () => Promise<boolean> | boolean,
-  timeoutMs: number,
-  intervalMs = 50
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (await fn()) return
-    await pause(intervalMs)
-  }
-  throw new Error(`waitForCondition timed out after ${timeoutMs}ms`)
-}
-
 // ── Tests ─────────────────────────────────────────────────────────────
 
 describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
@@ -193,16 +184,12 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
     const progress = bob.repo.findWithProgress<{ title: string }>(
       aliceHandle.url
     )
-    await waitForCondition(() => {
-      const s = progress.peek()
-      return s.state === "ready" && s.handle.doc()?.title === "Hello from Alice"
-    }, 5000)
-
-    const result = progress.peek()
-    expect(result.state).toBe("ready")
-    if (result.state === "ready") {
-      expect(result.handle.doc()!.title).toBe("Hello from Alice")
-    }
+    const bobHandle = await awaitSyncedHandle(
+      progress,
+      h => h.doc()?.title === "Hello from Alice",
+      { timeout: 5000 }
+    )
+    expect(bobHandle.doc()!.title).toBe("Hello from Alice")
   }, 10_000)
 
   it("updates flow in both directions", async () => {
@@ -216,21 +203,23 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
       d.alice = "Alice was here"
     })
 
-    await pause(500)
-
-    const bobHandle = await bob.repo.find<{ alice: string; bob?: string }>(
-      aliceHandle.url
+    const bobProgress = bob.repo.findWithProgress<{
+      alice: string
+      bob?: string
+    }>(aliceHandle.url)
+    const bobHandle = await awaitSyncedHandle(
+      bobProgress,
+      h => h.doc()?.alice === "Alice was here",
+      { timeout: 5000 }
     )
-    expect(bobHandle.doc()!.alice).toBe("Alice was here")
 
     bobHandle.change(d => {
       d.bob = "Bob was here"
     })
 
-    await waitForCondition(
-      () => aliceHandle.doc()!.bob === "Bob was here",
-      5000
-    )
+    await awaitDoc(aliceHandle, h => h.doc()?.bob === "Bob was here", {
+      timeout: 5000,
+    })
   }, 10_000)
 
   // ── Document lifecycle ────────────────────────────────────────────
@@ -241,12 +230,14 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
 
     // Wait for the connection to be established so we're not just
     // racing against connection setup.
-    await pause(500)
+    await awaitSubductionConnected(alice.repo, { timeout: 5000 })
 
     const bogusUrl = generateAutomergeUrl()
     const progress = alice.repo.findWithProgress(bogusUrl)
 
-    await waitForCondition(() => progress.peek().state === "unavailable", 3000)
+    await awaitProgress(progress, s => s.state === "unavailable", {
+      timeout: 3000,
+    })
   }, 10_000)
 
   // ── Concurrent edits ──────────────────────────────────────────────
@@ -265,12 +256,13 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
       // initial empty state
     })
 
-    await pause(500)
-
-    const bobHandle = await bob.repo.find<{
+    const bobProgress = bob.repo.findWithProgress<{
       alice?: string
       bob?: string
     }>(aliceHandle.url)
+    const bobHandle = await awaitSyncedHandle(bobProgress, undefined, {
+      timeout: 5000,
+    })
 
     // Both edit simultaneously (different keys — no conflict)
     aliceHandle.change(d => {
@@ -280,12 +272,14 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
       d.bob = "bob-edit"
     })
 
-    await waitForCondition(
-      () =>
-        aliceHandle.doc()!.bob === "bob-edit" &&
-        bobHandle.doc()!.alice === "alice-edit",
-      5000
-    )
+    await Promise.all([
+      awaitDoc(aliceHandle, h => h.doc()?.bob === "bob-edit", {
+        timeout: 5000,
+      }),
+      awaitDoc(bobHandle, h => h.doc()?.alice === "alice-edit", {
+        timeout: 5000,
+      }),
+    ])
 
     expect(aliceHandle.doc()!.alice).toBe("alice-edit")
     expect(aliceHandle.doc()!.bob).toBe("bob-edit")
@@ -304,9 +298,12 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
       d.items = []
     })
 
-    await pause(500)
-
-    const bobHandle = await bob.repo.find<{ items: string[] }>(aliceHandle.url)
+    const bobProgress = bob.repo.findWithProgress<{ items: string[] }>(
+      aliceHandle.url
+    )
+    const bobHandle = await awaitSyncedHandle(bobProgress, undefined, {
+      timeout: 5000,
+    })
 
     for (let i = 0; i < 20; i++) {
       aliceHandle.change(d => {
@@ -314,7 +311,9 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
       })
     }
 
-    await waitForCondition(() => bobHandle.doc()!.items.length === 20, 5000)
+    await awaitDoc(bobHandle, h => (h.doc()?.items.length ?? 0) === 20, {
+      timeout: 5000,
+    })
 
     expect(bobHandle.doc()!.items).toHaveLength(20)
     expect(bobHandle.doc()!.items[0]).toBe("item-0")
@@ -337,17 +336,21 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
       d.before = "before outage"
     })
 
-    await pause(500)
-
-    const bobHandle = await bob.repo.find<{
+    const bobProgress = bob.repo.findWithProgress<{
       before?: string
       after?: string
     }>(aliceHandle.url)
-    expect(bobHandle.doc()!.before).toBe("before outage")
+    const bobHandle = await awaitSyncedHandle(
+      bobProgress,
+      h => h.doc()?.before === "before outage",
+      { timeout: 5000 }
+    )
 
-    // Kill the server and wait for clients to notice
+    // Kill, then restart. Clients reconnect lazily (no prompt disconnect
+    // signal), so a brief bounded pause; the post-restart sync below is the
+    // real check.
     await server.stop()
-    await pause(500)
+    await wait(500)
 
     // Restart on the same port, keeping storage
     await server.restart({ clearStorage: false })
@@ -358,10 +361,9 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
       d.after = "after outage"
     })
 
-    await waitForCondition(
-      () => bobHandle.doc()!.after === "after outage",
-      10_000
-    )
+    await awaitDoc(bobHandle, h => h.doc()?.after === "after outage", {
+      timeout: 10_000,
+    })
   }, 20_000)
 
   // ── Multiple documents ────────────────────────────────────────────
@@ -382,12 +384,18 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
       d.from = "bob"
     })
 
-    await pause(500)
-
-    const bobDocA = await bob.repo.find<{ from: string }>(docA.url)
+    const bobDocA = await awaitSyncedHandle(
+      bob.repo.findWithProgress<{ from: string }>(docA.url),
+      h => h.doc()?.from === "alice",
+      { timeout: 5000 }
+    )
     expect(bobDocA.doc()!.from).toBe("alice")
 
-    const aliceDocB = await alice.repo.find<{ from: string }>(docB.url)
+    const aliceDocB = await awaitSyncedHandle(
+      alice.repo.findWithProgress<{ from: string }>(docB.url),
+      h => h.doc()?.from === "bob",
+      { timeout: 5000 }
+    )
     expect(aliceDocB.doc()!.from).toBe("bob")
   }, 10_000)
 
@@ -424,7 +432,10 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
 
       const alice = startClient("alice", server.url)
       const bob = startClient("bob", server.url)
-      await pause(500)
+      await Promise.all([
+        awaitSubductionConnected(alice.repo, { timeout: 5000 }),
+        awaitSubductionConnected(bob.repo, { timeout: 5000 }),
+      ])
 
       // Alice pushes a doc (put is allowed).
       const aliceHandle = alice.repo.create<{ value: string }>()
@@ -432,14 +443,17 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
         d.value = "access granted"
       })
 
-      // Let Alice's push reach the server's WASM storage
-      await pause(1000)
+      // Let Alice's push reach the server's WASM storage. The server is a raw
+      // Subduction with no "stored" event to await, so this is a bounded wait.
+      await wait(1000)
 
-      // Bob requests the doc.
+      // Bob requests the doc; while the policy denies fetch it must NOT become
+      // ready. There is no "fetch denied" signal, so confirm over a bounded
+      // window.
       const progress = bob.repo.findWithProgress<{ value: string }>(
         aliceHandle.url
       )
-      await pause(1000)
+      await wait(1000)
       expect(progress.peek().state).not.toBe("ready")
 
       // Policy changes: Bob is now allowed.
@@ -448,12 +462,12 @@ describe("Subduction over NetworkAdapterInterface (WebSocket adapter)", () => {
       // Tell the client the share config changed.
       bob.repo.shareConfigChanged()
 
-      await waitForCondition(() => {
-        const s = progress.peek()
-        return s.state === "ready" && s.handle.doc()?.value === "access granted"
-      }, 5000)
-
-      expect(progress.peek().state).toBe("ready")
+      const bobHandle = await awaitSyncedHandle(
+        progress,
+        h => h.doc()?.value === "access granted",
+        { timeout: 5000 }
+      )
+      expect(bobHandle.doc()!.value).toBe("access granted")
     }
   )
 })

--- a/packages/automerge-repo/test/subduction/BlobInterceptor.test.ts
+++ b/packages/automerge-repo/test/subduction/BlobInterceptor.test.ts
@@ -12,7 +12,8 @@ import { type DocumentId, type PeerId } from "../../src/types.js"
 import { type BlobInterceptor } from "../../src/subduction/source.js"
 import { WebSocketTransport } from "../../src/subduction/websocket-transport.js"
 import { toSedimentreeId } from "../../src/subduction/helpers.js"
-import { pause } from "../../src/helpers/pause.js"
+import { waitFor } from "../helpers/waitFor.js"
+import { wait } from "../helpers/wait.js"
 
 const INTERCEPTOR_PREFIX = new Uint8Array([0xe2, 0xe2, 0xee, 0x01])
 
@@ -112,24 +113,11 @@ class TestServer {
   }
 }
 
-async function waitForCondition(
-  fn: () => Promise<boolean> | boolean,
-  timeoutMs: number,
-  intervalMs = 50
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (await fn()) return
-    await pause(intervalMs)
-  }
-  throw new Error(`waitForCondition timed out after ${timeoutMs}ms`)
-}
-
 async function waitForBlobs(server: TestServer, documentId: DocumentId) {
   const sid = toSedimentreeId(documentId)
-  await waitForCondition(async () => {
+  await waitFor(async () => {
     const blobs = await server.subduction.getBlobs(sid)
-    return blobs !== undefined && blobs.length > 0
+    expect(blobs?.length ?? 0).toBeGreaterThan(0)
   }, 5000)
 }
 
@@ -195,7 +183,10 @@ describe("BlobInterceptor", () => {
       d.text = "check id"
     })
 
-    await waitForCondition(() => interceptor.outgoingCount > 0, 5000)
+    await waitFor(
+      () => expect(interceptor.outgoingCount).toBeGreaterThan(0),
+      5000
+    )
 
     expect(interceptor.documentIds.length).toBeGreaterThan(0)
     for (const id of interceptor.documentIds) {
@@ -222,7 +213,7 @@ describe("BlobInterceptor", () => {
       d.text = "should not crash"
     })
 
-    await waitForCondition(() => callCount > 0, 5000)
+    await waitFor(() => expect(callCount).toBeGreaterThan(0), 5000)
 
     const sid = toSedimentreeId(handle.documentId)
     const blobs = await server.subduction.getBlobs(sid)
@@ -307,7 +298,7 @@ describe("BlobInterceptor delayed server policy", () => {
     })
 
     // Wait for at least one sync attempt to fail (policy denies).
-    await pause(1500)
+    await wait(1500)
 
     // Verify blobs are NOT on the server yet.
     const sid = toSedimentreeId(handle.documentId)
@@ -318,9 +309,9 @@ describe("BlobInterceptor delayed server policy", () => {
     policyAllowed = true
 
     // The heal scheduler should retry and push the blobs.
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await server.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 15_000)
 
     const blobs = (await server.subduction.getBlobs(sid))!
@@ -363,16 +354,16 @@ describe("BlobInterceptor delayed server policy", () => {
     })
 
     // Wait for initial sync attempts to fail.
-    await pause(1500)
+    await wait(1500)
 
     // Enable the policy (authorization state has arrived on the server).
     policyAllowed = true
 
     // Wait for sender's blobs to reach the server via heal retry.
     const sid = toSedimentreeId(senderHandle.documentId)
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await server.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 15_000)
 
     // Now create the receiver. The server has the blobs and

--- a/packages/automerge-repo/test/subduction/BlobLoadDedup.test.ts
+++ b/packages/automerge-repo/test/subduction/BlobLoadDedup.test.ts
@@ -18,7 +18,8 @@ import {
 } from "@automerge/automerge-subduction"
 import { Repo } from "../../src/Repo.js"
 import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
-import { pause } from "../../src/helpers/pause.js"
+import { awaitDoc } from "../helpers/awaitDoc.js"
+import { waitFor } from "../helpers/waitFor.js"
 import { initSubduction } from "../../src/initSubduction.js"
 import { toSedimentreeId } from "../../src/subduction/helpers.js"
 import { WebSocketTransport } from "../../src/subduction/websocket-transport.js"
@@ -27,19 +28,6 @@ import type { PeerId } from "../../src/types.js"
 beforeAll(async () => {
   await initSubduction()
 })
-
-async function waitForCondition(
-  fn: () => Promise<boolean>,
-  timeoutMs: number,
-  intervalMs = 200
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (await fn()) return
-    await pause(intervalMs)
-  }
-  throw new Error(`waitForCondition timed out after ${timeoutMs}ms`)
-}
 
 async function startSubductionServer(listenPort = 0): Promise<{
   url: string
@@ -106,9 +94,9 @@ describe("SubductionSource blob load deduplication", () => {
     })
 
     const sid = toSedimentreeId(handle.documentId)
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await server.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 5000)
 
     const reader = createClientRepo("reader", server.url)
@@ -137,9 +125,9 @@ describe("SubductionSource blob load deduplication", () => {
     })
 
     const sid = toSedimentreeId(handle.documentId)
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await server.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 5000)
 
     const reader = createClientRepo("reader", server.url)
@@ -150,6 +138,6 @@ describe("SubductionSource blob load deduplication", () => {
       d.count = 2
     })
 
-    await waitForCondition(async () => fetched.doc()?.count === 2, 5000)
+    await awaitDoc(fetched, h => h.doc()?.count === 2, { timeout: 5000 })
   })
 })

--- a/packages/automerge-repo/test/subduction/Policy.test.ts
+++ b/packages/automerge-repo/test/subduction/Policy.test.ts
@@ -13,7 +13,7 @@ import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
 import { type PeerId } from "../../src/types.js"
 import { toSedimentreeId } from "../../src/subduction/helpers.js"
 import { WebSocketTransport } from "../../src/subduction/websocket-transport.js"
-import { pause } from "../../src/helpers/pause.js"
+import { waitFor } from "../helpers/waitFor.js"
 
 interface TestServer {
   port: number
@@ -122,10 +122,16 @@ describe("SubductionPolicy", () => {
       d.value = 1
     })
 
+    // Poll the server's storage directly rather than awaiting a sync event: the
+    // system under test here is the policy, and the obvious event
+    // (subduction-remote-heads) is gated by authorizeFetch -- awaiting it would
+    // couple this test's synchronization to the policy under test. A bounded
+    // getBlobs poll is an independent end-state check. (Same below and in the
+    // other policy-bearing suites.)
     const sid = toSedimentreeId(handle.documentId)
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await server.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 5000)
 
     expect(policy.spies.authorizeConnect).toHaveBeenCalled()
@@ -149,9 +155,9 @@ describe("SubductionPolicy", () => {
     })
 
     const sid = toSedimentreeId(handle.documentId)
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await server.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 5000)
 
     // The client-side policy should have been invoked during the sync.
@@ -188,12 +194,9 @@ describe("SubductionPolicy", () => {
       d.value = "should not arrive"
     })
 
-    // Give ample time for sync attempts
-    await pause(3000)
-
     // Verify the policy was actually invoked (not a false positive from
     // a connection failure preventing data from ever reaching the server).
-    expect(authorizePutSpy).toHaveBeenCalled()
+    await waitFor(() => expect(authorizePutSpy).toHaveBeenCalled(), 5000)
 
     // The server should NOT have any blobs for this document
     const sid = toSedimentreeId(handle.documentId)
@@ -201,16 +204,3 @@ describe("SubductionPolicy", () => {
     expect(blobs?.length ?? 0).toBe(0)
   }, 10_000)
 })
-
-async function waitForCondition(
-  fn: () => Promise<boolean>,
-  timeoutMs: number,
-  intervalMs = 200
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (await fn()) return
-    await pause(intervalMs)
-  }
-  throw new Error(`waitForCondition timed out after ${timeoutMs}ms`)
-}

--- a/packages/automerge-repo/test/subduction/RecomputeCoalescing.test.ts
+++ b/packages/automerge-repo/test/subduction/RecomputeCoalescing.test.ts
@@ -36,7 +36,6 @@ vi.mock("../../src/helpers/yield.js", async importOriginal => {
 
 import { Repo } from "../../src/Repo.js"
 import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
-import { pause } from "../../src/helpers/pause.js"
 import { initSubduction } from "../../src/initSubduction.js"
 import type { PeerId } from "../../src/types.js"
 
@@ -80,9 +79,10 @@ describe("SubductionSource recompute coalescing", () => {
   }
 
   it("coalesces a synchronous burst of attaches into O(1) walks", async () => {
-    // Construct with real timers: subduction's async init awaits real I/O.
+    // Await subduction's ready promise (the API's init signal) before
+    // installing fake timers, rather than guessing with a fixed sleep.
     const repo = makeRepo()
-    await pause(100)
+    await repo.subduction
 
     vi.useFakeTimers()
     try {
@@ -113,7 +113,7 @@ describe("SubductionSource recompute coalescing", () => {
 
   it("schedules a fresh walk for requests arriving after a walk completed", async () => {
     const repo = makeRepo()
-    await pause(100)
+    await repo.subduction
 
     vi.useFakeTimers()
     try {

--- a/packages/automerge-repo/test/subduction/RemoteHeads.test.ts
+++ b/packages/automerge-repo/test/subduction/RemoteHeads.test.ts
@@ -13,7 +13,8 @@ import { Repo } from "../../src/Repo.js"
 import { encodeHeads } from "../../src/AutomergeUrl.js"
 import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
 import { initSubduction } from "../../src/initSubduction.js"
-import { pause } from "../../src/helpers/pause.js"
+import { awaitDoc } from "../helpers/awaitDoc.js"
+import { waitFor } from "../helpers/waitFor.js"
 import type { PeerId, UrlHeads } from "../../src/types.js"
 
 beforeAll(async () => {
@@ -25,19 +26,6 @@ const sameSet = (a: readonly string[], b: readonly string[]) =>
 
 const headsOf = (handle: { doc(): unknown }): UrlHeads =>
   encodeHeads(A.getHeads(handle.doc() as A.Doc<unknown>))
-
-async function waitFor(
-  fn: () => boolean | Promise<boolean>,
-  timeoutMs: number,
-  intervalMs = 50
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (await fn()) return
-    await pause(intervalMs)
-  }
-  throw new Error(`waitFor timed out after ${timeoutMs}ms`)
-}
 
 describe("subduction remote-heads forwarding", () => {
   const cleanups: Array<() => void | Promise<void>> = []
@@ -127,13 +115,13 @@ describe("subduction remote-heads forwarding", () => {
     })
 
     // Bidirectional sync lands bob's change on alice.
-    await waitFor(() => aliceHandle.doc()?.bob === "b", 8000)
+    await awaitDoc(aliceHandle, h => h.doc()?.bob === "b", { timeout: 8000 })
 
     // Alice eventually receives a remote-heads event whose heads equal her
     // (now fully-synced) doc heads.
     await waitFor(() => {
       const want = headsOf(aliceHandle)
-      return events.some(e => sameSet(e.heads, want))
+      expect(events.some(e => sameSet(e.heads, want))).toBe(true)
     }, 8000)
 
     const want = headsOf(aliceHandle)
@@ -171,13 +159,14 @@ describe("subduction remote-heads forwarding", () => {
     bobHandle.change(d => {
       d.bob = "b"
     })
-    await waitFor(() => aliceHandle.doc()?.bob === "b", 8000)
+    await awaitDoc(aliceHandle, h => h.doc()?.bob === "b", { timeout: 8000 })
 
     // Wait until the server has advertised alice's current heads back to her.
     await waitFor(() => {
-      if (!serverStorageId) return false
-      const info = aliceHandle.getSyncInfo(serverStorageId as any)
-      return !!info && sameSet(info.lastHeads, headsOf(aliceHandle))
+      const info = serverStorageId
+        ? aliceHandle.getSyncInfo(serverStorageId as any)
+        : undefined
+      expect(!!info && sameSet(info.lastHeads, headsOf(aliceHandle))).toBe(true)
     }, 8000)
 
     // We hold our own heads, and everything the server has advertised.
@@ -212,10 +201,10 @@ describe("subduction remote-heads forwarding", () => {
     bobHandle.change(d => {
       d.bob = "b"
     })
-    await waitFor(() => aliceHandle.doc()?.bob === "b", 8000)
-    await waitFor(() => captured !== undefined, 8000)
+    await awaitDoc(aliceHandle, h => h.doc()?.bob === "b", { timeout: 8000 })
+    await waitFor(() => expect(captured).toBeDefined(), 8000)
     // Let the fire-and-forget saveRemoteHeads land in the shared adapter.
-    await pause(300)
+    await alice.repo.flush()
 
     const expected = captured!
 
@@ -233,7 +222,7 @@ describe("subduction remote-heads forwarding", () => {
     const handle = await reloaded.find(url)
 
     await waitFor(
-      () => handle.getSyncInfo(expected.storageId as any) !== undefined,
+      () => expect(handle.getSyncInfo(expected.storageId as any)).toBeDefined(),
       8000
     )
     const info = handle.getSyncInfo(expected.storageId as any)!

--- a/packages/automerge-repo/test/subduction/SaveResilience.test.ts
+++ b/packages/automerge-repo/test/subduction/SaveResilience.test.ts
@@ -29,6 +29,7 @@ import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
 import { initSubduction } from "../../src/initSubduction.js"
 import type { Chunk, StorageKey } from "../../src/storage/types.js"
 import type { StorageAdapterInterface } from "../../src/storage/StorageAdapterInterface.js"
+import { waitFor } from "../helpers/waitFor.js"
 
 beforeAll(async () => {
   await initSubduction()
@@ -114,7 +115,10 @@ describe("SubductionSource #save resilience", () => {
 
       // Wait until at least one save attempt has been made — we
       // detect that by polling for pending storage writes.
-      await waitForCondition(() => storage.pendingCount() > 0, 5_000)
+      await waitFor(
+        () => expect(storage.pendingCount()).toBeGreaterThan(0),
+        5000
+      )
 
       // THEN releasing the storage allows the save to drain. If
       // `saveInProgress` were leaking (e.g., because `try/finally`
@@ -162,7 +166,10 @@ describe("SubductionSource #save resilience", () => {
 
       // Wait for at least one rejection to confirm we're actually
       // exercising the rejection path.
-      await waitForCondition(() => storage.rejectionCount > 0, 5_000)
+      await waitFor(
+        () => expect(storage.rejectionCount).toBeGreaterThan(0),
+        5000
+      )
 
       // Make a SECOND change. If `saveInProgress` were stuck `true`
       // from the first failed save, the throttle's next firing
@@ -174,9 +181,12 @@ describe("SubductionSource #save resilience", () => {
       handle.change(d => {
         d.count = 2
       })
-      await waitForCondition(
-        () => storage.rejectionCount > rejectionsBeforeSecondChange,
-        5_000
+      await waitFor(
+        () =>
+          expect(storage.rejectionCount).toBeGreaterThan(
+            rejectionsBeforeSecondChange
+          ),
+        5000
       )
 
       expect(storage.rejectionCount).toBeGreaterThan(
@@ -213,13 +223,19 @@ describe("SubductionSource #save resilience", () => {
       //
       // We force the second save by issuing another mutation after
       // the first rejection lands.
-      await waitForCondition(() => storage.rejectionCount >= 1, 5_000)
+      await waitFor(
+        () => expect(storage.rejectionCount).toBeGreaterThanOrEqual(1),
+        5000
+      )
 
       handle.change(d => {
         d.count = 2
       })
 
-      await waitForCondition(() => storage.rejectionCount >= 2, 5_000)
+      await waitFor(
+        () => expect(storage.rejectionCount).toBeGreaterThanOrEqual(2),
+        5000
+      )
 
       // After two rejections the gate flips and subsequent writes
       // succeed. A final mutation triggers a save that lands.
@@ -439,17 +455,4 @@ class TransientlyRejectingStorageAdapter implements StorageAdapterInterface {
     }
     return this.#inner.saveBatch(entries)
   }
-}
-
-async function waitForCondition(
-  fn: () => boolean,
-  timeoutMs: number,
-  intervalMs = 25
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (fn()) return
-    await new Promise(r => setTimeout(r, intervalMs))
-  }
-  throw new Error(`waitForCondition timed out after ${timeoutMs}ms`)
 }

--- a/packages/automerge-repo/test/subduction/SubductionEvents.test.ts
+++ b/packages/automerge-repo/test/subduction/SubductionEvents.test.ts
@@ -17,19 +17,21 @@ import { Repo } from "../../src/Repo.js"
 import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
 import { type PeerId } from "../../src/types.js"
 import { WebSocketTransport } from "../../src/subduction/websocket-transport.js"
-import { pause } from "../../src/helpers/pause.js"
+import { awaitDoc } from "../helpers/awaitDoc.js"
+import { awaitEvent } from "../helpers/awaitEvent.js"
+import { awaitSubductionConnected } from "../helpers/awaitSubductionConnected.js"
+import { awaitSyncedHandle } from "../helpers/awaitSyncedHandle.js"
+import { wait } from "../helpers/wait.js"
 
-async function waitFor(
-  fn: () => boolean | Promise<boolean>,
-  timeoutMs: number,
-  intervalMs = 25
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (await fn()) return
-    await pause(intervalMs)
-  }
-  throw new Error(`waitFor timed out after ${timeoutMs}ms`)
+interface RemoteHeadsEvent {
+  documentId: string
+  storageId: string
+  heads: string[]
+}
+
+/** Resolve once the repo's subduction link is up, driven by the event. */
+async function awaitConnected(repo: Repo, timeout = 6000): Promise<void> {
+  await awaitSubductionConnected(repo, { timeout })
 }
 
 describe("Subduction Repo events (sync-indicator surface)", () => {
@@ -81,7 +83,8 @@ describe("Subduction Repo events (sync-indicator surface)", () => {
     const events: boolean[] = []
     repo.on("subduction-connection", ({ connected }) => events.push(connected))
 
-    await waitFor(() => repo.isSubductionConnected(), 6000)
+    await awaitConnected(repo)
+    expect(repo.isSubductionConnected()).toBe(true)
     expect(events.at(-1)).toBe(true)
     expect(events).toContain(true)
   }, 15_000)
@@ -96,12 +99,7 @@ describe("Subduction Repo events (sync-indicator surface)", () => {
       subductionWebsocketEndpoints: [server.url],
     })
 
-    await waitFor(() => repo.isSubductionConnected(), 6000)
-    await waitFor(
-      async () =>
-        (await repo.connectedSubductionPeerIds()).includes(server.peerId),
-      6000
-    )
+    await awaitConnected(repo)
     const peers = await repo.connectedSubductionPeerIds()
     expect(peers).toContain(server.peerId)
   }, 15_000)
@@ -122,48 +120,30 @@ describe("Subduction Repo events (sync-indicator surface)", () => {
     const alice = makeWorker("alice")
     const bob = makeWorker("bob")
 
-    const events: Array<{
-      documentId: string
-      storageId: string
-      heads: string[]
-    }> = []
-    bob.on("subduction-remote-heads", e =>
-      events.push({
-        documentId: e.documentId,
-        storageId: e.storageId,
-        heads: [...e.heads],
-      })
-    )
-
-    await waitFor(
-      () => alice.isSubductionConnected() && bob.isSubductionConnected(),
-      6000
-    )
+    await Promise.all([awaitConnected(alice), awaitConnected(bob)])
 
     const handle = alice.create<{ title: string }>()
     handle.change(d => {
       d.title = "hello"
     })
 
+    // Subscribe to the server's heads advertisement before opening the doc, so
+    // the event is not missed if it fires during the sync below.
+    const remoteHeads = awaitEvent<RemoteHeadsEvent>(
+      bob,
+      "subduction-remote-heads",
+      e => e.documentId === handle.documentId && e.heads.length > 0,
+      { timeout: 8000 }
+    )
+
     // Bob opens the doc; syncing with the server makes the server advertise its
     // heads to Bob, surfacing onRemoteHeads → the event.
     const bobProgress = bob.findWithProgress<{ title: string }>(handle.url)
-    await waitFor(() => {
-      const s = bobProgress.peek()
-      return s.state === "ready" && s.handle.doc()?.title === "hello"
-    }, 8000)
+    await awaitSyncedHandle(bobProgress, h => h.doc()?.title === "hello", {
+      timeout: 8000,
+    })
 
-    await waitFor(
-      () =>
-        events.some(
-          e => e.documentId === handle.documentId && e.heads.length > 0
-        ),
-      6000
-    )
-
-    const ours = events.find(
-      e => e.documentId === handle.documentId && e.heads.length > 0
-    )!
+    const ours = await remoteHeads
     expect(ours.storageId).toBeTruthy() // the server's verifying-key peer id
     expect(ours.heads).toEqual(handle.heads())
   }, 20_000)
@@ -179,12 +159,7 @@ describe("Subduction Repo events (sync-indicator surface)", () => {
       subductionWebsocketEndpoints: [server.url],
     })
 
-    const events: Array<{ documentId: string; heads: string[] }> = []
-    repo.on("subduction-remote-heads", e =>
-      events.push({ documentId: e.documentId, heads: [...e.heads] })
-    )
-
-    await waitFor(() => repo.isSubductionConnected(), 6000)
+    await awaitConnected(repo)
 
     const handle = repo.create<{ n: number }>()
     handle.change(d => {
@@ -193,22 +168,15 @@ describe("Subduction Repo events (sync-indicator surface)", () => {
 
     // After we push, the server should advertise our heads back, so the event
     // reports heads equal to our current local heads.
-    await waitFor(
-      () =>
-        events.some(
-          e =>
-            e.documentId === handle.documentId &&
-            sameHeadList(e.heads, handle.heads())
-        ),
-      8000
+    const ev = await awaitEvent<RemoteHeadsEvent>(
+      repo,
+      "subduction-remote-heads",
+      e =>
+        e.documentId === handle.documentId &&
+        sameHeadList(e.heads, handle.heads()),
+      { timeout: 8000 }
     )
-    expect(
-      events.some(
-        e =>
-          e.documentId === handle.documentId &&
-          sameHeadList(e.heads, handle.heads())
-      )
-    ).toBe(true)
+    expect(sameHeadList(ev.heads, handle.heads())).toBe(true)
   }, 20_000)
 
   it("resyncSubduction is a no-op for a document this repo has not attached", async () => {
@@ -227,8 +195,9 @@ describe("Subduction Repo events (sync-indicator surface)", () => {
       sharePolicy: async () => true,
       subductionWebsocketEndpoints: [server.url],
     })
-
-    await waitFor(() => a.isSubductionConnected(), 6000)
+    // Await both repos: leaving one mid-connection lets afterEach close the
+    // server while a socket is still settling, which wedges the close.
+    await Promise.all([awaitConnected(a), awaitConnected(b)])
 
     // A well-formed documentId attached on `b` but never on `a`: resyncing it
     // on `a` must hit the unknown-entry early return rather than throw.
@@ -257,10 +226,7 @@ describe("Subduction Repo events (sync-indicator surface)", () => {
     const pusher = makeWorker("pusher")
     const reader = makeWorker("reader")
 
-    await waitFor(
-      () => pusher.isSubductionConnected() && reader.isSubductionConnected(),
-      6000
-    )
+    await Promise.all([awaitConnected(pusher), awaitConnected(reader)])
 
     const handle = pusher.create<{ n: number }>()
     handle.change(d => {
@@ -268,25 +234,29 @@ describe("Subduction Repo events (sync-indicator surface)", () => {
     })
 
     const readerDoc = reader.findWithProgress<{ n: number }>(handle.url)
-    const peekN = (): number | undefined => {
-      const s = readerDoc.peek()
-      return s.state === "ready" ? s.handle.doc()?.n : undefined
-    }
-    await waitFor(() => peekN() === 1, 8000)
+    const readerHandle = await awaitSyncedHandle(
+      readerDoc,
+      h => h.doc()?.n === 1,
+      { timeout: 8000 }
+    )
 
     // Force a fresh sync round on the already-"succeeded" reader entry. The
     // value must stay put and the link must remain up.
     reader.resyncSubduction(handle.documentId)
-    await pause(500)
-    expect(peekN()).toBe(1)
+    // Steady-state assertion: a resync must not change an already-synced value.
+    // No "resync settled" event is exposed and the round runs over real
+    // WebSocket + Wasm (so fake timers don't apply), so confirm over a short
+    // bounded window. The change below also proves the link stayed live.
+    await wait(500)
+    expect(readerHandle.doc()?.n).toBe(1)
     expect(reader.isSubductionConnected()).toBe(true)
 
     // The entry is still live after the re-arm, so a later change propagates.
     handle.change(d => {
       d.n = 2
     })
-    await waitFor(() => peekN() === 2, 8000)
-    expect(peekN()).toBe(2)
+    await awaitDoc(readerHandle, h => h.doc()?.n === 2, { timeout: 8000 })
+    expect(readerHandle.doc()?.n).toBe(2)
   }, 30_000)
 })
 

--- a/packages/automerge-repo/test/subduction/Topology.test.ts
+++ b/packages/automerge-repo/test/subduction/Topology.test.ts
@@ -27,7 +27,12 @@ import { type StorageId } from "../../src/storage/types.js"
 import { type DocHandleRemoteHeadsPayload } from "../../src/DocHandle.js"
 import { WebSocketTransport } from "../../src/subduction/websocket-transport.js"
 import { toSedimentreeId } from "../../src/subduction/helpers.js"
-import { pause } from "../../src/helpers/pause.js"
+import { awaitDoc } from "../helpers/awaitDoc.js"
+import { awaitEvent } from "../helpers/awaitEvent.js"
+import { awaitProgress } from "../helpers/awaitProgress.js"
+import { awaitSyncedHandle } from "../helpers/awaitSyncedHandle.js"
+import { waitFor } from "../helpers/waitFor.js"
+import { wait } from "../helpers/wait.js"
 
 // ── Test helpers ──────────────────────────────────────────────────────
 
@@ -149,19 +154,6 @@ function makeTabWorkerPair(
   return { tab, worker, channel }
 }
 
-async function waitForCondition(
-  fn: () => Promise<boolean> | boolean,
-  timeoutMs: number,
-  intervalMs = 50
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (await fn()) return
-    await pause(intervalMs)
-  }
-  throw new Error(`waitForCondition timed out after ${timeoutMs}ms`)
-}
-
 // ── Tests ─────────────────────────────────────────────────────────────
 
 describe("Tab → Worker → Server topology", () => {
@@ -203,14 +195,11 @@ describe("Tab → Worker → Server topology", () => {
       d.title = "Hello from Alice"
     })
 
-    // Wait for Alice's data to reach the server before Bob tries to find it
-    const sid = toSedimentreeId(aliceHandle.documentId)
-    await waitForCondition(async () => {
-      const blobs = await server.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
-    }, 5000)
-
-    const bobHandle = await pair2.tab.find<{ title: string }>(aliceHandle.url)
+    const bobHandle = await awaitSyncedHandle(
+      pair2.tab.findWithProgress<{ title: string }>(aliceHandle.url),
+      h => h.doc()?.title === "Hello from Alice",
+      { timeout: 5000 }
+    )
 
     expect(bobHandle.doc()!.title).toBe("Hello from Alice")
   }, 10_000)
@@ -226,19 +215,21 @@ describe("Tab → Worker → Server topology", () => {
       d.alice = "Alice was here"
     })
 
-    await pause(500)
-
-    const bobHandle = await pair2.tab.find<{ alice: string; bob?: string }>(
-      aliceHandle.url
+    const bobHandle = await awaitSyncedHandle(
+      pair2.tab.findWithProgress<{ alice: string; bob?: string }>(
+        aliceHandle.url
+      ),
+      h => h.doc()?.alice === "Alice was here",
+      { timeout: 5000 }
     )
-    expect(bobHandle.doc()!.alice).toBe("Alice was here")
 
     bobHandle.change(d => {
       d.bob = "Bob was here"
     })
 
-    await pause(500)
-
+    await awaitDoc(aliceHandle, h => h.doc()?.bob === "Bob was here", {
+      timeout: 5000,
+    })
     expect(aliceHandle.doc()!.bob).toBe("Bob was here")
   }, 10_000)
 
@@ -257,7 +248,9 @@ describe("Tab → Worker → Server topology", () => {
       aliceHandle.url
     )
 
-    await pause(500)
+    await awaitProgress(bobProgress, s => s.state === "unavailable", {
+      timeout: 5000,
+    })
     expect(bobProgress.peek().state).toBe("unavailable")
 
     // Connect new pairs via a server
@@ -271,10 +264,10 @@ describe("Tab → Worker → Server topology", () => {
       d.value = 123
     })
 
-    await pause(500)
-
-    const bobHandle2 = await pair2c.tab.find<{ value: number }>(
-      aliceHandle2.url
+    const bobHandle2 = await awaitSyncedHandle(
+      pair2c.tab.findWithProgress<{ value: number }>(aliceHandle2.url),
+      h => h.doc()?.value === 123,
+      { timeout: 5000 }
     )
     expect(bobHandle2.doc()!.value).toBe(123)
   }, 10_000)
@@ -289,8 +282,9 @@ describe("Tab → Worker → Server topology", () => {
       d.value = "created offline"
     })
 
-    // Wait for tab → worker sync via messagechannel
-    await pause(200)
+    // Wait for tab → worker sync via messagechannel. This local sync has no
+    // exposed completion signal, so it is a bounded wait.
+    await wait(200)
 
     // Now start server and create a connected worker for Alice
     // (simulating the worker establishing its websocket connection)
@@ -304,12 +298,14 @@ describe("Tab → Worker → Server topology", () => {
       d.value = "created offline"
     })
 
-    await pause(500)
-
     // Another user can find it
     const pair2 = createTabWorkerPair("bob", server.url)
 
-    const bobHandle = await pair2.tab.find<{ value: string }>(aliceHandle2.url)
+    const bobHandle = await awaitSyncedHandle(
+      pair2.tab.findWithProgress<{ value: string }>(aliceHandle2.url),
+      h => h.doc()?.value === "created offline",
+      { timeout: 5000 }
+    )
     expect(bobHandle.doc()!.value).toBe("created offline")
   }, 10_000)
 
@@ -323,7 +319,13 @@ describe("Tab → Worker → Server topology", () => {
       d.data = "important"
     })
 
-    await pause(500)
+    // Confirm Alice's doc reached the server before the wipe, so the restart
+    // actually clears it.
+    const sid = toSedimentreeId(aliceHandle.documentId)
+    await waitFor(async () => {
+      const blobs = await server.subduction.getBlobs(sid)
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
+    }, 5000)
 
     // Restart with fresh storage — Alice's doc is gone
     await server.restart()
@@ -335,10 +337,9 @@ describe("Tab → Worker → Server topology", () => {
       aliceHandle.url
     )
 
-    await waitForCondition(
-      () => bobProgress.peek().state === "unavailable",
-      3000
-    )
+    await awaitProgress(bobProgress, s => s.state === "unavailable", {
+      timeout: 3000,
+    })
   }, 10_000)
 
   // ── Concurrent edits ──────────────────────────────────────────────
@@ -358,13 +359,15 @@ describe("Tab → Worker → Server topology", () => {
       // initial empty state
     })
 
-    await pause(500)
-
     // Bob finds it
-    const bobHandle = await pair2.tab.find<{
-      alice?: string
-      bob?: string
-    }>(aliceHandle.url)
+    const bobHandle = await awaitSyncedHandle(
+      pair2.tab.findWithProgress<{
+        alice?: string
+        bob?: string
+      }>(aliceHandle.url),
+      undefined,
+      { timeout: 5000 }
+    )
 
     // Both edit simultaneously (different keys — no conflict)
     aliceHandle.change(d => {
@@ -375,12 +378,14 @@ describe("Tab → Worker → Server topology", () => {
     })
 
     // Wait for changes to propagate both ways
-    await waitForCondition(
-      () =>
-        aliceHandle.doc()!.bob === "bob-edit" &&
-        bobHandle.doc()!.alice === "alice-edit",
-      5000
-    )
+    await Promise.all([
+      awaitDoc(aliceHandle, h => h.doc()?.bob === "bob-edit", {
+        timeout: 5000,
+      }),
+      awaitDoc(bobHandle, h => h.doc()?.alice === "alice-edit", {
+        timeout: 5000,
+      }),
+    ])
 
     // Both should have both changes
     expect(aliceHandle.doc()!.alice).toBe("alice-edit")
@@ -400,9 +405,11 @@ describe("Tab → Worker → Server topology", () => {
       d.items = []
     })
 
-    await pause(500)
-
-    const bobHandle = await pair2.tab.find<{ items: string[] }>(aliceHandle.url)
+    const bobHandle = await awaitSyncedHandle(
+      pair2.tab.findWithProgress<{ items: string[] }>(aliceHandle.url),
+      undefined,
+      { timeout: 5000 }
+    )
 
     // Alice makes many rapid changes
     for (let i = 0; i < 20; i++) {
@@ -412,7 +419,9 @@ describe("Tab → Worker → Server topology", () => {
     }
 
     // Wait for all changes to arrive at Bob
-    await waitForCondition(() => bobHandle.doc()!.items.length === 20, 5000)
+    await awaitDoc(bobHandle, h => (h.doc()?.items.length ?? 0) === 20, {
+      timeout: 5000,
+    })
 
     expect(bobHandle.doc()!.items).toHaveLength(20)
     expect(bobHandle.doc()!.items[0]).toBe("item-0")
@@ -436,13 +445,15 @@ describe("Tab → Worker → Server topology", () => {
       d.before = "before outage"
     })
 
-    await pause(500)
-
-    const bobHandle = await pair2.tab.find<{
-      before?: string
-      during?: string
-      after?: string
-    }>(aliceHandle.url)
+    const bobHandle = await awaitSyncedHandle(
+      pair2.tab.findWithProgress<{
+        before?: string
+        during?: string
+        after?: string
+      }>(aliceHandle.url),
+      h => h.doc()?.before === "before outage",
+      { timeout: 5000 }
+    )
     expect(bobHandle.doc()!.before).toBe("before outage")
 
     // Kill the server
@@ -453,26 +464,26 @@ describe("Tab → Worker → Server topology", () => {
       d.during = "during outage"
     })
 
-    await pause(200)
+    // Let Alice's during-outage edit settle locally (tab → worker) before the
+    // server is back; no exposed signal for that, so a bounded wait.
+    await wait(200)
 
     // Restart on the same port, keeping storage so existing data persists
     await server.restart({ clearStorage: false })
 
     // Wait for workers to reconnect and sync
-    await waitForCondition(
-      () => bobHandle.doc()!.during === "during outage",
-      5000
-    )
+    await awaitDoc(bobHandle, h => h.doc()?.during === "during outage", {
+      timeout: 5000,
+    })
 
     // Further edits should also flow
     aliceHandle.change(d => {
       d.after = "after outage"
     })
 
-    await waitForCondition(
-      () => bobHandle.doc()!.after === "after outage",
-      5000
-    )
+    await awaitDoc(bobHandle, h => h.doc()?.after === "after outage", {
+      timeout: 5000,
+    })
   }, 15_000)
 
   // ── Ordering / causality ──────────────────────────────────────────
@@ -498,16 +509,12 @@ describe("Tab → Worker → Server topology", () => {
 
     // Wait for the full document (including the value=42 change) to arrive,
     // not just the initial empty change which also satisfies "ready".
-    await waitForCondition(() => {
-      const s = progress.peek()
-      return s.state === "ready" && s.handle.doc()?.value === 42
-    }, 5000)
-
-    const readyState = progress.peek()
-    expect(readyState.state).toBe("ready")
-    if (readyState.state === "ready") {
-      expect(readyState.handle.doc()!.value).toBe(42)
-    }
+    const bobHandle = await awaitSyncedHandle(
+      progress,
+      h => h.doc()?.value === 42,
+      { timeout: 5000 }
+    )
+    expect(bobHandle.doc()!.value).toBe(42)
   }, 10_000)
 
   it("recovers from unavailable to ready when data arrives later", async () => {
@@ -524,9 +531,9 @@ describe("Tab → Worker → Server topology", () => {
       d.value = 42
     })
     const sid = toSedimentreeId(aliceHandle.documentId)
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await server.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 5000)
 
     // Stop the server so Bob can't reach it
@@ -544,14 +551,16 @@ describe("Tab → Worker → Server topology", () => {
       if (!states.includes(s.state)) states.push(s.state)
     })
 
-    await waitForCondition(() => progress.peek().state === "unavailable", 5000)
+    await awaitProgress(progress, s => s.state === "unavailable", {
+      timeout: 5000,
+    })
     expect(states).toContain("unavailable")
 
     // Restart the server (with the same storage — Alice's data persists)
     await server.restart({ clearStorage: false })
 
     // Bob's reconnect should eventually sync and recover to "ready"
-    await waitForCondition(() => progress.peek().state === "ready", 8000)
+    await awaitProgress(progress, s => s.state === "ready", { timeout: 8000 })
 
     expect(states).toContain("ready")
     const readyState = progress.peek()
@@ -579,14 +588,20 @@ describe("Tab → Worker → Server topology", () => {
       d.from = "bob"
     })
 
-    await pause(500)
-
     // Bob finds Alice's doc
-    const bobDocA = await pair2.tab.find<{ from: string }>(docA.url)
+    const bobDocA = await awaitSyncedHandle(
+      pair2.tab.findWithProgress<{ from: string }>(docA.url),
+      h => h.doc()?.from === "alice",
+      { timeout: 5000 }
+    )
     expect(bobDocA.doc()!.from).toBe("alice")
 
     // Alice finds Bob's doc
-    const aliceDocB = await pair1.tab.find<{ from: string }>(docB.url)
+    const aliceDocB = await awaitSyncedHandle(
+      pair1.tab.findWithProgress<{ from: string }>(docB.url),
+      h => h.doc()?.from === "bob",
+      { timeout: 5000 }
+    )
     expect(aliceDocB.doc()!.from).toBe("bob")
   }, 10_000)
 
@@ -605,10 +620,12 @@ describe("Tab → Worker → Server topology", () => {
       d.items = []
     })
 
-    await pause(500)
-
     // Bob opens the list
-    const bobList = await pair2.tab.find<ListDoc>(listHandle.url)
+    const bobList = await awaitSyncedHandle(
+      pair2.tab.findWithProgress<ListDoc>(listHandle.url),
+      undefined,
+      { timeout: 5000 }
+    )
     expect(bobList.doc()!.items).toHaveLength(0)
 
     // Alice creates a sub-document and links it in one go (like react-todo)
@@ -621,21 +638,18 @@ describe("Tab → Worker → Server topology", () => {
     })
 
     // Wait for the list doc to show the new item URL on Bob's side
-    await waitForCondition(() => {
-      const doc = bobList.doc()
-      return doc !== undefined && doc.items.length === 1
-    }, 5000)
+    await awaitDoc(bobList, h => h.doc()?.items.length === 1, { timeout: 5000 })
 
     const subUrl = bobList.doc()!.items[0]
 
-    // Wait for the sub-document data to arrive on Bob's worker via
-    // subduction. We poll findWithProgress rather than calling find()
-    // (which rejects on unavailable) because the worker may need
-    // several sync rounds before the sub-doc arrives.
-    await waitForCondition(() => {
-      const state = pair2.worker.findWithProgress<ItemDoc>(subUrl).peek()
-      return state.state === "ready" && state.handle.doc()?.title !== undefined
-    }, 5000)
+    // Wait for the sub-document data to arrive on Bob's worker via subduction.
+    // Use findWithProgress (not find(), which rejects on unavailable) because
+    // the worker may need several sync rounds before the sub-doc arrives.
+    await awaitSyncedHandle(
+      pair2.worker.findWithProgress<ItemDoc>(subUrl),
+      h => h.doc()?.title != null,
+      { timeout: 5000 }
+    )
 
     // Now Bob's tab can find the sub-document via MessageChannel sync
     // with the worker — the worker already has the data.
@@ -660,10 +674,12 @@ describe("Tab → Worker → Server topology", () => {
         d.value = "hello"
       })
 
-      await pause(500)
-
       // Bob finds the doc
-      const bobHandle = await pair2.tab.find<{ value: string }>(aliceHandle.url)
+      const bobHandle = await awaitSyncedHandle(
+        pair2.tab.findWithProgress<{ value: string }>(aliceHandle.url),
+        h => h.doc()?.value === "hello",
+        { timeout: 5000 }
+      )
 
       // Bob makes a change — this will sync to the server
       bobHandle.change(d => {
@@ -671,14 +687,11 @@ describe("Tab → Worker → Server topology", () => {
       })
 
       // Wait for the remote heads event on Bob's handle
-      const remoteHeads = await new Promise<DocHandleRemoteHeadsPayload>(
-        resolve => {
-          bobHandle.on("remote-heads", msg => {
-            if (msg.storageId === server.storageId) {
-              resolve(msg)
-            }
-          })
-        }
+      const remoteHeads = await awaitEvent<DocHandleRemoteHeadsPayload>(
+        bobHandle,
+        "remote-heads",
+        msg => msg.storageId === server.storageId,
+        { timeout: 5000 }
       )
 
       expect(remoteHeads.storageId).toBe(server.storageId)
@@ -701,7 +714,8 @@ describe("Tab → Worker → Server topology", () => {
         d.count = 1
       })
 
-      await pause(500)
+      // Let Alice's initial sync settle before we start collecting.
+      await wait(500)
 
       // Collect all remote heads events on Alice's handle
       const remoteHeadsEvents: DocHandleRemoteHeadsPayload[] = []
@@ -712,14 +726,21 @@ describe("Tab → Worker → Server topology", () => {
       })
 
       // Bob finds the doc and makes a change
-      const bobHandle = await pair2.tab.find<{ count: number }>(aliceHandle.url)
+      const bobHandle = await awaitSyncedHandle(
+        pair2.tab.findWithProgress<{ count: number }>(aliceHandle.url),
+        h => h.doc()?.count === 1,
+        { timeout: 5000 }
+      )
       bobHandle.change(d => {
         d.count = 2
       })
 
       // Wait for Alice to receive at least one remote heads event
       // reflecting the server having ingested Bob's change
-      await waitForCondition(() => remoteHeadsEvents.length > 0, 5000)
+      await waitFor(
+        () => expect(remoteHeadsEvents.length).toBeGreaterThan(0),
+        5000
+      )
 
       const latestHeads = remoteHeadsEvents[remoteHeadsEvents.length - 1]
       expect(latestHeads.storageId).toBe(server.storageId)
@@ -742,14 +763,16 @@ describe("Tab → Worker → Server topology", () => {
         d.value = "hello"
       })
 
-      await pause(500)
-
       // Bob finds the doc
-      const bobHandle = await pair2.tab.find<{ value: string }>(aliceHandle.url)
+      const bobHandle = await awaitSyncedHandle(
+        pair2.tab.findWithProgress<{ value: string }>(aliceHandle.url),
+        h => h.doc()?.value === "hello",
+        { timeout: 5000 }
+      )
 
-      // Wait for sync to fully settle (peer states need to be resolved
-      // for ephemeral relay in DocSynchronizer)
-      await pause(500)
+      // Wait for sync to fully settle (peer states need to be resolved for
+      // ephemeral relay in DocSynchronizer). No exposed signal, so bounded.
+      await wait(500)
 
       // Bob listens for ephemeral messages
       const received = new Promise<unknown>(resolve => {
@@ -776,10 +799,13 @@ describe("Tab → Worker → Server topology", () => {
         d.value = "shared doc"
       })
 
-      await pause(500)
-
-      const bobHandle = await pair2.tab.find<{ value: string }>(aliceHandle.url)
-      await pause(500)
+      const bobHandle = await awaitSyncedHandle(
+        pair2.tab.findWithProgress<{ value: string }>(aliceHandle.url),
+        h => h.doc()?.value === "shared doc",
+        { timeout: 5000 }
+      )
+      // Settle so peer states are resolved for ephemeral relay (no signal).
+      await wait(500)
 
       // Alice listens for ephemeral messages
       const aliceReceived = new Promise<unknown>(resolve => {

--- a/packages/automerge-repo/test/subduction/Topology.test.ts
+++ b/packages/automerge-repo/test/subduction/Topology.test.ts
@@ -714,9 +714,6 @@ describe("Tab → Worker → Server topology", () => {
         d.count = 1
       })
 
-      // Let Alice's initial sync settle before we start collecting.
-      await wait(500)
-
       // Collect all remote heads events on Alice's handle
       const remoteHeadsEvents: DocHandleRemoteHeadsPayload[] = []
       aliceHandle.on("remote-heads", msg => {
@@ -735,14 +732,15 @@ describe("Tab → Worker → Server topology", () => {
         d.count = 2
       })
 
-      // Wait for Alice to receive at least one remote heads event
-      // reflecting the server having ingested Bob's change
+      // Wait for a remote-heads event with non-empty heads, reflecting the
+      // server having ingested Bob's change.
       await waitFor(
-        () => expect(remoteHeadsEvents.length).toBeGreaterThan(0),
+        () =>
+          expect(remoteHeadsEvents.some(e => e.heads.length > 0)).toBe(true),
         5000
       )
 
-      const latestHeads = remoteHeadsEvents[remoteHeadsEvents.length - 1]
+      const latestHeads = remoteHeadsEvents.findLast(e => e.heads.length > 0)!
       expect(latestHeads.storageId).toBe(server.storageId)
       expect(latestHeads.heads.length).toBeGreaterThan(0)
     }, 10_000)

--- a/packages/automerge-repo/test/subduction/WebSocket.test.ts
+++ b/packages/automerge-repo/test/subduction/WebSocket.test.ts
@@ -13,21 +13,11 @@ import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
 import { type PeerId } from "../../src/types.js"
 import { toSedimentreeId } from "../../src/subduction/helpers.js"
 import { WebSocketTransport } from "../../src/subduction/websocket-transport.js"
-import { pause } from "../../src/helpers/pause.js"
-
-/** Poll a condition until it returns true, or throw after timeout. */
-async function waitForCondition(
-  fn: () => Promise<boolean>,
-  timeoutMs: number,
-  intervalMs = 200
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (await fn()) return
-    await pause(intervalMs)
-  }
-  throw new Error(`waitForCondition timed out after ${timeoutMs}ms`)
-}
+import { awaitDoc } from "../helpers/awaitDoc.js"
+import { awaitSubductionConnected } from "../helpers/awaitSubductionConnected.js"
+import { awaitSyncedHandle } from "../helpers/awaitSyncedHandle.js"
+import { waitFor } from "../helpers/waitFor.js"
+import { wait } from "../helpers/wait.js"
 
 interface TestServer {
   port: number
@@ -207,9 +197,9 @@ describe("Subduction WebSocket sync", () => {
     })
 
     const sid = toSedimentreeId(handle.documentId)
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await server.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 5000)
 
     const blobs = await server.subduction.getBlobs(sid)
@@ -228,13 +218,14 @@ describe("Subduction WebSocket sync", () => {
       d.count = 42
     })
 
-    await pause(500)
-
     // Client 2 connects and fetches the same doc
     const client2 = createClientRepo("client-2", server.url)
 
-    const handle2 = await client2.find<{ count: number }>(handle1.url)
-    await handle2.whenReady()
+    const handle2 = await awaitSyncedHandle(
+      client2.findWithProgress<{ count: number }>(handle1.url),
+      h => h.doc()?.count === 42,
+      { timeout: 8000 }
+    )
 
     const doc = handle2.doc()!
     console.log(
@@ -258,11 +249,12 @@ describe("Subduction WebSocket sync", () => {
       d.items = ["first"]
     })
 
-    await pause(500)
-
     // Client 2 finds it
-    const handle2 = await client2.find<{ items: string[] }>(handle1.url)
-    await handle2.whenReady()
+    const handle2 = await awaitSyncedHandle(
+      client2.findWithProgress<{ items: string[] }>(handle1.url),
+      h => h.doc()?.items?.[0] === "first",
+      { timeout: 8000 }
+    )
 
     expect(handle2.doc()!.items).toEqual(["first"])
 
@@ -271,10 +263,10 @@ describe("Subduction WebSocket sync", () => {
       d.items.push("second")
     })
 
-    await pause(500)
-
     // Client 1 should see the change (via server re-sync/subscription)
-    // Force a re-sync by checking the handle
+    await awaitDoc(handle1, h => h.doc()?.items?.includes("second") ?? false, {
+      timeout: 5000,
+    })
     expect(handle1.doc()!.items).toContain("second")
   }, 10_000)
 
@@ -326,9 +318,9 @@ describe("Subduction WebSocket sync", () => {
 
     // Wait for the client to reconnect and sync the document to the server
     const sid = toSedimentreeId(handle1.documentId)
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await subduction.getBlobs(sid)
-      return blobs.length > 0
+      expect(blobs.length).toBeGreaterThan(0)
     }, 10_000)
   }, 10_000)
 
@@ -342,15 +334,16 @@ describe("Subduction WebSocket sync", () => {
     handle1.change(d => {
       d.value = 99
     })
-    await pause(500)
-
-    // Client 2: issue find() immediately — the connection manager is
+    // Client 2: issue findWithProgress immediately — the connection manager is
     // still connecting at this point, so syncWithAllPeers will find 0
     // peers initially. The query should stay pending until the
     // connection is established and #onPeerConnected re-syncs.
     const client2 = createClientRepo("client-2", server.url)
-    const handle2 = await client2.find<{ value: number }>(handle1.url)
-    await handle2.whenReady()
+    const handle2 = await awaitSyncedHandle(
+      client2.findWithProgress<{ value: number }>(handle1.url),
+      h => h.doc()?.value === 99,
+      { timeout: 8000 }
+    )
     expect(handle2.doc()!.value).toBe(99)
   }, 10_000)
 
@@ -373,18 +366,19 @@ describe("Subduction WebSocket sync", () => {
     })
 
     // Wait long enough that an infinite loop would have spun hundreds of
-    // times. If the no-peers guard is missing, this would peg the CPU.
-    await pause(500)
+    // times. If the no-peers guard is missing, this would peg the CPU. This is
+    // intentionally a fixed wait: it bounds a "nothing bad happens" window.
+    await wait(500)
 
     // Now start the server on the same port
     const server = await startSubductionServer(freePort)
     cleanups.push(() => server.close())
 
     // Wait for the reconnect backoff (1s base, doubles each retry) + sync
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const sid = toSedimentreeId(handle.documentId)
       const blobs = await server.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 8000)
 
     // Verify the data reached the server
@@ -404,11 +398,12 @@ describe("Subduction WebSocket sync", () => {
     const client = createClientRepo("client-1", server.url)
 
     // Wait for the connection to establish
-    await pause(500)
+    await awaitSubductionConnected(client, { timeout: 5000 })
 
-    // Stop the server — client is now disconnected
+    // Stop the server. The client notices the drop lazily (no prompt disconnect
+    // signal), so a short bounded pause stands in here.
     await server.close()
-    await pause(200)
+    await wait(200)
 
     // Make several changes while disconnected. Each #save will see
     // lastSyncResult === "no-peers" and skip the sync trigger.
@@ -423,7 +418,8 @@ describe("Subduction WebSocket sync", () => {
       d.items.push("third")
     })
 
-    await pause(500)
+    // Drain the disconnected saves so they are durable before the restart.
+    await client.flush()
 
     // Restart the server on the same port — client will reconnect
     // and #setConnectionState("running") should reset lastSyncResult,
@@ -433,15 +429,18 @@ describe("Subduction WebSocket sync", () => {
 
     // Verify ALL changes made while disconnected arrive at the server
     const sid = toSedimentreeId(handle.documentId)
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await newServer.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 8000)
 
     // Verify by loading the doc on a second client
     const client2 = createClientRepo("client-2", newServer.url)
-    const handle2 = await client2.find<{ items: string[] }>(handle.url)
-    await handle2.whenReady()
+    const handle2 = await awaitSyncedHandle(
+      client2.findWithProgress<{ items: string[] }>(handle.url),
+      h => (h.doc()?.items?.length ?? 0) === 3,
+      { timeout: 8000 }
+    )
 
     expect(handle2.doc()!.items).toEqual(["first", "second", "third"])
   }, 15_000)
@@ -460,28 +459,33 @@ describe("Subduction WebSocket sync", () => {
     })
 
     const clientB = createClientRepo("client-B", server.url)
-    const handleB = await clientB.find<{ value: number }>(handleA.url)
-    await handleB.whenReady()
+    const handleB = await awaitSyncedHandle(
+      clientB.findWithProgress<{ value: number }>(handleA.url),
+      h => h.doc()?.value === 1,
+      { timeout: 8000 }
+    )
     expect(handleB.doc()!.value).toBe(1)
 
     // Let A's sync settle to "succeeded" before dropping the connection.
-    await pause(500)
+    // (No "sync succeeded" signal is exposed, so this is a bounded wait.)
+    await wait(500)
 
     // Drop the server, then restart on the same port so both clients reconnect.
     await server.close()
-    await pause(300)
+    await wait(300)
     const newServer = await startSubductionServer(serverPort)
     cleanups.push(() => newServer.close())
 
-    // After reconnect, B changes the doc; that local change forces B to re-push
-    // regardless, isolating the test to whether A re-subscribed.
-    await pause(1500)
+    // Give both clients time to reconnect before B edits (reconnect-after-
+    // restart has no prompt signal, so a bounded wait). B's local change then
+    // forces a re-push, isolating the test to whether A re-subscribed.
+    await wait(1500)
     handleB.change(d => {
       d.value = 2
     })
 
     // A converges only if it re-subscribed on the new connection.
-    await waitForCondition(async () => handleA.doc()!.value === 2, 10_000)
+    await awaitDoc(handleA, h => h.doc()?.value === 2, { timeout: 10_000 })
     expect(handleA.doc()!.value).toBe(2)
   }, 25_000)
 
@@ -504,15 +508,17 @@ describe("Subduction WebSocket sync", () => {
     handle1.change(d => {
       d.value = "shared"
     })
-    await pause(500)
-
     const client2 = createClientRepo("client-2", server.url)
-    const handle2 = await client2.find<{ value: string }>(handle1.url)
-    await handle2.whenReady()
+    const handle2 = await awaitSyncedHandle(
+      client2.findWithProgress<{ value: string }>(handle1.url),
+      h => h.doc()?.value === "shared",
+      { timeout: 8000 }
+    )
 
-    // Settle: peers must be exchanged and ephemeral subscriptions
-    // registered on the server before broadcasts will be relayed.
-    await pause(500)
+    // Settle: peers must be exchanged and ephemeral subscriptions registered on
+    // the server before broadcasts will be relayed. No signal is exposed for
+    // that, so this is a bounded wait.
+    await wait(500)
 
     const received: unknown[] = []
     handle2.on("ephemeral-message", ({ message }) => {
@@ -523,7 +529,7 @@ describe("Subduction WebSocket sync", () => {
     handle1.broadcast({ seq: 2 })
     handle1.broadcast({ seq: 3 })
 
-    await waitForCondition(() => received.length >= 3, 3000)
+    await waitFor(() => expect(received.length).toBeGreaterThanOrEqual(3), 3000)
 
     expect(received).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }])
   }, 10_000)
@@ -543,11 +549,11 @@ describe("Subduction WebSocket sync", () => {
     // quiesce round is guaranteed a peer. A fixed pause would be racy
     // under parallel load.
     const warmup = client1.create<{ x: number }>({ x: 1 })
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await server.subduction.getBlobs(
         toSedimentreeId(warmup.documentId)
       )
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 8000)
 
     // Mutate, then shut down with NO intervening await: the 100ms save
@@ -566,8 +572,11 @@ describe("Subduction WebSocket sync", () => {
     cleanups.push(async () => {
       await client2.shutdown()
     })
-    const handle2 = await client2.find<{ value: number }>(url)
-    await handle2.whenReady()
+    const handle2 = await awaitSyncedHandle(
+      client2.findWithProgress<{ value: number }>(url),
+      h => h.doc()?.value === 42,
+      { timeout: 8000 }
+    )
 
     expect(handle2.doc()!.value).toBe(42)
   }, 20_000)
@@ -594,9 +603,9 @@ describe("Subduction WebSocket sync", () => {
     // completes (no in-flight #doSync at shutdown time).
     const handle = client.create<{ value: number }>({ value: 0 })
     const sid = toSedimentreeId(handle.documentId)
-    await waitForCondition(async () => {
+    await waitFor(async () => {
       const blobs = await server.subduction.getBlobs(sid)
-      return blobs !== undefined && blobs.length > 0
+      expect(blobs?.length ?? 0).toBeGreaterThan(0)
     }, 8000)
 
     // Peer goes dark: still connected (handshake done), but every


### PR DESCRIPTION

> Rebased onto `subductionjs` now that #708 has merged; the diff is just the test
> commits.

## What and why

A small, low-risk robustness pass on `test/subduction/*`. The tests waited for async
work with fixed `pause()` sleeps. A fixed sleep is a guess: too short and it flakes
under CI load, too long and every run pays for it, and it never keys off the actual
completion signal. This replaces them with waits that resolve exactly when the work is
done.

It's deliberately simple, and each commit is scoped to one file. **The per-file commit
messages have the detail**: every one states what became genuinely event-driven versus
what didn't and why. At a glance, the changes are three kinds:

- **Event-driven (the robustness win):** wait on the signal the code already emits,
  the handle's `heads-changed`, `subduction-connection`, `subduction-remote-heads`, the
  `repo.subduction` init promise, `repo.flush()`. A few small composable test helpers
  (`awaitEvent` / `awaitDoc` / `awaitProgress` / `awaitSyncedHandle` /
  `awaitSubductionConnected`) back these; `waitFor` also gains an optional bounded
  timeout that reports the failing assertion.
- **DRY consolidation (cosmetic, labelled as such):** some suites only moved a
  duplicated local `waitForCondition` to the shared `waitFor`. No robustness change;
  the commit titles say "(DRY)".
- **Intentional bounded waits (kept, and commented):** where no signal is exposed. A
  raw `Subduction` server has no "stored" event (so `getBlobs` is polled directly,
  which is also the right independent check for the policy tests), disconnect detection
  is lazy, and "must-not-happen" negatives need a window. These are deliberate, not
  oversights.

No production code changes; tests only. Full subduction suite is green.

## Please review carefully: suggestions from a non-expert

I don't know the subduction internals deeply, so treat this as suggestions. The calls
most likely to be wrong are the "no signal exists, so this stays a bounded wait" ones.
If there's a settle/stored/disconnect signal I missed, those waits should become
event-driven too. Corrections very welcome.
