### PR TITLE
perf(subduction): bound the compaction delete fan-out

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -129,6 +129,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     subductionWebsocketEndpoints,
     subductionAdapters,
     subductionTimeouts,
+    subductionCompactionDeleteConcurrency,
     subductionBlobInterceptor,
   }: RepoConfig = {}) {
     super()
@@ -205,6 +206,7 @@ export class Repo extends EventEmitter<RepoEvents> {
       adapters: subductionAdapters ?? [],
       policy: subductionPolicy,
       timeouts: subductionTimeouts,
+      compactionDeleteConcurrency: subductionCompactionDeleteConcurrency,
       blobInterceptor: subductionBlobInterceptor,
       onRemoteHeadsChanged: (documentId, storageId, heads, timestamp) => {
         const handle = this.#queries[documentId]?.handle
@@ -1046,6 +1048,13 @@ export interface RepoConfig {
    * are optional; sensible defaults apply.
    */
   subductionTimeouts?: SubductionTimeouts
+
+  /**
+   * Max number of stale-blob deletes Subduction runs concurrently during a
+   * compaction pass. Defaults to 16. Raise it if your storage adapter
+   * handles many parallel deletes well; lower it to reduce burst load.
+   */
+  subductionCompactionDeleteConcurrency?: number
 
   /**
    * Optional interceptor for transforming incoming and outgoing blobs (e.g.,

--- a/packages/automerge-repo/src/helpers/semaphore.ts
+++ b/packages/automerge-repo/src/helpers/semaphore.ts
@@ -1,0 +1,79 @@
+/**
+ * A counting semaphore that caps how many of the functions passed to it run at
+ * once. Returns a gate, `limit`, that you wrap each call in; at most
+ * `concurrency` run concurrently and the rest queue (FIFO), starting as slots
+ * free up.
+ *
+ * @remarks
+ * Gate each call so at most `concurrency` run concurrently:
+ *
+ * ```typescript
+ * const limit = semaphore(10)
+ * const results = await Promise.all(items.map(item => limit(() => work(item))))
+ * ```
+ *
+ * `Promise.all` still resolves results in input order, and its rejection
+ * semantics are unchanged; the gate only throttles *when* each function is
+ * invoked. A slot is released in `finally`, so a rejecting task does not stall
+ * the queue. Note this is the "run a function under the gate" shape
+ * (`limit(() => fn())`), not a classic `acquire()` / `release()` semaphore.
+ *
+ * **Choosing `concurrency`**: tie it to the constraining resource.
+ * - filesystem: stay well under the process's file-descriptor ceiling
+ * - HTTP/1.1-backed: a browser allows ~6 connections per origin
+ * - HTTP/2-backed: ~100 multiplexed streams per connection
+ * - database-backed: at or below the connection-pool size, with headroom for
+ *   other callers
+ *
+ * **Synchronous-start contract**: when a slot is free, `fn` is invoked
+ * *synchronously* in the current tick (like a bare `items.map(fn)`), not
+ * deferred to a microtask. Callers that start work and then synchronously act
+ * on it (for example, unblocking a paused test double immediately after kicking
+ * the work off) rely on this. Do not refactor the call to `fn` behind a
+ * `.then()` / `queueMicrotask` (or an `await` before `fn()` is reached on the
+ * free-slot path).
+ *
+ * @param concurrency - Maximum number of wrapped functions allowed to run at
+ *   once. Must be a positive integer.
+ * @returns A `limit(fn)` gate. Each call runs `fn` when a slot is free and
+ *   resolves/rejects with `fn`'s result.
+ */
+export function semaphore(concurrency: number): Limit {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new TypeError("semaphore: concurrency must be a positive integer")
+  }
+
+  let active = 0
+  const waiters: Array<() => void> = []
+
+  const release = () => {
+    // Hand the slot straight to the next waiter (active unchanged) so a caller
+    // arriving in the same tick can't slip in front of it; only free the slot
+    // when nobody is waiting.
+    const wake = waiters.shift()
+    if (wake) wake()
+    else active--
+  }
+
+  return async <T>(fn: () => PromiseLike<T> | T): Promise<T> => {
+    if (active < concurrency) {
+      active++
+    } else {
+      // At capacity: park until release() hands us a slot.
+      const { promise, resolve } = Promise.withResolvers<void>()
+      waiters.push(resolve)
+      await promise
+    }
+    // The free-slot path reaches here with no intervening await, so `fn()` runs
+    // synchronously in the current tick (the synchronous-start contract).
+    try {
+      return await fn()
+    } finally {
+      release()
+    }
+  }
+}
+
+/** The gate returned by {@link semaphore}: runs `fn` under the concurrency
+ * limit and resolves/rejects with its result. */
+export type Limit = <T>(fn: () => PromiseLike<T> | T) => Promise<T>

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -22,6 +22,7 @@ import { ConnectionManager } from "./ConnectionManager.js"
 import type { StorageId } from "../storage/types.js"
 import type { UrlHeads } from "../types.js"
 import { mergeArrays } from "../helpers/mergeArrays.js"
+import { semaphore } from "../helpers/semaphore.js"
 import { throttle, type ThrottledFunction } from "../helpers/throttle.js"
 import { makeYielder, yieldToMacrotask } from "../helpers/yield.js"
 import debug from "debug"
@@ -48,6 +49,15 @@ const DEFAULT_SYNC_TIMEOUT_MS = 60_000
  * unresponsive or half-torn-down peer.
  */
 const SHUTDOWN_SYNC_TIMEOUT_MS = 5_000
+
+/**
+ * Default cap on how many stale-blob deletes run concurrently during a
+ * compaction pass. A long-lived doc can accumulate a large stale set, and
+ * without a cap every delete would fire at once and flood the storage
+ * adapter. Override per-Repo via
+ * `RepoConfig.subductionCompactionDeleteConcurrency`.
+ */
+const DEFAULT_COMPACTION_DELETE_CONCURRENCY = 16
 
 // ── Per-sedimentree state ───────────────────────────────────────────────
 //
@@ -327,6 +337,12 @@ export interface SubductionSourceOptions {
   /** Tunable timeouts for sync and heal-retry. See {@link SubductionTimeouts}. */
   timeouts?: SubductionTimeouts
 
+  /**
+   * Max number of stale-blob deletes to run concurrently during a compaction
+   * pass. Defaults to {@link DEFAULT_COMPACTION_DELETE_CONCURRENCY}.
+   */
+  compactionDeleteConcurrency?: number
+
   blobInterceptor?: BlobInterceptor
 }
 
@@ -339,6 +355,7 @@ export class SubductionSource implements DocumentSource {
   #scheduler: SyncScheduler
   #syncTimeoutMs: number
   #syncTimeout: number | null
+  #compactionDeleteConcurrency: number
   #blobInterceptor?: BlobInterceptor
   #onRemoteHeadsChanged?: OnRemoteHeadsChanged
   #onConnectionChanged?: (connected: boolean) => void
@@ -371,6 +388,7 @@ export class SubductionSource implements DocumentSource {
     priority = 2,
     policy,
     timeouts,
+    compactionDeleteConcurrency = DEFAULT_COMPACTION_DELETE_CONCURRENCY,
     blobInterceptor,
   }: SubductionSourceOptions) {
     this.#blobInterceptor = blobInterceptor
@@ -378,6 +396,7 @@ export class SubductionSource implements DocumentSource {
     this.priority = priority
     this.#syncTimeoutMs = timeouts?.syncMs ?? DEFAULT_SYNC_TIMEOUT_MS
     this.#syncTimeout = this.#syncTimeoutMs
+    this.#compactionDeleteConcurrency = compactionDeleteConcurrency
     // Default roundtrip deadline forwarded to the Subduction constructor.
     // The field must be *omitted* (not passed as `undefined`) to get the
     // wasm built-in default (30 s) — passing `undefined` is coerced to a
@@ -1718,12 +1737,25 @@ export class SubductionSource implements DocumentSource {
     if (staleCommits.length === 0 && staleFragments.length === 0) return
 
     const sid = entry.sedimentreeId
+    // Bounded fan-out: a long-lived doc can accumulate a large stale set,
+    // and firing every delete at once would flood the storage adapter in a
+    // single burst (the shutdown final-sync pool bounds its rounds for the
+    // same reason). Cap how many deletes run concurrently.
+    const limit = semaphore(this.#compactionDeleteConcurrency)
     const ops: Array<Promise<unknown>> = []
     for (const hex of staleCommits) {
-      ops.push(this.#storage.deleteCommit(sid, CommitId.fromHexString(hex)))
+      ops.push(
+        limit(() =>
+          this.#storage.deleteCommit(sid, CommitId.fromHexString(hex))
+        )
+      )
     }
     for (const hex of staleFragments) {
-      ops.push(this.#storage.deleteFragment(sid, CommitId.fromHexString(hex)))
+      ops.push(
+        limit(() =>
+          this.#storage.deleteFragment(sid, CommitId.fromHexString(hex))
+        )
+      )
     }
 
     try {

--- a/packages/automerge-repo/test/semaphore.test.ts
+++ b/packages/automerge-repo/test/semaphore.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest"
+import { semaphore } from "../src/helpers/semaphore.js"
+
+// Drain all pending microtasks by bouncing off a macrotask.
+const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+describe("semaphore", () => {
+  it("runs free-slot tasks synchronously and defers only the over-capacity ones", () => {
+    // Pins the synchronous-start contract: a free slot must invoke `fn` in the
+    // current tick (callers like Repo.flush unblock a paused test double right
+    // after starting the work). An `await` before `fn` (e.g. `await acquire()`)
+    // would defer it to a microtask: this test would then see `[]` here. A
+    // missing gate would see `[0, 1, 2]`. Only `[0, 1]` is correct.
+    const limit = semaphore(2)
+    const startedSync: number[] = []
+    const holdSlotOpen = () => new Promise<void>(() => {})
+    void limit(() => {
+      startedSync.push(0)
+      return holdSlotOpen()
+    })
+    void limit(() => {
+      startedSync.push(1)
+      return holdSlotOpen()
+    })
+    void limit(() => {
+      startedSync.push(2) // over capacity — must not run in this tick
+      return holdSlotOpen()
+    })
+    expect(startedSync).toEqual([0, 1])
+  })
+
+  it("runs at most `concurrency` tasks at once and starts queued tasks as slots free", async () => {
+    const limit = semaphore(2)
+    const started: number[] = []
+    const resolvers: Array<() => void> = []
+    const make = (i: number) =>
+      limit(() => {
+        started.push(i)
+        return new Promise<void>(resolve => {
+          resolvers[i] = resolve
+        })
+      })
+
+    const all = Promise.all([make(0), make(1), make(2), make(3)])
+
+    await flush()
+    expect(started).toEqual([0, 1]) // only two slots
+
+    resolvers[0]()
+    await flush()
+    expect(started).toEqual([0, 1, 2]) // a freed slot admits the next
+
+    resolvers[1]()
+    await flush()
+    expect(started).toEqual([0, 1, 2, 3])
+
+    resolvers[2]()
+    resolvers[3]()
+    await all
+  })
+
+  it("resolves results in input order regardless of completion order", async () => {
+    const limit = semaphore(3)
+    const results = await Promise.all(
+      [30, 10, 20].map((ms, i) =>
+        limit(
+          () => new Promise<number>(resolve => setTimeout(() => resolve(i), ms))
+        )
+      )
+    )
+    expect(results).toEqual([0, 1, 2])
+  })
+
+  it("releases the slot when a task rejects so the queue keeps draining", async () => {
+    const limit = semaphore(1)
+    let bRan = false
+    const a = limit(() => Promise.reject(new Error("boom")))
+    const b = limit(() => {
+      bRan = true
+    })
+    // If a rejection did not free the slot, `b` would never run and the await
+    // below would hang the test.
+    await expect(a).rejects.toThrow("boom")
+    await b
+    expect(bRan).toBe(true)
+  })
+
+  it("rejects an invalid concurrency", () => {
+    expect(() => semaphore(0)).toThrow(TypeError)
+    expect(() => semaphore(-1)).toThrow(TypeError)
+    expect(() => semaphore(1.5)).toThrow(TypeError)
+  })
+})


### PR DESCRIPTION

> Rebased onto `subductionjs` now that #708 has merged; the diff is just the two
> commits below.

## What and why

Stale-blob cleanup during compaction pushed one `deleteCommit` / `deleteFragment`
per stale hash onto a single `Promise.all`, a fan-out over the whole stale set. On a
doc with a long history that's a burst of N concurrent storage deletes against a
possibly single-threaded (worker) adapter.

Everywhere else `SubductionSource` already bounds its fan-out (the shutdown
final-sync uses a `Math.min(16, queue.length)` worker pool; other `Promise.all`s
only await already-in-flight work). This makes the compaction deletes consistent
with that: they now run through a small counting `semaphore`. Ordering and failure
handling are unchanged; it only throttles when each delete starts.

The cap is **configurable**, following the existing `flushConcurrency` pattern:
`RepoConfig.subductionCompactionDeleteConcurrency` (or the
`SubductionSourceOptions.compactionDeleteConcurrency` constructor option), with a
fallback default of **16**, the same ceiling the shutdown final-sync pool uses.

Two commits:

- **`feat(helpers): add a bounded-concurrency semaphore`**: a small
  `limit(() => fn())` gate (at most N run at once, the rest queue FIFO), with tests.
- **`perf(subduction): bound the compaction delete fan-out`**: route the deletes
  through it, with the configurable cap.

## Questions / notes for the reviewer

- **Is 16 the right default?** It's now configurable, so a consumer can tune it, but
  the default should be a sane ceiling for the storage adapters in play. I matched
  the shutdown pool; a maintainer may want a different number.
- **The `semaphore` helper is the same one added by #692** (which bounds storage
  fan-out on `main`). This PR copies it because `subductionjs` doesn't have it yet;
  when the two lines converge on `main`, the duplicate should be dropped (the helper
  is byte-identical). If #692 lands on `main` first, that dedup happens when the
  subduction line next merges `main`.
- I'm not deep in the subduction internals, so please sanity-check that bounding the
  deletes can't interact badly with a concurrent compaction pass.
