### PR TITLE
fix(repo): make shutdown() best-effort instead of rejecting on flush failure

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -756,18 +756,25 @@ export class Repo extends EventEmitter<RepoEvents> {
   }
 
   async shutdown(): Promise<void> {
-    // Best-effort teardown. Drain saves first (flush awaits all of them), but
-    // swallow and log a flush failure rather than rejecting, so shutdown()
-    // always disconnects the network and closes storage instead of leaking
-    // those resources on a partial save failure. Call flush() explicitly before
+    // Best-effort teardown. Drain saves first (flush awaits all of them), then
+    // disconnect the network and close storage. Each step is guarded and its
+    // failure logged rather than thrown, so one failing step neither skips a
+    // later one nor rejects shutdown(). Call flush() explicitly before
     // shutdown() if you need to observe save failures.
     try {
       await this.flush()
     } catch (err) {
       this.#log.error("error flushing documents during shutdown", err)
-    } finally {
+    }
+    try {
       this.networkSubsystem.disconnect()
+    } catch (err) {
+      this.#log.error("error disconnecting network during shutdown", err)
+    }
+    try {
       await this.storageSubsystem?.close()
+    } catch (err) {
+      this.#log.error("error closing storage during shutdown", err)
     }
   }
 

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -756,11 +756,15 @@ export class Repo extends EventEmitter<RepoEvents> {
   }
 
   async shutdown(): Promise<void> {
-    // Drain saves first (flush awaits all of them), then always tear down in
-    // the finally so a partial flush failure (which rejects flush) still
-    // disconnects the network and closes storage rather than leaking resources.
+    // Best-effort teardown. Drain saves first (flush awaits all of them), but
+    // swallow and log a flush failure rather than rejecting, so shutdown()
+    // always disconnects the network and closes storage instead of leaking
+    // those resources on a partial save failure. Call flush() explicitly before
+    // shutdown() if you need to observe save failures.
     try {
       await this.flush()
+    } catch (err) {
+      this.#log.error("error flushing documents during shutdown", err)
     } finally {
       this.networkSubsystem.disconnect()
       await this.storageSubsystem?.close()

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1068,9 +1068,9 @@ describe("Repo", () => {
 
     it("shutdown() flushes best-effort, logging a flush failure instead of rejecting", async () => {
       const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-      const logged = (needle: string) =>
+      const logged = (str: string) =>
         errSpy.mock.calls.some(call =>
-          call.some(arg => String(arg).includes(needle))
+          call.some(arg => String(arg).includes(str))
         )
       try {
         const storage = new DummyStorageAdapter()
@@ -1097,6 +1097,39 @@ describe("Repo", () => {
         await expect(repo.shutdown()).resolves.toBeUndefined()
         expect(disconnectSpy).toHaveBeenCalledOnce()
         expect(logged("error flushing documents during shutdown")).toBe(true)
+      } finally {
+        errSpy.mockRestore()
+      }
+    })
+
+    it("shutdown() is best-effort when teardown throws, still closing storage and resolving", async () => {
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      const logged = (str: string) =>
+        errSpy.mock.calls.some(call =>
+          call.some(arg => String(arg).includes(str))
+        )
+      try {
+        const storage = new DummyStorageAdapter()
+        const closeSpy = vi.fn(async () => {
+          throw new Error("close failed")
+        })
+        storage.close = closeSpy
+        const repo = new Repo({ storage })
+        repo.create({ a: 1 })
+
+        // A throwing disconnect() must not skip storage close(), and a throwing
+        // close() must not reject shutdown(); each failure is logged instead.
+        const disconnectSpy = vi
+          .spyOn(repo.networkSubsystem, "disconnect")
+          .mockImplementation(() => {
+            throw new Error("disconnect failed")
+          })
+
+        await expect(repo.shutdown()).resolves.toBeUndefined()
+        expect(disconnectSpy).toHaveBeenCalledOnce()
+        expect(closeSpy).toHaveBeenCalledOnce()
+        expect(logged("error disconnecting network during shutdown")).toBe(true)
+        expect(logged("error closing storage during shutdown")).toBe(true)
       } finally {
         errSpy.mockRestore()
       }

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1050,13 +1050,28 @@ describe("Repo", () => {
         repo.create({ b: 2 })
 
         await expect(repo.flush()).rejects.toThrow(AggregateError)
+
+        // create() also schedules a fire-and-forget throttled save per document;
+        // wait for those to run and be logged (rather than leaking past the test
+        // as unattributed stderr) and assert the failure is surfaced.
+        await vi.waitFor(() =>
+          expect(
+            errSpy.mock.calls.some(call =>
+              call.some(arg => String(arg).includes("Error saving document"))
+            )
+          ).toBe(true)
+        )
       } finally {
         errSpy.mockRestore()
       }
     })
 
-    it("shutdown() disconnects even if flush() fails", async () => {
+    it("shutdown() flushes best-effort, logging a flush failure instead of rejecting", async () => {
       const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      const logged = (needle: string) =>
+        errSpy.mock.calls.some(call =>
+          call.some(arg => String(arg).includes(needle))
+        )
       try {
         const storage = new DummyStorageAdapter()
         const realSave = storage.save.bind(storage)
@@ -1068,11 +1083,20 @@ describe("Repo", () => {
         }
         const repo = new Repo({ storage })
         repo.create({ a: 1 })
+
+        // Drain the fire-and-forget throttled save first (while storage is open)
+        // so its log is asserted here rather than leaking into a later test.
+        await vi.waitFor(() =>
+          expect(logged("Error saving document")).toBe(true)
+        )
+
         const disconnectSpy = vi.spyOn(repo.networkSubsystem, "disconnect")
 
-        // shutdown rethrows flush's failure, but the finally must still run.
-        await expect(repo.shutdown()).rejects.toThrow(AggregateError)
+        // shutdown() is best-effort: it swallows and logs the flush failure,
+        // resolves, and still disconnects.
+        await expect(repo.shutdown()).resolves.toBeUndefined()
         expect(disconnectSpy).toHaveBeenCalledOnce()
+        expect(logged("error flushing documents during shutdown")).toBe(true)
       } finally {
         errSpy.mockRestore()
       }


### PR DESCRIPTION
## Summary

`Repo.shutdown()` drained saves via `flush()` in a `try`/`finally`. The `finally` already disconnected the network and closed storage, but with no `catch`, `flush()`'s `AggregateError` propagated after the `finally` ran, so `shutdown()` rejected. That forced callers to handle a rejection just to shut down. This changes `shutdown()` to catch and log the flush failure instead, so it disconnects the network, closes storage, and resolves. Call `flush()` explicitly beforehand if you need to observe save failures.

Teardown is now also individually guarded: `flush()`, `networkSubsystem.disconnect()`, and `storageSubsystem.close()` each run under their own `try`/`catch`. `disconnect()` can throw synchronously (each adapter's `disconnect()` runs in a `forEach`) and `close()` can reject (a user-supplied `adapter.close()`), so guarding each step keeps one failing step from skipping a later one or rejecting `shutdown()`.

`flush()` itself is unchanged and still rejects with an `AggregateError`, since a caller awaiting it should see the failure.

This aligns `main` with the best-effort `shutdown()` behavior already in `subductionjs` (#716).

## Contract change (please review)

This reverses the shutdown-rejects behavior added in #692: `shutdown()` now resolves on a flush failure rather than rejecting. Any caller relying on `shutdown()` rejecting to detect a failed save must call `flush()` first. Flagging explicitly for a maintainer decision.

## Tests

- The shutdown failure-injection test now asserts `shutdown()` resolves, still disconnects, and logs the failure (renamed accordingly).
- A new test forces both `disconnect()` and `close()` to throw and asserts `shutdown()` still closes storage, resolves, and logs each failure.
- Both flush failure-injection tests drain and assert the fire-and-forget throttled save log via `vi.waitFor` (mirroring `StorageSource.test.ts`), so a failed background save is captured and asserted rather than leaking into a later test's stderr as an unattributed "disk full" error.

## Verification

`pnpm --filter @automerge/automerge-repo build`, `tsc --noEmit` (packages + examples + svelte-check), `oxfmt --check`, `oxlint`, and the full `vitest` suite (848 passing, 2 skipped) all green, with no leaked stderr.
