### PR TITLE
Improve adapter contract

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocument.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocument.ts
@@ -1,4 +1,7 @@
-import { AnyDocumentId } from "@automerge/automerge-repo/slim"
+import {
+  AnyDocumentId,
+  DocumentDeletedError,
+} from "@automerge/automerge-repo/slim"
 import { ChangeFn, ChangeOptions, Doc } from "@automerge/automerge/slim"
 import { useCallback, useEffect, useState } from "react"
 import { useDocHandle } from "./useDocHandle.js"
@@ -70,7 +73,7 @@ export function useDocument<T>(
     }
     const onChange = () => setDoc(handle.doc())
     const onDelete = () => {
-      setDeleteError(new Error(`Document ${id} was deleted`))
+      setDeleteError(new DocumentDeletedError(handle.documentId))
     }
 
     handle.on("change", onChange)

--- a/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/useDocument.test.tsx
@@ -1,6 +1,7 @@
 import {
   AutomergeUrl,
   Doc,
+  DocumentDeletedError,
   generateAutomergeUrl,
 } from "@automerge/automerge-repo"
 import { render, screen, waitFor } from "@testing-library/react"
@@ -99,6 +100,10 @@ describe("useDocument", () => {
 
     // Should trigger error boundary
     expect(screen.getByTestId("error")).toHaveTextContent("Error")
+
+    const error = onError.mock.calls[0]?.[0]
+    expect(error).toBeInstanceOf(DocumentDeletedError)
+    expect(error.documentId).toBe(handleA.documentId)
 
     consoleSpy.mockRestore()
   })

--- a/packages/automerge-repo/src/DocumentQuery.ts
+++ b/packages/automerge-repo/src/DocumentQuery.ts
@@ -4,6 +4,7 @@ import { decodeHeads } from "./AutomergeUrl.js"
 import type { DocumentId, UrlHeads } from "./types.js"
 import type { Segment } from "./subdoc-handles/types.js"
 import { type FindProgress, queryStateToFindProgress } from "./_compat.js"
+import { DocumentLoadFailedError, DocumentUnavailableError } from "./errors.js"
 
 /**
  * The state a {@link DocumentSource} reports for a particular document.
@@ -82,7 +83,12 @@ export interface DocumentProgress<T> {
 
 /** Higher numbers represent earlier availability tiers. */
 export type SourcePriority = number
-type SourceInfo = { state: SourceState; priority: SourcePriority }
+type SourceInfo = {
+  state: SourceState
+  priority: SourcePriority
+  /** If unavailable due to fault */
+  error?: Error
+}
 
 const DEFAULT_SOURCE_PRIORITY = 0
 
@@ -178,7 +184,7 @@ export class DocumentQuery<T> implements DocumentProgress<T> {
 
     // Already unavailable — reject immediately
     if (this.#state.state === "unavailable") {
-      throw new Error(`Document ${this.documentId} is unavailable`)
+      throw new DocumentUnavailableError(this.documentId)
     }
 
     return new Promise<DocHandle<T>>((resolve, reject) => {
@@ -196,7 +202,7 @@ export class DocumentQuery<T> implements DocumentProgress<T> {
           reject(state.error)
         } else if (state.state === "unavailable") {
           cleanup()
-          reject(new Error(`Document ${this.documentId} is unavailable`))
+          reject(new DocumentUnavailableError(this.documentId))
         }
       })
 
@@ -239,14 +245,20 @@ export class DocumentQuery<T> implements DocumentProgress<T> {
   }
 
   /**
-   * A source has determined it cannot provide data right now (e.g. sync
-   * completed with no peers, or no data in local storage). The query
-   * transitions to `unavailable` if no source is still pending and the
-   * handle has no data.
+   * A source has given up on providing the document.
+   *
+   * Omitting `error` asserts a *determinate* negative: the source looked and
+   * the document is not there (an empty storage read, or peers that all replied
+   * they don't have it). Passing `error` says the source could not determine
+   * whether the document exists.
+   *
+   * That distinction decides where the query settles once every source has
+   * given up: `unavailable` only when every negative was determinate, otherwise
+   * `failed` carrying the error.
    */
-  sourceUnavailable(source: string): void {
+  sourceUnavailable(source: string, error?: Error): void {
     if (this.#failed) return
-    this.#setSource(source, "unavailable")
+    this.#setSource(source, "unavailable", error)
     this.#recompute()
   }
 
@@ -293,9 +305,10 @@ export class DocumentQuery<T> implements DocumentProgress<T> {
     return this.#sources.get(source)?.priority ?? DEFAULT_SOURCE_PRIORITY
   }
 
-  #setSource(source: string, state: SourceState): void {
+  #setSource(source: string, state: SourceState, error?: Error): void {
     const priority = this.#sourcePriority(source)
-    this.#sources.set(source, { state, priority })
+    // `error` is present if `sourceUnavailable` was called with an error
+    this.#sources.set(source, { state, priority, error })
   }
 
   #recompute(): void {
@@ -320,8 +333,34 @@ export class DocumentQuery<T> implements DocumentProgress<T> {
     }
 
     // All sources have settled (ready or unavailable) and we still have no
-    // data — nothing more is coming.
+    // data. If any of them gave up without being able to determine whether the
+    // document exists, we don't know that it's absent, so report that rather
+    // than claiming it isn't there.
+    const causes = this.#undeterminedCauses()
+    if (causes) {
+      return {
+        state: "failed",
+        error: new DocumentLoadFailedError(this.documentId, causes),
+        sources,
+      }
+    }
+
     return { state: "unavailable", sources }
+  }
+
+  /**
+   * Why each source gave up without determining whether the document exists,
+   * or undefined if every negative was determinate.
+   */
+  #undeterminedCauses(): Record<string, Error> | undefined {
+    let causes: Record<string, Error> | undefined
+    for (const [name, info] of this.#sources) {
+      if (info.state === "unavailable" && info.error) {
+        causes ??= {}
+        causes[name] = info.error
+      }
+    }
+    return causes
   }
 
   #sourcesView(): Record<string, SourceState> {
@@ -351,9 +390,35 @@ function statesEqual<T>(a: QueryState<T>, b: QueryState<T>): boolean {
   if (a.state === "ready" && b.state === "ready" && a.handle !== b.handle) {
     return false
   }
-  // `failed` is terminal and only reached via fail(), which is called once
-  // per query — its error doesn't churn, so we don't compare it here.
+  // `failed` is reached two ways: terminally via fail(), and derived from
+  // sources that couldn't determine absence. Both can produce a new error
+  // while the source map is unchanged:
+  //  - fail() a derived failure can be replaced by a deletion
+  //  - a source can revise an undetermined negative
+  // So the error has to be compared.
+  if (a.state === "failed" && b.state === "failed") {
+    if (!errorsEquivalent(a.error, b.error)) return false
+  }
   return sourceMapsEqual(a.sources, b.sources)
+}
+
+/**
+ * Identity, except for derived load failures: those are lazily recreated, so
+ * they have to be compared logically. Two DocumentLoadFailedErrors are
+ * equivalent when they blame the same sources with the same underlying errors.
+ */
+function errorsEquivalent(a: Error, b: Error): boolean {
+  if (a === b) return true
+  if (
+    a instanceof DocumentLoadFailedError &&
+    b instanceof DocumentLoadFailedError
+  ) {
+    const aKeys = Object.keys(a.causes)
+    const bKeys = Object.keys(b.causes)
+    if (aKeys.length !== bKeys.length) return false
+    return aKeys.every(key => a.causes[key] === b.causes[key])
+  }
+  return false
 }
 
 function sourceMapsEqual(

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -16,6 +16,7 @@ import {
   progressAtPath,
   type DocumentProgress,
 } from "./DocumentQuery.js"
+import { DocumentDeletedError } from "./errors.js"
 import { RemoteHeadsSubscriptions } from "./RemoteHeadsSubscriptions.js"
 import { StorageSource } from "./StorageSource.js"
 import { SyncStateTracker } from "./SyncStateTracker.js"
@@ -42,7 +43,7 @@ import { Document } from "./Document.js"
 import { truePromiseFactory } from "./helpers/truePromiseFactory.js"
 import { isPlainObject } from "./helpers/isPlainObject.js"
 import { hasAtLeastOneKey } from "./helpers/has-at-least-one-key.js"
-import { noop } from "./helpers/noop.js"
+
 import { semaphore } from "./helpers/semaphore.js"
 
 /**
@@ -186,16 +187,19 @@ export class Repo extends EventEmitter<RepoEvents> {
           if (!storageId || isEph) return
           return this.storageSubsystem.loadSyncState(documentId, storageId)
         },
-        // Resolve to void once the adapters are ready, or on adapter failure
-        // (logged): networkReady gates "peers have had their chance to connect",
-        // so a failed network should let documents settle rather than hang, and
-        // it must never reject (no consumer acts on the rejection, and an
-        // unhandled one would surface before any DocSynchronizer attaches).
-        networkReady: networkSubsystem
-          .whenReady()
-          .then(noop, err =>
+        // Resolves once the adapters are ready, or with the failure cause if
+        // they never became ready. `networkReady` gates "peers have had their
+        // chance to connect", so a failed network should let documents settle
+        // rather than hang, and it must never reject. The error is carried so
+        // sync can distinguish "there was nobody to ask" from "we asked and
+        // nobody had it".
+        networkReady: networkSubsystem.whenReady().then(
+          () => undefined,
+          (err: unknown) => {
             this.#log.error("network adapters failed to become ready", err)
-          ),
+            return err instanceof Error ? err : new Error(String(err))
+          }
+        ),
         syncStateLoadConcurrency,
         sharePolicyConcurrency,
       },
@@ -597,7 +601,7 @@ export class Repo extends EventEmitter<RepoEvents> {
       query.handle.delete()
     }
     if (query) {
-      query.fail(new Error(`Document ${documentId} was deleted`))
+      query.fail(new DocumentDeletedError(documentId))
     }
     delete this.#queries[documentId]
 

--- a/packages/automerge-repo/src/StorageSource.ts
+++ b/packages/automerge-repo/src/StorageSource.ts
@@ -75,7 +75,12 @@ export class StorageSource implements DocumentSource {
           `Error loading document ${handle.documentId} from storage`,
           err
         )
-        query.sourceUnavailable("storage")
+        // Report it as undetermined rather than a plain negative: the read
+        // failed, so we never learned whether the document is in storage.
+        query.sourceUnavailable(
+          "storage",
+          err instanceof Error ? err : new Error(String(err))
+        )
       })
   }
 

--- a/packages/automerge-repo/src/errors.ts
+++ b/packages/automerge-repo/src/errors.ts
@@ -1,0 +1,77 @@
+import type { DocumentId } from "./types.js"
+
+/**
+ * Thrown when a wait for a document gives up because every registered source
+ * has reported that it cannot provide the document.
+ *
+ * @remarks
+ * Unavailability is not necessarily permanent: a source may return to `pending`
+ * when circumstances change, for example when a peer that holds the document
+ * connects.
+ *
+ * This error means every source reached a *determinate* negative. A source that
+ * could not complete the read settles as {@link DocumentLoadFailedError}
+ * instead.
+ *
+ * Note that the sync protocol does not distinguish these failure modes, so
+ * peers may claim a document unavailable even if they failed to check.
+ */
+export class DocumentUnavailableError extends Error {
+  readonly documentId: DocumentId
+
+  constructor(documentId: DocumentId) {
+    super(`Document ${documentId} is unavailable`)
+    this.name = "DocumentUnavailableError"
+    this.documentId = documentId
+  }
+}
+
+/**
+ * Thrown when every source has given up on a document and at least one of them
+ * could not determine whether it exists: a failed storage read, network
+ * adapters that never came up.
+ *
+ * @remarks
+ * Distinct from {@link DocumentUnavailableError}, which asserts a determinate
+ * negative. Here the document's absence was never established.
+ *
+ * {@link DocumentLoadFailedError.causes} is keyed by source name (`"storage"`,
+ * `"automerge-sync"`), because more than one source can fail for unrelated
+ * reasons.
+ */
+export class DocumentLoadFailedError extends Error {
+  readonly documentId: DocumentId
+
+  /** Why each source could not determine availability, by source name. */
+  readonly causes: Record<string, Error>
+
+  constructor(documentId: DocumentId, causes: Record<string, Error>) {
+    const detail = Object.entries(causes)
+      .map(([source, cause]) => `${source}: ${cause.message}`)
+      .join("; ")
+    super(`Document ${documentId} could not be loaded (${detail})`)
+    this.name = "DocumentLoadFailedError"
+    this.documentId = documentId
+    this.causes = causes
+  }
+}
+
+/**
+ * Thrown when a document has been deleted locally, via {@link Repo.delete}.
+ *
+ * @remarks
+ * A deleted document surfaces through the same `failed` query state as a
+ * genuine fault (a storage error, say), but the two call for opposite
+ * responses: deletion is an intentional, known-terminal outcome, whereas a
+ * fault may be transient and retryable. Catching this type distinguishes them
+ * without matching on message text.
+ */
+export class DocumentDeletedError extends Error {
+  readonly documentId: DocumentId
+
+  constructor(documentId: DocumentId) {
+    super(`Document ${documentId} was deleted`)
+    this.name = "DocumentDeletedError"
+    this.documentId = documentId
+  }
+}

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -40,6 +40,11 @@ export {
 } from "./AutomergeUrl.js"
 export type { ParsedAutomergeUrl, UrlOptions } from "./AutomergeUrl.js"
 export { Repo } from "./Repo.js"
+export {
+  DocumentDeletedError,
+  DocumentLoadFailedError,
+  DocumentUnavailableError,
+} from "./errors.js"
 export { setLoggerFactory, makeLogger } from "./Logger.js"
 export type { Logger, LoggerFactory } from "./Logger.js"
 export { Presence } from "./presence/Presence.js"

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -57,12 +57,12 @@ export interface AutomergeSyncConfig {
   syncStateLoadConcurrency?: number
 
   /**
-   * Resolves when the network layer is ready to send messages.
-   * Documents created before this resolves get a "network" source
-   * registered on their query to keep them in "loading" state until
-   * peers have had a chance to connect.
+   * Resolves when the network layer is ready to send messages, or with the
+   * error if the adapters never became ready. Documents created before this
+   * resolves get a "network" source registered on their query to keep them
+   * in "loading" state until peers have had a chance to connect.
    */
-  networkReady: Promise<void>
+  networkReady: Promise<Error | undefined>
 
   /**
    * Maximum number of share-policy resolutions run concurrently during
@@ -95,7 +95,7 @@ export class CollectionSynchronizer
   #docSynchronizers: Record<DocumentId, DocSynchronizer> = {}
   #denylist: DocumentId[]
   #config: AutomergeSyncConfig
-  #networkReady: Promise<void>
+  #networkReady: Promise<Error | undefined>
   #log = makeLogger("automerge-repo:collectionsync")
 
   // Bounds the loadSyncState reads fanned out when peers are added to documents,

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -119,6 +119,8 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
   #shareConfig: ShareConfig
   #seenEphemeralMessages = new HashRing(1000)
   #networkReady: boolean = false
+  /** Set when the adapters never became ready, so we could not ask anyone. */
+  #networkError: Error | undefined
 
   constructor({
     handle,
@@ -128,7 +130,7 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
   }: {
     handle: DocHandle<unknown>
     query: DocumentQuery<unknown>
-    networkReady: Promise<void>
+    networkReady: Promise<Error | undefined>
     shareConfig: ShareConfig
   }) {
     super()
@@ -172,8 +174,9 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
     )
 
     networkReady
-      .then(() => {
+      .then(error => {
         this.#networkReady = true
+        this.#networkError = error
         this.#evaluate()
       })
       .catch(() => {})
@@ -428,10 +431,16 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
     // query state is up-to-date when we check whether to send doc-unavailable.
     this.#updateAvailability()
 
-    // Phase 3: Notify wanting peers that the document is unavailable.
-    // Only fires when the query has settled to unavailable/failed
-    // and we have no data. The "unavailable-notified" status ensures each
-    // peer is only told once.
+    // Phase 3: Notify wanting peers that the document is unavailable. Only
+    // fires when the query has settled to unavailable/failed and we have no
+    // data. The "unavailable-notified" status ensures each peer is only told
+    // once.
+    //
+    // Including `failed` here is deliberate, and it is lossy. Locally the two
+    // states differ: `unavailable` means we established the document isn't
+    // here, `failed` means we couldn't establish anything (a storage fault,
+    // adapters that never came up). The protocol does not support this
+    // distinction.
     const queryState = this.#query.peek()
     if (
       !weHaveData &&
@@ -488,13 +497,16 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
    * - `ready`: at least one connected `has` peer's advertised initial
    *   heads are present in our doc — we have a complete copy from
    *   someone.
-   * - `unavailable`: no connected peer ever advertised the doc.
+   * - `unavailable`: no connected peer ever advertised the doc
    */
   #updateAvailability(): void {
     if (!this.#networkReady) return
 
     if (this.#peers.size === 0) {
-      this.#query.sourceUnavailable("automerge-sync")
+      // With healthy adapters and no peers there is genuinely nobody to ask,
+      // which is an answer. Pass along `#networkError` in case the adapters
+      // themselves failed,.
+      this.#query.sourceUnavailable("automerge-sync", this.#networkError)
       return
     }
 

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/AutomergeUrl.js"
 import { DocHandle } from "../src/DocHandle.js"
 import { DocumentQuery } from "../src/DocumentQuery.js"
+import { DocumentLoadFailedError } from "../src/errors.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { MessageContents } from "../src/network/messages.js"
 import { DocSynchronizer } from "../src/synchronizer/DocSynchronizer.js"
@@ -64,6 +65,100 @@ describe("DocSynchronizer", () => {
   it("takes the handle passed into it", () => {
     const { handle, docSynchronizer } = setup()
     assert(docSynchronizer.documentId === handle.documentId)
+  })
+
+  describe("availability with no peers", () => {
+    /** An empty handle plus a query with sync registered as a source. */
+    const setupEmpty = () => {
+      const docId = parseAutomergeUrl(generateAutomergeUrl()).documentId
+      const emptyHandle = createTestHandle<TestDoc>(docId)
+      const query = new DocumentQuery(emptyHandle as DocHandle<unknown>)
+      query.sourcePending("automerge-sync")
+      return { emptyHandle, query }
+    }
+
+    it("settles unavailable when the network is healthy and nobody is connected", async () => {
+      const { emptyHandle, query } = setupEmpty()
+
+      new DocSynchronizer({
+        handle: emptyHandle as DocHandle<unknown>,
+        query,
+        networkReady: Promise.resolve(undefined),
+        shareConfig: defaultShareConfig,
+      })
+
+      await vi.waitFor(() => assert.notEqual(query.peek().state, "loading"))
+
+      // Working adapters with no peers is a real answer: there is nobody
+      // left to ask, so the document is genuinely not obtainable.
+      assert.equal(query.peek().state, "unavailable")
+    })
+
+    it("still tells wanting peers unavailable when the query failed", async () => {
+      // Deliberate lossiness, see Phase 3 in DocSynchronizer: a `failed` query
+      // means we couldn't determine anything, but we must still respond.
+      const docId = parseAutomergeUrl(generateAutomergeUrl()).documentId
+      const aliceHandle = createTestHandle<TestDoc>(docId)
+      const aliceQuery = new DocumentQuery(aliceHandle)
+      aliceQuery.sourcePending("automerge-sync")
+      aliceQuery.sourceUnavailable("storage", new Error("disk fault"))
+
+      const aliceSync = new DocSynchronizer({
+        handle: aliceHandle as DocHandle<unknown>,
+        query: aliceQuery as DocumentQuery<unknown>,
+        networkReady,
+        shareConfig: defaultShareConfig,
+      })
+
+      // A peer that wants the document from us.
+      const drewHandle = createTestHandle<TestDoc>(docId)
+      const drewSync = createDocSynchronizer(drewHandle as DocHandle<unknown>)
+      const drewReqP = eventPromise(drewSync, "message")
+      drewSync.addPeer(alice, Promise.resolve(undefined))
+      const drewReq = await drewReqP
+
+      const aliceMessages: MessageContents[] = []
+      aliceSync.on("message", m => aliceMessages.push(m))
+      aliceSync.addPeer("drew" as PeerId, Promise.resolve(undefined))
+      await new Promise(setImmediate)
+
+      aliceSync.receiveMessage({ ...drewReq, senderId: "drew" as PeerId })
+      await new Promise(setImmediate)
+      await new Promise(setImmediate)
+
+      assert.equal(aliceQuery.peek().state, "failed")
+      assert.ok(
+        aliceMessages.find(
+          m => m.type === "doc-unavailable" && m.targetId === "drew"
+        ),
+        "a failed query should still settle the wanting peer"
+      )
+    })
+
+    it("settles failed when the adapters never became ready", async () => {
+      const { emptyHandle, query } = setupEmpty()
+      const adapterFailure = new Error("adapters failed to become ready")
+
+      new DocSynchronizer({
+        handle: emptyHandle as DocHandle<unknown>,
+        query,
+        networkReady: Promise.resolve(adapterFailure),
+        shareConfig: defaultShareConfig,
+      })
+
+      await vi.waitFor(() => assert.notEqual(query.peek().state, "loading"))
+
+      // Same zero peers, but we never got to ask anyone, so claiming the
+      // document is absent would be asserting something we never learned.
+      const state = query.peek()
+      assert.equal(state.state, "failed")
+      if (state.state === "failed") {
+        // Attributed to sync specifically, so a caller can tell an
+        // unreachable network from a storage fault.
+        const { causes } = state.error as DocumentLoadFailedError
+        assert.equal(causes["automerge-sync"], adapterFailure)
+      }
+    })
   })
 
   it("emits a syncMessage when addPeer is called", async () => {

--- a/packages/automerge-repo/test/DocumentQuery.test.ts
+++ b/packages/automerge-repo/test/DocumentQuery.test.ts
@@ -1,6 +1,11 @@
 import { next as A } from "@automerge/automerge"
 import { describe, expect, it, vi } from "vitest"
 import { DocumentQuery, progressAtHeads } from "../src/DocumentQuery.js"
+import {
+  DocumentDeletedError,
+  DocumentLoadFailedError,
+  DocumentUnavailableError,
+} from "../src/errors.js"
 import { encodeHeads } from "../src/AutomergeUrl.js"
 import type { DocumentId, UrlHeads } from "../src/types.js"
 import { createTestQuery } from "./helpers/testHandle.js"
@@ -106,6 +111,142 @@ describe("DocumentQuery", () => {
 
       query.sourcePending("source-a")
       expect(query.peek().state).toBe("loading")
+    })
+
+    it("transitions to failed when a source gave up without determining absence", () => {
+      const query = createTestQuery(docId)
+      query.sourcePending("source-a")
+      query.sourceUnavailable("source-a", new Error("read failed"))
+
+      const state = query.peek()
+      expect(state.state).toBe("failed")
+      if (state.state === "failed") {
+        expect(state.error).toBeInstanceOf(DocumentLoadFailedError)
+        const { causes } = state.error as DocumentLoadFailedError
+        expect(causes["source-a"].message).toBe("read failed")
+      }
+    })
+
+    it("collects a cause per source rather than reporting only the first", () => {
+      const query = createTestQuery(docId)
+      query.sourcePending("storage")
+      query.sourcePending("automerge-sync")
+      query.sourceUnavailable("storage", new Error("disk on fire"))
+      query.sourceUnavailable("automerge-sync", new Error("adapters down"))
+
+      const state = query.peek()
+      expect(state.state).toBe("failed")
+      if (state.state === "failed") {
+        const { causes } = state.error as DocumentLoadFailedError
+        expect(Object.keys(causes).sort()).toEqual([
+          "automerge-sync",
+          "storage",
+        ])
+        expect(state.error.message).toMatch(/storage: disk on fire/)
+        expect(state.error.message).toMatch(/automerge-sync: adapters down/)
+      }
+    })
+
+    it("stays unavailable when only determinate sources gave up", () => {
+      const query = createTestQuery(docId)
+      query.sourcePending("source-a")
+      query.sourcePending("source-b")
+      query.sourceUnavailable("source-a")
+      query.sourceUnavailable("source-b")
+
+      expect(query.peek().state).toBe("unavailable")
+    })
+
+    it("prefers failed over unavailable when sources are mixed", () => {
+      const query = createTestQuery(docId)
+      query.sourcePending("determinate")
+      query.sourcePending("undetermined")
+      // One source has a real answer, the other never found out. We don't
+      // collectively know the document is absent, so we must not say so.
+      query.sourceUnavailable("determinate")
+      query.sourceUnavailable("undetermined", new Error("could not reach"))
+
+      expect(query.peek().state).toBe("failed")
+    })
+
+    it("leaves the derived failed state when a source retries", () => {
+      const query = createTestQuery(docId)
+      query.sourcePending("source-a")
+      query.sourceUnavailable("source-a", new Error("read failed"))
+      expect(query.peek().state).toBe("failed")
+
+      query.sourcePending("source-a")
+      expect(query.peek().state).toBe("loading")
+
+      loadInto(query, [makeBlob({ count: 7 })])
+      expect(query.peek().state).toBe("ready")
+    })
+
+    it("lets a terminal fail() replace a derived failure", () => {
+      const query = createTestQuery(docId)
+      query.sourcePending("storage")
+      query.sourceUnavailable("storage", new Error("disk on fire"))
+      const stateBefore = query.peek()
+      expect(stateBefore.state).toBe("failed")
+      if (stateBefore.state === "failed") {
+        expect(stateBefore.error).not.toBeInstanceOf(DocumentDeletedError)
+      }
+      expect(query.peek().state)
+
+      const subscriber = vi.fn()
+      query.subscribe(subscriber)
+      query.fail(new DocumentDeletedError(docId))
+
+      const state = query.peek()
+      expect(state.state).toBe("failed")
+      if (state.state === "failed") {
+        expect(state.error).toBeInstanceOf(DocumentDeletedError)
+      }
+      expect(subscriber).toHaveBeenCalledTimes(1)
+    })
+
+    it("picks up a second undetermined cause reported later", () => {
+      const query = createTestQuery(docId)
+      query.sourcePending("storage")
+      query.sourcePending("automerge-sync")
+      query.sourceUnavailable("automerge-sync")
+      query.sourceUnavailable("storage", new Error("first"))
+
+      const subscriber = vi.fn()
+      query.subscribe(subscriber)
+      query.sourceUnavailable("automerge-sync", new Error("adapters down"))
+
+      const state = query.peek()
+      if (state.state !== "failed") throw new Error("expected failed")
+      const { causes } = state.error as DocumentLoadFailedError
+      expect(Object.keys(causes).sort()).toEqual(["automerge-sync", "storage"])
+      expect(subscriber).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not churn subscribers while the causes are unchanged", () => {
+      const query = createTestQuery(docId)
+      query.sourcePending("storage")
+      const cause = new Error("disk on fire")
+      query.sourceUnavailable("storage", cause)
+
+      const subscriber = vi.fn()
+      query.subscribe(subscriber)
+      // Re-reporting the identical cause rebuilds the error object, which
+      // must not read as a transition.
+      query.sourceUnavailable("storage", cause)
+      query.sourceUnavailable("storage", cause)
+
+      expect(subscriber).not.toHaveBeenCalled()
+    })
+
+    it("clears a stale error when a source reports a determinate negative", () => {
+      const query = createTestQuery(docId)
+      query.sourcePending("source-a")
+      query.sourceUnavailable("source-a", new Error("read failed"))
+      expect(query.peek().state).toBe("failed")
+
+      query.sourceUnavailable("source-a")
+      expect(query.peek().state).toBe("unavailable")
     })
 
     it("transitions from unavailable to ready when data arrives", () => {
@@ -262,6 +403,49 @@ describe("DocumentQuery", () => {
       await promise
 
       expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function))
+    })
+
+    it("rejects with DocumentUnavailableError when already unavailable", async () => {
+      const query = createTestQuery(docId)
+      query.sourceUnavailable("test")
+      expect(query.peek().state).toBe("unavailable")
+
+      await expect(query.whenReady()).rejects.toThrow(DocumentUnavailableError)
+    })
+
+    it("rejects with DocumentUnavailableError when it becomes unavailable while waiting", async () => {
+      const query = createTestQuery(docId)
+      query.sourcePending("test")
+
+      const promise = query.whenReady()
+      query.sourceUnavailable("test")
+
+      await expect(promise).rejects.toThrow(DocumentUnavailableError)
+    })
+
+    it("reports the documentId on the error", async () => {
+      const query = createTestQuery(docId)
+      query.sourceUnavailable("storage")
+      query.sourceUnavailable("sync")
+
+      const error = await query.whenReady().catch(e => e)
+
+      expect(error).toBeInstanceOf(DocumentUnavailableError)
+      expect(error.documentId).toBe(docId)
+    })
+
+    it("distinguishes a determinate negative from an undetermined one by type", async () => {
+      const determinate = createTestQuery(docId)
+      determinate.sourceUnavailable("storage")
+      await expect(determinate.whenReady()).rejects.toBeInstanceOf(
+        DocumentUnavailableError
+      )
+
+      const undetermined = createTestQuery(docId)
+      undetermined.sourceUnavailable("storage", new Error("read failed"))
+      await expect(undetermined.whenReady()).rejects.toBeInstanceOf(
+        DocumentLoadFailedError
+      )
     })
   })
 

--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -12,6 +12,7 @@ import {
   stringifyAutomergeUrl,
 } from "../src/AutomergeUrl.js"
 import { DocMetrics, Repo, ShareConfig } from "../src/Repo.js"
+import { DocumentDeletedError } from "../src/errors.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import { pause } from "../src/helpers/pause.js"
 import {
@@ -407,6 +408,30 @@ describe("Repo", () => {
 
       assert.equal(repo.handles[handle.documentId], undefined)
       assert.equal(repo.handles[handle.documentId], undefined)
+    })
+
+    it("fails an outstanding query with DocumentDeletedError on delete", async () => {
+      const { repo } = setup()
+      const handle = repo.create<TestDoc>()
+      handle.change(d => {
+        d.foo = "bar"
+      })
+      await pause()
+
+      // Hold the query from before the delete: `delete` drops it from the
+      // repo's cache, so a later `find` would start a fresh one and report
+      // plain unavailability instead.
+      const progress = repo.findWithProgress<TestDoc>(handle.url)
+      repo.delete(handle.documentId)
+
+      const error = await progress.whenReady().catch(e => e)
+
+      // Deletion is intentional and terminal; a storage fault may be
+      // transient. Both use the `failed` state, so the type is what tells
+      // them apart without matching on message text.
+      expect(error).toBeInstanceOf(DocumentDeletedError)
+      expect(error.documentId).toBe(handle.documentId)
+      expect(error.message).toMatch(/Document (.*) was deleted/)
     })
 
     it("can delete an existing document by url", async () => {

--- a/packages/automerge-repo/test/StorageSource.test.ts
+++ b/packages/automerge-repo/test/StorageSource.test.ts
@@ -74,7 +74,7 @@ describe("StorageSource", () => {
     assert.equal(merged.shared, "base")
   })
 
-  it("marks the storage source unavailable when the load fails, instead of leaving the query stuck loading", async () => {
+  it("settles the query as failed when the load fails, instead of leaving it stuck loading", async () => {
     vi.useFakeTimers()
     try {
       type T = { foo?: string }
@@ -98,15 +98,19 @@ describe("StorageSource", () => {
       // (rejected) microtask chain deterministically (no real-time wait).
       await vi.runAllTimersAsync()
 
-      // A failed storage load must settle the "storage" source as unavailable
-      // so the query can resolve. With storage the only source and no handle
-      // data, the query becomes "unavailable" and whenReady() rejects.
+      // The read failed, so we never learned whether the document is in
+      // storage. With storage the only source, the query settles `failed`
+      // carrying that error.
+      const state = query.peek()
       assert.equal(
-        query.peek().state,
-        "unavailable",
-        "failed storage load should mark the source unavailable, not hang the query"
+        state.state,
+        "failed",
+        "failed storage load should settle the query, not hang it"
       )
-      await assert.rejects(query.whenReady(), /unavailable/)
+      if (state.state === "failed") {
+        assert.match(state.error.message, /storage read failed/)
+      }
+      await assert.rejects(query.whenReady(), /storage read failed/)
     } finally {
       vi.useRealTimers()
     }


### PR DESCRIPTION
Adds typed errors for DocumentDeleted, DocumentedLoadFailed, and
DocumentUnavailable to communicate the relevant document id when
operations fail. This makes it easier to handle errors far from a
failing `find`.

It also distinguishes "I don't have it" from "I could not check if I
have it," and allows the caller to react differently on a definite
absence versus what could be a transient error.

Update the React useDocument hook for this behavior as well.
