### PR TITLE
optionally customize WebSocketClientAdapter WebSocket construction

### DIFF
--- a/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
+++ b/packages/automerge-repo-network-websocket/src/WebSocketClientAdapter.ts
@@ -22,6 +22,8 @@ abstract class WebSocketNetworkAdapter extends NetworkAdapter {
   socket?: WebSocket
 }
 
+type WebSocketFactory = (url: string) => WebSocket
+
 export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
   #ready = false
   #readyResolver?: () => void
@@ -49,15 +51,18 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
   #forceReadyTimeoutId?: TimeoutId
   #disconnected = false
   #log = debug("automerge-repo:websocket:browser")
+  #socketFactory: WebSocketFactory
 
   remotePeerId?: PeerId // this adapter only connects to one remote client at a time
 
   constructor(
     public readonly url: string,
-    public readonly retryInterval = 5000
+    public readonly retryInterval = 5000,
+    socketFactory?: WebSocketFactory
   ) {
     super()
     this.#log = this.#log.extend(url)
+    this.#socketFactory = socketFactory ?? (url => new WebSocket(url))
   }
 
   connect(peerId: PeerId, peerMetadata?: PeerMetadata) {
@@ -82,7 +87,7 @@ export class WebSocketClientAdapter extends WebSocketNetworkAdapter {
         this.connect(peerId, peerMetadata)
       }, this.retryInterval)
 
-    this.socket = new WebSocket(this.url)
+    this.socket = this.#socketFactory(this.url)
 
     this.socket.binaryType = "arraybuffer"
 

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -18,7 +18,7 @@ import * as CBOR from "cbor-x"
 import { EventEmitter, once } from "events"
 import http from "http"
 import { getPortPromise as getAvailablePort } from "portfinder"
-import { afterEach, describe, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import WebSocket, { WebSocketServer } from "ws"
 import { WebSocketClientAdapter } from "../src/WebSocketClientAdapter.js"
 import { WebSocketServerAdapter } from "../src/WebSocketServerAdapter.js"
@@ -364,6 +364,34 @@ describe("Websocket adapters", () => {
       })
 
       server.close()
+    })
+
+    it("should use the provided socket factory to connect", async () => {
+      const port = await getPort() //?
+      const retryInterval = 100
+      const socketFactory = vi
+        .fn()
+        .mockImplementation(
+          url => new WebSocket(url, ["protocol1", "protocol2"])
+        )
+
+      const browserAdapter = await setupClient({
+        port,
+        retryInterval,
+        socketFactory,
+      })
+
+      const _browserRepo = new Repo({
+        network: [browserAdapter],
+        peerId: browserPeerId,
+      })
+
+      await pause(500)
+
+      const { serverAdapter } = await setupServer({ port, retryInterval })
+
+      expect(socketFactory).toBeCalled()
+      await eventPromise(browserAdapter, "peer-candidate")
     })
   })
 
@@ -945,9 +973,10 @@ const setupClient = async (options: SetupOptions = {}) => {
     clientCount = 1,
     retryInterval = 1000,
     port = await getPort(),
+    socketFactory,
   } = options
   const serverUrl = `ws://localhost:${port}`
-  return new WebSocketClientAdapter(serverUrl, retryInterval)
+  return new WebSocketClientAdapter(serverUrl, retryInterval, socketFactory)
 }
 
 const pause = (t = 0) =>
@@ -979,4 +1008,5 @@ type SetupOptions = {
   clientCount?: number
   retryInterval?: number
   port?: number
+  socketFactory?: (url: string) => WebSocket
 }

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -386,12 +386,9 @@ describe("Websocket adapters", () => {
         peerId: browserPeerId,
       })
 
-      await pause(500)
-
       const { serverAdapter } = await setupServer({ port, retryInterval })
 
-      expect(socketFactory).toBeCalled()
-      await eventPromise(browserAdapter, "peer-candidate")
+      expect(socketFactory).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
I'd like to authenticate clients connecting via WebSocket using [the Kubernetes trick of smuggling a bearer token in via the Sec-WebSocket-Protocol header value](https://github.com/kubernetes/kubernetes/commit/714f97d7baf4975ad3aa47735a868a81a984d1f0) so that it works for clients either in the browser (where that's the only header we can modify) or with the `ws` library (where we have more control).  I couldn't see a good way to do this without copying `WebSocketClientAdapter` into my application and modifying it, although I'd love it if I just missed a better way to accomplish this.

In this PR, `WebSocketClientAdapter` optionally accepts an additional argument, a "web socket factory" function, in the constructor.  If supplied, that function is then called in `.connect()`, rather than calling `new WebSocket(url)` directly.  In the browser, that might look like this:

```ts
    const socketFactory = (url: string) => new WebSocket(url, [
        `base64url.bearer.authorization.io.${bearerTokenWithoutTrailingPadding}`,
    ]);

    const repo = new Automerge.Repo({
        network: [
            new CustomWebSocketClientAdapter(
                url,
                RETRY_INTERVAL_MS,
                socketFactory,
            ),
        ],
        storage: new Automerge.IndexedDBStorageAdapter(),
    });
```