### PR TITLE
Capture commit/fragment ids on bulk blob load and stop compaction deleting blobs awaiting decryption

### DIFF
--- a/examples/react-counter/package.json
+++ b/examples/react-counter/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-demo-counter",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/examples/react-counter",
   "private": true,
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/examples/react-remote-heads/package.json
+++ b/examples/react-remote-heads/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-demo-remote-heads",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/examples/react-remote-heads",
   "private": true,
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/examples/react-todo-worker/package.json
+++ b/examples/react-todo-worker/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-demo-todo-worker",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/examples/react-todo-worker",
   "private": true,
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/examples/react-todo/package.json
+++ b/examples/react-todo/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-demo-todo",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/examples/react-todo",
   "private": true,
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/examples/react-use-presence/package.json
+++ b/examples/react-use-presence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-demo-use-presence",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "private": true,
   "repository": "https://github.com/automerge/automerge-repo/tree/main/examples/react-use-presence",
   "type": "module",

--- a/examples/svelte-counter/package.json
+++ b/examples/svelte-counter/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/automerge-repo-demo-counter-svelte",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/examples/svelte-counter",
   "private": true,
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/sync-server/package.json
+++ b/examples/sync-server/package.json
@@ -2,7 +2,7 @@
   "name": "@automerge/example-sync-server",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/examples/sync-server",
   "private": true,
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "main": "index.js",
   "license": "MIT",
   "type": "module",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "pnpm",
-  "version": "2.6.0-subduction.47"
+  "version": "2.6.0-subduction.48"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-monorepo",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "Automerge Repo monorepo",
   "main": "packages/automerge-repo/dist/index.js",
   "repository": "https://github.com/automerge/automerge-repo",

--- a/packages/automerge-react/package.json
+++ b/packages/automerge-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/react",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "A quick-import React package for Automerge Repo",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/automerge-react",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",

--- a/packages/automerge-repo-network-broadcastchannel/package.json
+++ b/packages/automerge-repo-network-broadcastchannel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-network-broadcastchannel",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "BroadcastChannel network adapter for Automerge Repo",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/automerge-repo-network-broadcastchannel",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",

--- a/packages/automerge-repo-network-messagechannel/package.json
+++ b/packages/automerge-repo-network-messagechannel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-network-messagechannel",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "MessageChannel network adapter for Automerge Repo",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/automerge-repo-network-messagechannel",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",

--- a/packages/automerge-repo-network-websocket/package.json
+++ b/packages/automerge-repo-network-websocket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-network-websocket",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "isomorphic node/browser Websocket network adapter for Automerge Repo",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/automerge-repo-network-websocket",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",

--- a/packages/automerge-repo-react-hooks/package.json
+++ b/packages/automerge-repo-react-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-react-hooks",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "Hooks to access an Automerge Repo from your react app.",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/automerge-repo-react-hooks",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",

--- a/packages/automerge-repo-solid-primitives/package.json
+++ b/packages/automerge-repo-solid-primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-solid-primitives",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "Access Automerge Repo in your SolidJS application",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/automerge-repo-storage-indexeddb/package.json
+++ b/packages/automerge-repo-storage-indexeddb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-storage-indexeddb",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "IndexedDB storage adapter for Automerge Repo",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/automerge-repo-storage-indexeddb",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",

--- a/packages/automerge-repo-storage-lmdb/package.json
+++ b/packages/automerge-repo-storage-lmdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-storage-lmdb",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "LMDB storage adapter for Automerge Repo (Node)",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/automerge-repo-storage-lmdb",
   "author": "Brooklyn Zelenka <hello@brooklynzelenka.com>",

--- a/packages/automerge-repo-storage-nodefs/package.json
+++ b/packages/automerge-repo-storage-nodefs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-storage-nodefs",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "Simple Node filesystem storage adapter for Automerge Repo",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/automerge-repo-storage-nodefs",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",

--- a/packages/automerge-repo-svelte-store/package.json
+++ b/packages/automerge-repo-svelte-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo-svelte-store",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "A Svelte store containing your automerge documents",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/automerge-repo-svelte-store",
   "license": "MIT",

--- a/packages/automerge-repo/package.json
+++ b/packages/automerge-repo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-repo",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "A repository object to manage a collection of automerge documents",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/automerge-repo",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -190,6 +190,14 @@ interface SedimentreeEntry {
    */
   saveDeltaPending: boolean
 
+  /**
+   * Hashes of blobs that arrived and were persisted but that the interceptor
+   * could not transform yet (their decryption key had not arrived).
+   * `#compactAbsorbed` would otherwise classify them as absorbed into a fragment
+   * and delete them before we are able to decrypt them.
+   */
+  untransformedHashes: Set<string>
+
   // True when stored blobs exist that the interceptor could not transform
   // (e.g., their decryption keys have not arrived yet). shareConfigChanged
   // uses this to re-transform such an entry's blobs once a key change may
@@ -657,11 +665,14 @@ export class SubductionSource implements DocumentSource {
           if (!result) {
             // Could not transform this blob yet. Mark the entry so a later
             // shareConfigChanged retries it, and schedule a content-driven
-            // retry.
+            // retry. Remember the hash so compaction does not delete the
+            // stored blob before that retry can run.
             entry.hasUntransformedBlobs = true
+            entry.untransformedHashes.add(hex)
             this.#scheduleTransformRetry(entry)
             return
           }
+          entry.untransformedHashes.delete(hex)
           entry.pendingInbound.push(result)
           if (!entry.inboundFlushScheduled) {
             entry.inboundFlushScheduled = true
@@ -771,6 +782,7 @@ export class SubductionSource implements DocumentSource {
       lastSavedHeads: new Set(),
       knownHashes: new Set(),
       persistedCommitHashes: new Set(),
+      untransformedHashes: new Set(),
       persistedFragmentHashes: new Set(),
       compactionInFlight: null,
       flushSave: throttledSave,
@@ -1218,8 +1230,7 @@ export class SubductionSource implements DocumentSource {
     if (!allBlobs || allBlobs.length === 0) return false
 
     // Prefer the id-keyed view of the same blobs. Fall back to the id-less one
-    // if it does not cover everything subduction reports, so this can only add
-    // ids, never drop a blob.
+    // if it does not cover everything subduction reports.
     let blobsWithIds: Array<{ idHex: string; blob: Uint8Array }> | null = null
     try {
       const keyed = await this.#idKeyedBlobs(entry)
@@ -1233,8 +1244,8 @@ export class SubductionSource implements DocumentSource {
     if (!blobsWithIds) blobsWithIds = allBlobs.map(blob => ({ idHex: "", blob }))
     blobsWithIds.sort((a, b) => b.blob.byteLength - a.blob.byteLength)
 
-    // Everything here is already in subduction's storage, so none of it is a
-    // local write and none of it should be re-encrypted and re-saved as one.
+    // Record these IDs as known hashes since nothing in subduction's storage
+    // should be re-encrypted and re-saved.
     for (const u of blobsWithIds) {
       if (u.idHex) entry.knownHashes.add(u.idHex)
     }
@@ -1260,8 +1271,10 @@ export class SubductionSource implements DocumentSource {
           )
           if (result) {
             transformed.push(result)
+            if (unit.idHex) entry.untransformedHashes.delete(unit.idHex)
           } else {
             stillPending.push(unit)
+            if (unit.idHex) entry.untransformedHashes.add(unit.idHex)
           }
         }
         pending = stillPending
@@ -1793,11 +1806,15 @@ export class SubductionSource implements DocumentSource {
 
     const staleCommits: string[] = []
     for (const hex of entry.persistedCommitHashes) {
-      if (!liveCommits.has(hex)) staleCommits.push(hex)
+      if (!liveCommits.has(hex) && !entry.untransformedHashes.has(hex)) {
+        staleCommits.push(hex)
+      }
     }
     const staleFragments: string[] = []
     for (const hex of entry.persistedFragmentHashes) {
-      if (!liveFragments.has(hex)) staleFragments.push(hex)
+      if (!liveFragments.has(hex) && !entry.untransformedHashes.has(hex)) {
+        staleFragments.push(hex)
+      }
     }
 
     if (staleCommits.length === 0 && staleFragments.length === 0) return

--- a/packages/automerge-repo/src/subduction/source.ts
+++ b/packages/automerge-repo/src/subduction/source.ts
@@ -1166,6 +1166,32 @@ export class SubductionSource implements DocumentSource {
   }
 
   /**
+   * Pair each stored blob with the commit or fragment id it belongs to.
+   */
+  async #idKeyedBlobs(
+    entry: SedimentreeEntry
+  ): Promise<Array<{ idHex: string; blob: Uint8Array }>> {
+    const [commits, fragments] = await Promise.all([
+      this.#storage.loadAllCommits(entry.sedimentreeId),
+      this.#storage.loadAllFragments(entry.sedimentreeId),
+    ])
+    const out: Array<{ idHex: string; blob: Uint8Array }> = []
+    for (const c of commits) {
+      out.push({
+        idHex: c.signed.payload.commitId.toHexString(),
+        blob: new Uint8Array(c.blob),
+      })
+    }
+    for (const f of fragments) {
+      out.push({
+        idHex: f.signed.payload.head.toHexString(),
+        blob: new Uint8Array(f.blob),
+      })
+    }
+    return out
+  }
+
+  /**
    * Load all blobs for a sedimentree from Subduction and apply them to the
    * handle via `Automerge.loadIncremental`. If new data was loaded, signal
    * the query so it can transition to "ready".
@@ -1190,31 +1216,52 @@ export class SubductionSource implements DocumentSource {
       } blob(s), ${totalBytes} bytes, heads=${headCount()}`
     )
     if (!allBlobs || allBlobs.length === 0) return false
-    allBlobs.sort((a, b) => b.byteLength - a.byteLength)
 
-    let toApply = allBlobs
+    // Prefer the id-keyed view of the same blobs. Fall back to the id-less one
+    // if it does not cover everything subduction reports, so this can only add
+    // ids, never drop a blob.
+    let blobsWithIds: Array<{ idHex: string; blob: Uint8Array }> | null = null
+    try {
+      const keyed = await this.#idKeyedBlobs(entry)
+      if (keyed.length >= allBlobs.length) blobsWithIds = keyed
+    } catch (e) {
+      this.#log.debug(
+        "idKeyedBlobs failed, falling back to id-less load: %O",
+        e
+      )
+    }
+    if (!blobsWithIds) blobsWithIds = allBlobs.map(blob => ({ idHex: "", blob }))
+    blobsWithIds.sort((a, b) => b.blob.byteLength - a.blob.byteLength)
+
+    // Everything here is already in subduction's storage, so none of it is a
+    // local write and none of it should be re-encrypted and re-saved as one.
+    for (const u of blobsWithIds) {
+      if (u.idHex) entry.knownHashes.add(u.idHex)
+    }
+
+    let toApply = blobsWithIds.map(u => u.blob)
     if (this.#blobInterceptor) {
       // Transforming one blob may let the interceptor transform others
       // that failed on an earlier pass. Re-run over the still-pending
       // blobs until a pass makes no progress. Each pass strictly shrinks
       // `pending` or stops, so this runs at most N passes.
       const transformed: Uint8Array[] = []
-      let pending = allBlobs
+      let pending = blobsWithIds
       let prevPendingLen = pending.length + 1
       while (pending.length > 0 && pending.length < prevPendingLen) {
         prevPendingLen = pending.length
-        const stillPending: Uint8Array[] = []
-        for (const blob of pending) {
+        const stillPending: Array<{ idHex: string; blob: Uint8Array }> = []
+        for (const unit of pending) {
           const result = await this.#blobInterceptor.transformIncoming(
             entry.query.documentId,
-            "",
-            blob,
+            unit.idHex,
+            unit.blob,
             (id: string) => this.#storage.loadBlobById(entry.sedimentreeId, id)
           )
           if (result) {
             transformed.push(result)
           } else {
-            stillPending.push(blob)
+            stillPending.push(unit)
           }
         }
         pending = stillPending

--- a/packages/automerge-repo/test/subduction/BlobRetryAfterKey.test.ts
+++ b/packages/automerge-repo/test/subduction/BlobRetryAfterKey.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { WebSocketServer } from "ws"
+import {
+  MemorySigner,
+  MemoryStorage,
+  Subduction,
+} from "@automerge/automerge-subduction/slim"
+import { Repo } from "../../src/Repo.js"
+import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
+import { type DocumentId, type PeerId } from "../../src/types.js"
+import { type BlobInterceptor } from "../../src/subduction/source.js"
+import { WebSocketTransport } from "../../src/subduction/websocket-transport.js"
+import { toSedimentreeId } from "../../src/subduction/helpers.js"
+import { waitFor } from "../helpers/waitFor.js"
+import { wait } from "../helpers/wait.js"
+
+const PREFIX = new Uint8Array([0xe2, 0xe2, 0xee, 0x02])
+
+/**
+ * An interceptor that can pause decryption, simulating a peer whose decryption
+ * key has not arrived yet.
+ */
+function makeGatedInterceptor(): BlobInterceptor & { rejectIncoming: boolean } {
+  const interceptor = {
+    rejectIncoming: false,
+
+    async transformOutgoing(
+      _documentId: DocumentId,
+      _commitId: string,
+      _parents: string[],
+      blob: Uint8Array
+    ) {
+      const wrapped = new Uint8Array(PREFIX.length + blob.length)
+      wrapped.set(PREFIX, 0)
+      wrapped.set(blob, PREFIX.length)
+      return wrapped
+    },
+
+    async transformIncoming(
+      _documentId: DocumentId,
+      _commitId: string,
+      blob: Uint8Array
+    ) {
+      if (interceptor.rejectIncoming) return null
+      if (
+        blob.length < PREFIX.length || !PREFIX.every((b, i) => blob[i] === b)
+      ) {
+        return null
+      }
+      return blob.slice(PREFIX.length)
+    },
+  }
+  return interceptor
+}
+
+class TestServer {
+  #port: number
+  #wss: WebSocketServer | null = null
+  #subduction: Subduction | null = null
+
+  get url() {
+    return `ws://localhost:${this.#port}`
+  }
+  get subduction() {
+    return this.#subduction!
+  }
+
+  private constructor(port: number) {
+    this.#port = port
+  }
+
+  static async start(): Promise<TestServer> {
+    const wss = new WebSocketServer({ port: 0 })
+    await new Promise<void>(r => wss.on("listening", r))
+    const addr = wss.address()
+    if (typeof addr === "string") throw new Error("unexpected address type")
+
+    const subduction = new Subduction({
+      signer: new MemorySigner(),
+      storage: new MemoryStorage(),
+    })
+    const serviceName = `localhost:${addr.port}`
+    wss.on("connection", ws => {
+      subduction
+        .acceptTransport(new WebSocketTransport(ws as any), serviceName)
+        .catch(() => {})
+    })
+
+    const server = new TestServer(addr.port)
+    server.#wss = wss
+    server.#subduction = subduction
+    return server
+  }
+
+  async stop() {
+    if (this.#subduction) {
+      await this.#subduction.disconnectAll()
+      this.#subduction = null
+    }
+    if (this.#wss) {
+      await new Promise<void>((r, e) =>
+        this.#wss!.close(err => (err ? e(err) : r()))
+      )
+      this.#wss = null
+    }
+  }
+}
+
+describe("blobs that arrive before their key", () => {
+  const cleanups: Array<() => Promise<void> | void> = []
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.reverse()) await cleanup()
+    cleanups.length = 0
+  })
+
+  async function startServer() {
+    const server = await TestServer.start()
+    cleanups.push(() => server.stop())
+    return server
+  }
+
+  function createRepo(
+    name: string,
+    serverUrl: string,
+    interceptor: BlobInterceptor
+  ) {
+    return new Repo({
+      peerId: name as PeerId,
+      storage: new DummyStorageAdapter(),
+      subductionWebsocketEndpoints: [serverUrl],
+      subductionBlobInterceptor: interceptor,
+    })
+  }
+
+  it("keeps an untransformable blob so a later retry can apply it", async () => {
+    const server = await startServer()
+    const alice = createRepo("alice", server.url, makeGatedInterceptor())
+    const bobInterceptor = makeGatedInterceptor()
+    const bob = createRepo("bob", server.url, bobInterceptor)
+
+    const aliceHandle = alice.create<{ text: string }>()
+    aliceHandle.change(d => {
+      d.text = "before"
+    })
+
+    const bobHandle = await bob.find<{ text: string }>(aliceHandle.url)
+    await bobHandle.whenReady()
+    expect(bobHandle.doc()!.text).toBe("before")
+
+    bobInterceptor.rejectIncoming = true
+
+    aliceHandle.change(d => {
+      d.text = "after"
+    })
+
+    const sid = toSedimentreeId(aliceHandle.documentId)
+    await waitFor(async () => {
+      const blobs = await server.subduction.getBlobs(sid)
+      expect(blobs?.length ?? 0).toBeGreaterThan(1)
+    }, 10_000)
+
+    await wait(2000)
+    expect(bobHandle.doc()!.text).toBe("before")
+
+    bobInterceptor.rejectIncoming = false
+    bob.shareConfigChanged()
+
+    await waitFor(() => {
+      expect(bobHandle.doc()!.text).toBe("after")
+    }, 10_000)
+  }, 30_000)
+})

--- a/packages/automerge-vanillajs/package.json
+++ b/packages/automerge-vanillajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/vanillajs",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "A quick-import vanilla JS package for Automerge Repo",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/automerge-vanillajs",
   "author": "Peter van Hardenberg <pvh@pvh.ca>",

--- a/packages/create-repo-node-app/package.json
+++ b/packages/create-repo-node-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/create-repo-node-app",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "Create an automerge-repo app for node",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/create-repo-node-app",
   "author": "Alex Good <alex@memoryandthought.me>",

--- a/packages/create-vite-app/package.json
+++ b/packages/create-vite-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/create-vite-app",
-  "version": "2.6.0-subduction.47",
+  "version": "2.6.0-subduction.48",
   "description": "Create an automerge-repo app which uses Vite",
   "repository": "https://github.com/automerge/automerge-repo/tree/main/packages/create-vite-app",
   "author": "Alex Good <alex@memoryandthought.me>",


### PR DESCRIPTION
This PR includes two related fixes:

1. The bulk load used `getBlobs()`, which returns bytes but no commit/fragment ids. This means that on initial load, nothing was recorded in `knownHashes` and the save path rewrote the entire received history as if it were new. When a `BlobInterceptor` transforms new bytes on output, this caused it to re-encrypt the history under the current key. The new `idKeyedBlobs()` reads the ids from storage and adds them to `knownHashes`.

* Performance implications: this avoids unnecessarily re-saving the initially loaded history, but on the other hand calls four extra `loadRange` calls on initial load to look up ids. In some local benchmarking, it appeared to halve writes and double reads during initial load. If we created a new subduction API method for this purpose, we could reduce reads here. 

2. Compaction deleted blobs it could not decrypt yet. A blob whose decryption key had not yet arrived was stored but not yet part of the document, which compaction interpreted as being absorbed into a new fragment. The new `untransformedHashes` keeps track of not-yet-decrypted blobs so that compaction can ignore them. This change has no impact if there is no `BlobInterceptor`.

This also adds `BlobRetryAfterKey.test.ts`, which fails on `subductionjs` and passes with fix 2.