### PR TITLE
fix(react-hooks): hold settled handle wrappers weakly in the wrapper cache

### DIFF
--- a/packages/automerge-repo-react-hooks/src/useDocHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocHandle.ts
@@ -1,14 +1,65 @@
-import { AnyDocumentId, DocHandle } from "@automerge/automerge-repo/slim"
+import {
+  AnyDocumentId,
+  DocHandle,
+  interpretAsDocumentId,
+} from "@automerge/automerge-repo/slim"
+import { noop } from "@automerge/automerge-repo/helpers/noop.js"
+import { WeakValueMap } from "@automerge/automerge-repo/helpers/WeakValueMap.js"
 import { PromiseWrapper, wrapPromise } from "./wrapPromise.js"
 import { useRepo } from "./useRepo.js"
 import { useEffect, useRef, useState } from "react"
 import { anyDocumentIdToAutomergeUrl } from "../../automerge-repo/dist/AutomergeUrl.js"
 
+/**
+ * Promise wrappers per document id: strong while the find() is in flight
+ * (concurrent renders share one request), weak once settled. A settled
+ * wrapper stays available for cache hits while something still references
+ * it (React's pending suspense promise, a mounted component's state), and
+ * releases its DocHandle for repo eviction once nothing does - a permanent
+ * strong cache here would pin every document a hook ever resolved.
+ */
+class WrapperCache {
+  #inFlight = new Map<string, PromiseWrapper<DocHandle<unknown>>>()
+  #settled = new WeakValueMap<string, PromiseWrapper<DocHandle<unknown>>>()
+
+  // WeakValueMap keys must be primitives. Every AnyDocumentId form is a
+  // branded string except BinaryDocumentId, which is encoded to its
+  // canonical DocumentId string. String forms key as themselves: a
+  // heads-pinned url must not share an entry with its live document id.
+  #key(id: AnyDocumentId): string {
+    return typeof id === "string" ? id : interpretAsDocumentId(id)
+  }
+
+  get(id: AnyDocumentId): PromiseWrapper<DocHandle<unknown>> | undefined {
+    const key = this.#key(id)
+    return this.#inFlight.get(key) ?? this.#settled.get(key)
+  }
+
+  has(id: AnyDocumentId): boolean {
+    return this.get(id) !== undefined
+  }
+
+  set(id: AnyDocumentId, wrapper: PromiseWrapper<DocHandle<unknown>>): void {
+    const key = this.#key(id)
+    this.#settled.delete(key)
+    this.#inFlight.set(key, wrapper)
+    void wrapper.promise.catch(noop).then(() => {
+      if (this.#inFlight.get(key) === wrapper) {
+        this.#inFlight.delete(key)
+        this.#settled.set(key, wrapper)
+      }
+    })
+  }
+
+  delete(id: AnyDocumentId): void {
+    const key = this.#key(id)
+    this.#inFlight.delete(key)
+    this.#settled.delete(key)
+  }
+}
+
 // Shared with useDocHandles
-export const wrapperCache = new Map<
-  AnyDocumentId,
-  PromiseWrapper<DocHandle<unknown>>
->()
+export const wrapperCache = new WrapperCache()
 // NB: this is a global cache that isn't keyed on the Repo
 //     so if your app uses the same documents in two Repos
 //     this could cause problems. please let me know if you do.
@@ -55,14 +106,16 @@ export function useDocHandle<T>(
     }
   }
 
-  let wrapper = id ? wrapperCache.get(id) : undefined
+  let wrapper = id
+    ? (wrapperCache.get(id) as PromiseWrapper<DocHandle<T>> | undefined)
+    : undefined
   if (!wrapper && id) {
     controllerRef.current?.abort()
     controllerRef.current = new AbortController()
 
     const promise = repo.find<T>(id, { signal: controllerRef.current.signal })
     wrapper = wrapPromise(promise)
-    wrapperCache.set(id, wrapper)
+    wrapperCache.set(id, wrapper as PromiseWrapper<DocHandle<unknown>>)
   }
 
   /* From here we split into two paths: suspense and not.

--- a/packages/automerge-repo-react-hooks/test/wrapperCache.test.tsx
+++ b/packages/automerge-repo-react-hooks/test/wrapperCache.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import type { AnyDocumentId, DocHandle } from "@automerge/automerge-repo"
+import { wrapperCache } from "../src/useDocHandle"
+import { wrapPromise } from "../src/wrapPromise"
+import {
+  flushGC,
+  gcAvailable,
+  waitForGC,
+} from "../../automerge-repo/src/helpers/tests/flushGC.js"
+
+const itGC = gcAvailable ? it : it.skip
+
+describe("wrapperCache lifetime", () => {
+  const id = (s: string) => s as AnyDocumentId
+  const fakeHandle = () => ({}) as DocHandle<unknown>
+
+  it("shares one wrapper per id while the find is in flight", () => {
+    const wrapper = wrapPromise(
+      new Promise<DocHandle<unknown>>(() => {}) // never settles
+    )
+    wrapperCache.set(id("pending-doc"), wrapper)
+    expect(wrapperCache.get(id("pending-doc"))).toBe(wrapper)
+    wrapperCache.delete(id("pending-doc"))
+  })
+
+  itGC(
+    "holds an in-flight wrapper strongly even with no other references",
+    async () => {
+      let probe!: WeakRef<object>
+      ;(() => {
+        const wrapper = wrapPromise(new Promise<DocHandle<unknown>>(() => {}))
+        probe = new WeakRef(wrapper)
+        wrapperCache.set(id("inflight-doc"), wrapper)
+      })()
+
+      await flushGC()
+      expect(probe.deref()).toBeDefined()
+      expect(wrapperCache.has(id("inflight-doc"))).toBe(true)
+      wrapperCache.delete(id("inflight-doc"))
+    }
+  )
+
+  // A named helper so no test-frame register can keep the wrapper alive.
+  async function makeSettledWrapper(
+    docId: AnyDocumentId
+  ): Promise<WeakRef<object>> {
+    const wrapper = wrapPromise(Promise.resolve(fakeHandle()))
+    wrapperCache.set(docId, wrapper)
+    await wrapper.promise
+    return new WeakRef(wrapper)
+  }
+
+  itGC("releases a settled wrapper once nothing references it", async () => {
+    const probe = await makeSettledWrapper(id("settled-doc"))
+
+    expect(await waitForGC(probe)).toBe(true)
+    expect(wrapperCache.has(id("settled-doc"))).toBe(false)
+  })
+
+  itGC(
+    "keeps serving a settled wrapper while something references it",
+    async () => {
+      const wrapper = wrapPromise(Promise.resolve(fakeHandle()))
+      wrapperCache.set(id("held-doc"), wrapper)
+      await wrapper.promise
+
+      await flushGC()
+      expect(wrapperCache.get(id("held-doc"))).toBe(wrapper)
+      wrapperCache.delete(id("held-doc"))
+    }
+  )
+})


### PR DESCRIPTION
> **#736 has merged, so this is now a single commit based directly on `main`.** It uses that PR's `WeakValueMap` and shareable GC test helpers, both now in `main`. Motivated by #737, which it does not depend on and need not wait for.

## What it addresses

The module-global `wrapperCache` in `useDocHandle`/`useDocHandles` keeps a strong `PromiseWrapper` (and through it the resolved `DocHandle`) for every document a hook ever loaded, for the lifetime of the app. Once the Repo stops pinning documents (#737), this one map still pins every document React has touched, so React apps would see none of the memory benefit.

## What it does

The cache keeps a wrapper strong only while its `find()` is in flight (concurrent renders still share one request), then moves it into a `WeakValueMap`. A settled wrapper keeps serving cache hits while anything still references it (React's pending suspense promise, a mounted component's state); once nothing does, it collects and the document can evict. If a wrapper is collected between renders, the hook's existing ready-state fast path serves the handle without re-suspending while the cluster is alive. Cache keys are strings: string ids key as themselves (a heads-pinned url must not share an entry with its live document id), and a binary id is encoded to its canonical `DocumentId`.

## Tests

All existing hook tests pass unchanged. New cache-lifetime tests (using the shareable GC helpers from #736): an in-flight wrapper stays strong with no other references, a settled one releases once unreferenced, and a referenced settled one keeps serving.

Details are in the commit message.

