### PR TITLE
Drop the re-engagement share-policy rewrite

### DIFF
--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -578,9 +578,11 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
     // synced this document before: restore its engagement so a re-created
     // synchronizer (after cache eviction) resumes pushing updates to a
     // passively-subscribed peer instead of waiting for it to speak first.
-    if (syncState && state.sharedHeads.length > 0 && !peer.hasRequested) {
+    const reEngaged = Boolean(
+      syncState && state.sharedHeads.length > 0 && !peer.hasRequested
+    )
+    if (reEngaged) {
       peer.hasRequested = true
-      if (sharePolicyState === "share") sharePolicyState = "announce"
     }
 
     peer.sharePolicyState = sharePolicyState
@@ -606,12 +608,15 @@ export class DocSynchronizer extends EventEmitter<DocSynchronizerEvents> {
     }
 
     // Only emit "open-doc" when the peer has actually interacted with
-    // this document. "announce" peers are proactively shared with, and
-    // peers with pending messages have explicitly requested the doc.
+    // this document. "announce" peers are proactively shared with, peers
+    // with pending messages have explicitly requested the doc, and a
+    // re-engaged peer interacted before the synchronizer was recreated.
     // "share" peers without pending messages are just passively available.
     if (
       isNewPeer &&
-      (sharePolicyState === "announce" || peer.pendingMessages.length > 0)
+      (sharePolicyState === "announce" ||
+        peer.pendingMessages.length > 0 ||
+        reEngaged)
     ) {
       this.emit("open-doc", { documentId: this.documentId, peerId })
     }

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -694,4 +694,79 @@ describe("DocSynchronizer", () => {
       assert.deepStrictEqual(openedFor, [bob])
     })
   })
+  describe("a peer re-engaged from persisted sync state", () => {
+    /** Access without announce: served on request, never pushed to. */
+    const accessOnly: ShareConfig = {
+      announce: async () => false,
+      access: async () => true,
+    }
+
+    /** A sync state that records heads already shared with the peer. */
+    const syncStateSharing = (doc: Automerge.Doc<TestDoc>) => {
+      let ourDoc = Automerge.clone(doc)
+      let theirDoc = Automerge.init<TestDoc>()
+      let ours = Automerge.initSyncState()
+      let theirs = Automerge.initSyncState()
+      for (;;) {
+        const [nextOurs, toThem] = Automerge.generateSyncMessage(ourDoc, ours)
+        ours = nextOurs
+        if (toThem) {
+          ;[theirDoc, theirs] = Automerge.receiveSyncMessage(
+            theirDoc,
+            theirs,
+            toThem
+          )
+        }
+        const [nextTheirs, toUs] = Automerge.generateSyncMessage(
+          theirDoc,
+          theirs
+        )
+        theirs = nextTheirs
+        if (toUs) {
+          ;[ourDoc, ours] = Automerge.receiveSyncMessage(ourDoc, ours, toUs)
+        }
+        if (!toThem && !toUs) return ours
+      }
+    }
+
+    it("emits open-doc so it is resubscribed to remote-heads gossip", async () => {
+      const docId = parseAutomergeUrl(generateAutomergeUrl()).documentId
+      const handle = createTestHandle<TestDoc>(docId)
+      handle.update(() => Automerge.from<TestDoc>({ foo: "bar" }))
+      const shared = syncStateSharing(handle.doc()!)
+      assert.ok(shared.sharedHeads.length > 0, "the peer must share heads")
+
+      const docSync = createDocSynchronizer(
+        handle as DocHandle<unknown>,
+        undefined,
+        accessOnly
+      )
+      const openedFor: PeerId[] = []
+      docSync.on("open-doc", e => openedFor.push(e.peerId))
+
+      docSync.addPeer(bob, Promise.resolve(shared))
+      await new Promise(setImmediate)
+
+      assert.deepStrictEqual(openedFor, [bob])
+    })
+
+    it("does not emit open-doc when no heads were ever shared", async () => {
+      const docId = parseAutomergeUrl(generateAutomergeUrl()).documentId
+      const handle = createTestHandle<TestDoc>(docId)
+      handle.update(() => Automerge.from<TestDoc>({ foo: "bar" }))
+
+      const docSync = createDocSynchronizer(
+        handle as DocHandle<unknown>,
+        undefined,
+        accessOnly
+      )
+      const openedFor: PeerId[] = []
+      docSync.on("open-doc", e => openedFor.push(e.peerId))
+
+      docSync.addPeer(bob, Promise.resolve(Automerge.initSyncState()))
+      await new Promise(setImmediate)
+
+      assert.deepStrictEqual(openedFor, [])
+    })
+  })
 })


### PR DESCRIPTION
One hunk in `DocSynchronizer.#activatePeer`, plus the open-doc bookkeeping that goes with it.

## The change

Restoring a peer's engagement from its persisted sync state also rewrote the peer's resolved share policy from `"share"` to `"announce"`:

```diff
-    if (syncState && state.sharedHeads.length > 0 && !peer.hasRequested) {
+    const reEngaged = Boolean(
+      syncState && state.sharedHeads.length > 0 && !peer.hasRequested
+    )
+    if (reEngaged) {
       peer.hasRequested = true
-      if (sharePolicyState === "share") sharePolicyState = "announce"
     }
```

Engagement and policy are separate facts. Conflating them means the resolved policy field stops reporting what the policy actually decided, so anything reading it downstream is reading a value that was overwritten for an unrelated reason.

## Why it needed #742

`main` before #742 had no way for an outbound gate to act on `hasRequested` on its own, so rewriting the policy was the only lever available. #742's `#mayReceive` predicate supplies that lever, which is what makes this cleanup possible. Applied to #736 alone it fails #736's own `resumes pushing updates to a passive peer with persisted sync state` test.

## Behaviour is unchanged, and that took a second change

Only two places can distinguish `"announce"` from `"share"` for an access-granted peer:

- **`#mayReceive`** returns the same answer either way once `hasRequested` is set.
- **The open-doc emission** does not. Its condition is `sharePolicyState === "announce" || peer.pendingMessages.length > 0`, and a re-engaged peer satisfies neither: it stays `"share"`, and `CollectionSynchronizer` activates it with no pending messages. The later emitter in `#receiveSyncMessage` is also unavailable, because it is guarded by `!peer.hasRequested`, which this block has already set.

Dropping the rewrite on its own would therefore have silently stopped emitting open-doc for re-engaged peers, which is what subscribes a peer to remote-heads gossip for that document. So open-doc now names re-engagement as its own reason to fire, rather than depending on a rewritten policy value to imply it. Two tests cover it, and both fail if the disjunct is removed.

The exposure would have been narrow (`enableRemoteHeadsGossiping` defaults to false, and a peer that stays connected across a cache eviction keeps the subscription it already earned, since `#remoteHeadsSubscriptions` is Repo-scoped and `removeFromCache` does not touch it) but it would have been silent, and reconnecting peers would have lost it for good.

## Scope, stated plainly

This does not make an `announce: false` peer unreachable by announcement in general. `#resolveSharePolicy` independently maps `access && hasRequested` to `"announce"`, and has since `92de1f5a`, long predating this code path. That rule is untouched here. What this removes is the second, redundant expression of the same idea, so engagement is recorded once, on the peer, and read through the predicate.

That also keeps #737's option (a) cheap: a connection-scoped engagement index would only have to set `hasRequested` on activation, with no gate changes and no third representation of engagement.

## Verification

`packages/automerge-repo`: 698 passed / 4 skipped, including #736's re-engagement test. `tsc --noEmit`, `oxfmt --check` and `oxlint` clean. Both new open-doc tests were mutation-checked: removing the `reEngaged` disjunct fails the positive one.
