### PR TITLE
test(network): fix the flaky broadcast adapter acceptance test

### DIFF
--- a/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
@@ -176,15 +176,18 @@ export function runNetworkAdapterTests(_setup: SetupFn, title?: string): void {
       const aliceHandle = aliceRepo.create<TestDoc>()
       const charlieHandle = await charlieRepo.find(aliceHandle.url)
 
-      // pause to give charlie a chance to let alice know it wants the doc
-      await pause(100)
+      // A broadcast is dropped, not queued, for a peer whose share policy
+      // has not resolved yet. Charlie speaking first proves every hop
+      // between them has resolved, in either topology.
+      const atAlice = eventPromise(aliceHandle, "ephemeral-message")
+      charlieHandle.broadcast({ presence: "charlie" })
+      await atAlice
 
+      const atCharlie = eventPromise(charlieHandle, "ephemeral-message")
       const alicePresenceData = { presence: "alice" }
       aliceHandle.broadcast(alicePresenceData)
 
-      const { message } = await eventPromise(charlieHandle, "ephemeral-message")
-
-      assert.deepStrictEqual(message, alicePresenceData)
+      assert.deepStrictEqual((await atCharlie).message, alicePresenceData)
       teardown()
     })
 


### PR DESCRIPTION
`can broadcast a message` in the shared network-adapter acceptance suite waits out a fixed 100ms and then assumes a broadcast can be delivered. It can time out under full-suite load: observed repeatedly on a 32-thread machine, never when the file runs alone (0/25).

```
FAIL |@automerge/automerge-repo-network-websocket| test/Websocket.test.ts
  > Network adapter acceptance tests > can broadcast a message
Error: Test timed out in 5000ms.
 ❯ ../automerge-repo/src/helpers/tests/network-adapter-tests.ts:163:7
```

## Cause

```ts
const charlieHandle = await charlieRepo.find(aliceHandle.url)

// pause to give charlie a chance to let alice know it wants the doc
await pause(100)

aliceHandle.broadcast(alicePresenceData)
```

`#broadcastToPeers` skips any peer whose `sharePolicyState` is still `loading`, and ephemeral messages are dropped rather than queued. So if 100ms is not enough for the peers along the path to resolve, the broadcast leaves before anyone can receive it and the test waits out its 5s timeout for an `ephemeral-message` that was never sent.

`find()` resolving does not close that gap, because it settles only the peers on the path that served the document, and that path is topology-dependent. Instrumenting Alice's events shows the two setups are not alike:

| setup | Alice's peers |
|---|---|
| all-to-all | `peer:bob`, `peer:charlie` (direct) |
| hub and spoke | `peer:bob` only, Bob relays to Charlie |

That also rules out the obvious fix: waiting for Alice to emit `open-doc` for Charlie hangs 30/30 in hub and spoke, where Charlie is never Alice's peer.

## Fix

Bounce one message off Charlie before asserting on Alice's, so the barrier is an actual delivery rather than a duration:

```ts
const atAlice = eventPromise(aliceHandle, "ephemeral-message")
charlieHandle.broadcast({ presence: "charlie" })
await atAlice
```

Its arrival proves every hop between them has resolved, in either topology. This matches how `EphemeralMessages.test.ts` synchronises (`relays both directions in steady state`), and replaces a fixed 100ms with a round trip that is typically an order of magnitude quicker.

## Verification

| | failures |
|---|---|
| before the fix | 5 / 55 full-suite runs |
| this branch | 0 / 30 full-suite runs |

How often this bites is load- and machine-dependent, and it is rare: a 40-run census of `main` on its own saw none. The race itself does not depend on how often it is sampled, and the replacement is strictly better than a fixed delay regardless.

Still has teeth: replacing the `ephemeral-message-outbound` handler with a no-op fails `can broadcast a message` in all three adapter suites. Full suite 890 passed / 4 skipped; `tsc --noEmit`, `oxfmt --check` and `oxlint` clean.

The other two `pause()` calls in this file are left alone; neither is implicated in this failure.


