### PR TITLE
test(repo): stop adding two MessageChannel adapters to the same port

### DIFF
--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -1495,14 +1495,10 @@ describe("Repo", () => {
         bcChannel.port1.close()
       }
 
+      // Reuse the adapter already on `ab`: a second one there answers every
+      // frame too, so both would reply to bob's `arrive`.
       function connectAliceToBob() {
-        aliceRepo.networkSubsystem.addNetworkAdapter(
-          new MessageChannelNetworkAdapter(ab)
-        )
-      }
-
-      if (connectAlice) {
-        connectAliceToBob()
+        aliceRepo.networkSubsystem.addNetworkAdapter(aliceNetworkAdapter)
       }
 
       const aliceHandle = aliceRepo.create<TestDoc>()


### PR DESCRIPTION
The shared "with peers" setup in `Repo.test.ts` builds a `MessageChannelNetworkAdapter` on port `ab` and passes it to alice's `Repo`, then immediately calls `connectAliceToBob()`, which builds a second adapter on that same port.

Both adapters see every frame, so both answer bob's `arrive` with a `welcome`, and each one fires another peer-candidate for the same peerId. Every extra candidate re-runs `DocSynchronizer.addPeer`, which replaces the `PeerState` and drops its resolved share policy back to `"loading"`. A peer in `loading` is skipped by the outbound gates.

This is the same ghost-welcome shape #651 fixed for BroadcastChannel, reached through a duplicate adapter rather than through leftovers on a shared channel. Around twenty tests are built on this setup, and `setup()` returns after the first peer event per repo, so some of the resets land inside the test body.

## The change

`connectAliceToBob()` reuses the adapter that was already built. The two paths are mutually exclusive in practice: `connectAlice: true` connects via the constructor, and the one caller that connects later passes `connectAlice: false`.

## Verification

Full suite 890 passed / 4 skipped, `Repo.test.ts` 120 passed. `oxlint`, `oxfmt --check` and `tsc --noEmit` clean.
