### PR TITLE
test: await a peer, not whenReady(), to mean connected

### DIFF
--- a/packages/automerge-repo/test/Presence.test.ts
+++ b/packages/automerge-repo/test/Presence.test.ts
@@ -5,6 +5,7 @@ import { PresenceEventHeartbeat } from "../src/presence/types.js"
 import { Repo } from "../src/Repo.js"
 import { PeerId } from "../src/types.js"
 import { DummyNetworkAdapter } from "../src/helpers/DummyNetworkAdapter.js"
+import { whenPeersConnected } from "./helpers/whenPeerConnected.js"
 import { waitFor } from "./helpers/waitFor.js"
 
 type PresenceState = { position: number }
@@ -20,10 +21,7 @@ describe("Presence", () => {
       aliceToBob.peerCandidate("bob" as PeerId)
       bobToAlice.peerCandidate("alice" as PeerId)
     }
-    await Promise.all([
-      alice.networkSubsystem.whenReady(),
-      bob.networkSubsystem.whenReady(),
-    ])
+    if (!opts?.skipAnnounce) await whenPeersConnected(alice, bob)
 
     const aliceHandle = alice.create({
       test: "doc",

--- a/packages/automerge-repo/test/helpers/collectMessages.ts
+++ b/packages/automerge-repo/test/helpers/collectMessages.ts
@@ -13,7 +13,12 @@ export async function collectMessages({
   const messages = []
   const listener = (message: unknown) => messages.push(message)
   emitter.on(event, listener)
-  await until
-  emitter.off(event)
+  try {
+    await until
+  } finally {
+    // Scoped: eventemitter3's `off(event)` with no callback would clear
+    // every listener for that event, including the Repo's own.
+    emitter.off(event, listener)
+  }
   return messages
 }

--- a/packages/automerge-repo/test/helpers/connectRepos.ts
+++ b/packages/automerge-repo/test/helpers/connectRepos.ts
@@ -1,6 +1,6 @@
 import { DummyNetworkAdapter } from "../../src/helpers/DummyNetworkAdapter.js"
 import { Repo } from "../../src/Repo.js"
-import pause from "./pause.js"
+import { whenPeersConnected } from "./whenPeerConnected.js"
 
 export default async function connectRepos(left: Repo, right: Repo) {
   const [leftToRight, rightToLeft] = DummyNetworkAdapter.createConnectedPair({
@@ -10,9 +10,5 @@ export default async function connectRepos(left: Repo, right: Repo) {
   right.networkSubsystem.addNetworkAdapter(rightToLeft)
   leftToRight.peerCandidate(right.peerId)
   rightToLeft.peerCandidate(left.peerId)
-  await Promise.all([
-    left.networkSubsystem.whenReady(),
-    right.networkSubsystem.whenReady(),
-  ])
-  await pause(10)
+  await whenPeersConnected(left, right)
 }

--- a/packages/automerge-repo/test/helpers/whenPeerConnected.ts
+++ b/packages/automerge-repo/test/helpers/whenPeerConnected.ts
@@ -1,0 +1,29 @@
+import type { Repo } from "../../src/Repo.js"
+import type { PeerId } from "../../src/types.js"
+
+/**
+ * Resolves once `repo` has registered `peerId`.
+ *
+ * Not `networkSubsystem.whenReady()`, which can resolve on a timeout fallback
+ * with no peer registered. Filtered by peer, since a repo with several links
+ * emits `peer` for whichever answers first.
+ */
+export function whenPeerConnected(repo: Repo, peerId: PeerId): Promise<void> {
+  if (repo.peers.includes(peerId)) return Promise.resolve()
+  return new Promise(resolve => {
+    const onPeer = ({ peerId: arrived }: { peerId: PeerId }) => {
+      if (arrived !== peerId) return
+      repo.networkSubsystem.off("peer", onPeer)
+      resolve()
+    }
+    repo.networkSubsystem.on("peer", onPeer)
+  })
+}
+
+/** Both directions of a link between two repos. */
+export function whenPeersConnected(left: Repo, right: Repo): Promise<void[]> {
+  return Promise.all([
+    whenPeerConnected(left, right.peerId),
+    whenPeerConnected(right, left.peerId),
+  ])
+}

--- a/packages/automerge-repo/test/remoteHeads.test.ts
+++ b/packages/automerge-repo/test/remoteHeads.test.ts
@@ -2,6 +2,7 @@ import { next as A } from "@automerge/automerge/slim"
 import assert from "assert"
 import { describe, it } from "vitest"
 import { MessageChannelNetworkAdapter } from "../../automerge-repo-network-messagechannel/src/index.js"
+import { whenPeersConnected } from "./helpers/whenPeerConnected.js"
 import { generateAutomergeUrl, parseAutomergeUrl } from "../src/AutomergeUrl.js"
 import { eventPromise } from "../src/helpers/eventPromise.js"
 import {
@@ -296,8 +297,5 @@ async function connectRepos(a: Repo, b: Repo) {
   const bAdapter = new MessageChannelNetworkAdapter(b2a)
   a.networkSubsystem.addNetworkAdapter(aAdapter)
   b.networkSubsystem.addNetworkAdapter(bAdapter)
-  await Promise.all([
-    a.networkSubsystem.whenReady(),
-    a.networkSubsystem.whenReady(),
-  ])
+  await whenPeersConnected(a, b)
 }


### PR DESCRIPTION
Four setups treat `networkSubsystem.whenReady()` as a barrier for "these two repos are connected". It is not one. For `DummyNetworkAdapter` it is already resolved by the constructor, and for `MessageChannelNetworkAdapter` it resolves on a 100ms `forceReady` fallback whether or not a handshake happened, so it can return with no peer registered.

The tests then patch the gap by hand, each differently:

- `test/helpers/connectRepos.ts` follows it with `await pause(10)`
- `Presence.test.ts` has no backstop at all
- `remoteHeads.test.ts` awaits `a.networkSubsystem.whenReady()` twice and `b` never

## The change

Add `whenPeerConnected(repo, peerId)`, which observes the transition these tests actually depend on, and use it in all three. It is filtered by peer, because a repo with several links emits `peer` for whichever answers first, and it returns early when the peer is already known, so it cannot become a barrier that never fires. `connectRepos` loses its trailing sleep.

## One unrelated fix that has to ride along

`collectMessages` called `emitter.off(event)` with no callback. eventemitter3's `removeListener` treats that as "clear every listener for this event", and three call sites pass a `Repo`'s `networkSubsystem` and the `message` event, which is where the `Repo` registers its own inbound dispatcher. Nothing downstream needs traffic today, so it is currently invisible, but it deletes any listener an event-driven rewrite of those tests would add. The removal is now scoped to the helper's own listener, in a `finally`.

## Verification

Full suite 890 passed / 4 skipped. `oxlint`, `oxfmt --check` and `tsc --noEmit` clean.
