### PR TITLE
test(messagechannel): wait for the handshake and the close, not for 100ms

### DIFF
--- a/packages/automerge-repo-network-messagechannel/test/index.test.ts
+++ b/packages/automerge-repo-network-messagechannel/test/index.test.ts
@@ -5,6 +5,10 @@ import {
   MessageChannelNetworkAdapter,
 } from "../src/index.js"
 import { Repo } from "@automerge/automerge-repo/slim"
+import {
+  eventPromise,
+  eventPromises,
+} from "@automerge/automerge-repo/helpers/eventPromise.js"
 
 // bob is the hub, alice and charlie are spokes
 describe("MessageChannelNetworkAdapter", () => {
@@ -58,26 +62,26 @@ describe("MessageChannelNetworkAdapter", () => {
 
   it("should close the network adapter when a 'leave' message is received", async () => {
     const { port1: aliceToBob, port2: bobToAlice } = new MessageChannel()
-    const alice = new Repo({
-      network: [
-        new MessageChannelNetworkAdapter(aliceToBob, { useWeakRef: false }),
-      ],
+    const aliceAdapter = new MessageChannelNetworkAdapter(aliceToBob, {
+      useWeakRef: false,
     })
-    const bob = new Repo({
-      network: [
-        new MessageChannelNetworkAdapter(bobToAlice, { useWeakRef: true }),
-      ],
+    const bobAdapter = new MessageChannelNetworkAdapter(bobToAlice, {
+      useWeakRef: true,
     })
+    const alice = new Repo({ network: [aliceAdapter] })
+    const bob = new Repo({ network: [bobAdapter] })
 
-    await Promise.all([
-      alice.networkSubsystem.whenReady(),
-      bob.networkSubsystem.whenReady(),
-    ])
+    // whenReady() force-readies after 100ms with or without a handshake, so
+    // it does not imply the remote peer id that `leave` needs.
+    await eventPromises([aliceAdapter, bobAdapter], "peer-candidate")
+
+    // alice's adapter emits close synchronously inside disconnect()
+    const aliceClosed = eventPromise(aliceAdapter, "close")
+    const bobClosed = eventPromise(bobAdapter, "close")
 
     alice.networkSubsystem.disconnect()
 
-    // Wait for bob to process the leave message
-    await new Promise(r => setTimeout(r, 100))
+    await Promise.all([aliceClosed, bobClosed])
 
     assert.equal(bob.networkSubsystem.adapters.length, 0)
     assert.equal(alice.networkSubsystem.adapters.length, 0)


### PR DESCRIPTION
The disconnect test had two fixed 100ms windows, and the first one could make it fail outright.

Its precondition was `whenReady()`, but `MessageChannelNetworkAdapter.connect()` arms `setTimeout(() => this.#forceReady(), 100)`. So `whenReady` can resolve with no handshake at all, leaving the adapter's remote peer id unset. In that state `disconnect()` sends no `leave` and emits no close, and **both** assertions fail. It then waited a bare 100ms for the `leave` round trip.

## The change

Await `peer-candidate` on both adapters, which is the transition that establishes the peer id `leave` depends on, then await the close events rather than sleeping. Both adapters are bound to locals so their events can be observed.

## Verification

Package suite 15 passed, ten consecutive runs, no timeouts. Full suite 890 passed / 4 skipped. `oxlint`, `oxfmt --check` and `tsc --noEmit` clean.

The test drops from about 105ms to about 1ms.
