### PR TITLE
test(network): replace the last two adapter-suite sleeps

### DIFF
--- a/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
+++ b/packages/automerge-repo-network-broadcastchannel/test/index.test.ts
@@ -5,7 +5,6 @@ import {
   type SetupFn,
 } from "../../automerge-repo/src/helpers/tests/network-adapter-tests.js"
 import { BroadcastChannelNetworkAdapter } from "../src/index.js"
-import { pause } from "../../automerge-repo/src/helpers/pause.js"
 
 describe("BroadcastChannel", () => {
   const setup: SetupFn = async () => {
@@ -57,12 +56,18 @@ describe("BroadcastChannel", () => {
   })
 
   it("allows a wait time to be specified in the options and is ready after that even if no peers have connected", async () => {
-    const a = new BroadcastChannelNetworkAdapter({
-      channelName: "a",
-      peerWaitMs: 10,
-    })
-    await pause(10)
-    expect(a.isReady()).toBe(true)
+    vi.useFakeTimers()
+    try {
+      const a = new BroadcastChannelNetworkAdapter({
+        channelName: "a",
+        peerWaitMs: 10,
+      })
+      expect(a.isReady()).toBe(false)
+      await vi.advanceTimersByTimeAsync(10)
+      expect(a.isReady()).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("removes its listener and closes its channel on disconnect, and is idempotent", () => {

--- a/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
+++ b/packages/automerge-repo/src/helpers/tests/network-adapter-tests.ts
@@ -314,9 +314,12 @@ export function runNetworkAdapterTests(_setup: SetupFn, title?: string): void {
 
       await eventPromise(rightRepo.networkSubsystem, "peer")
 
+      const disconnected = eventPromise(
+        rightRepo.networkSubsystem,
+        "peer-disconnected"
+      )
       left.disconnect()
-
-      await pause(10)
+      await disconnected
 
       left.connect(leftPeerId)
       await eventPromise(left, "peer-candidate")


### PR DESCRIPTION
Two sleeps in the adapter suites cover real work rather than nothing, so they survived an earlier pass over `Repo.test.ts`. They still do not need to be sleeps, but they need different treatment from each other.

## The reconnect test: an event

`should support reconnecting after disconnect` in the shared acceptance suite slept 10ms between `disconnect()` and `connect()`. It now awaits `peer-disconnected`.

That barrier is safe by contract rather than by observation: every adapter is required to emit the event, and this same suite enforces it three tests earlier in `should emit disconnect events on disconnect`. So it fires in all three adapter configurations.

A fake timer would be the wrong tool here. The websocket adapter runs this suite against real sockets, and faking `setTimeout` does not fake a socket round trip.

## The broadcastchannel readiness test: fake timers

The opposite case. Its subject is the adapter's own `peerWaitMs` timer, which is armed in the constructor:

```ts
setTimeout(() => this.#markReady(), this.#options.peerWaitMs)
```

so `await pause(10)` was racing a `setTimeout(10)` with no margin, and only worked because the constructor's timer was inserted first. Fake timers make it deterministic, and they allow the assertion the test was missing: that the adapter is **not** ready before the wait elapses.

## Verification

All three adapter suites 54 passed, three consecutive runs. Full suite 890 passed / 4 skipped. `oxlint`, `oxfmt --check` and `tsc --noEmit` clean.

The readiness test was mutation checked: multiplying `peerWaitMs` by 100 fails it.

## Merge order

Independent of #753, despite both removing fixed sleeps. That one deletes sleeps from `Repo.test.ts` that cover nothing; this one converts the two that cover something real. Different files, either order.
