### PR TITLE
test(repo): delete eight sleeps that wait for state already set

### DIFF
--- a/packages/automerge-repo/test/Repo.test.ts
+++ b/packages/automerge-repo/test/Repo.test.ts
@@ -764,7 +764,6 @@ describe("Repo", () => {
 
         const repo2 = new Repo({ storage: storageAdapter })
         repo2.findWithProgress<TestDoc>(handle.url)
-        await pause(10)
         assert(repo2.synchronizer.docSynchronizers[handle.documentId])
       })
 
@@ -804,10 +803,8 @@ describe("Repo", () => {
         const { repo } = setup()
         const handle = repo.create<TestDoc>()
         const initialCount = handle.listenerCount("heads-changed")
-        await pause(10) // wait for debounced save to complete
         await repo.find<TestDoc>(handle.url)
         repo.findWithProgress<TestDoc>(handle.url)
-        await pause(10)
         // find/findWithProgress should not add extra listeners
         assert.equal(handle.listenerCount("heads-changed"), initialCount)
       })
@@ -1587,8 +1584,6 @@ describe("Repo", () => {
       // (This behaviour is mostly test-validation, we are already testing load/save elsewhere.)
       assert.deepStrictEqual(bobFoundIt.doc(), { foo: "foundOnFakeDisk" })
 
-      await pause(10)
-
       // We should have a docSynchronizer and its peers should be alice and charlie
       assert.strictEqual(
         bobRepo.synchronizer.docSynchronizers[bobFoundIt.documentId]?.hasPeer(
@@ -1789,8 +1784,6 @@ describe("Repo", () => {
       const { charlieRepo, notForBob, teardown } = await setup()
 
       const handle = await charlieRepo.find<TestDoc>(notForBob)
-
-      await pause(50)
 
       const doc = handle.doc()
       assert.deepStrictEqual(doc, { foo: "bap" })
@@ -2219,9 +2212,6 @@ describe("Repo", () => {
 
     it("can report the connected peers", async () => {
       const { bobRepo, charlieRepo, teardown } = await setup()
-
-      // pause to let the connections happen
-      await pause(1)
 
       assert.deepStrictEqual(bobRepo.peers, ["alice", "charlie"])
       assert.deepStrictEqual(charlieRepo.peers, ["bob"])
@@ -2870,8 +2860,6 @@ describe("Repo.find() abort behavior", () => {
       aliceToBob.peerCandidate("bob" as PeerId)
       bobToAlice.peerCandidate("alice" as PeerId)
 
-      await pause(50)
-
       const handle = await alice.create2({ foo: "bar" })
       const bobHandle = await bob.find(handle.url)
       assert.deepStrictEqual(bobHandle.doc(), { foo: "bar" })
@@ -2888,8 +2876,6 @@ describe("Repo.find() abort behavior", () => {
       const bob = new Repo({ peerId: "bob" as PeerId, network: [bobToAlice] })
       aliceToBob.peerCandidate("bob" as PeerId)
       bobToAlice.peerCandidate("alice" as PeerId)
-
-      await pause(50)
 
       return { alice, bob }
     }


### PR DESCRIPTION
Eight `pause()` calls in `Repo.test.ts` waited for state that was already set by the time the preceding statement returned.

Six covered synchronous wiring: `Repo.#ensureQuery` attaches sources in a loop with no await, `CollectionSynchronizer.attach` registers the synchronizer and adds peers synchronously, `StorageSource.attach` adds its throttled listener synchronously, and `DummyNetworkAdapter.peerCandidate` emits synchronously with the pair defaulting to microtask delivery. The other two sat after an awaited `find()`, so the state they waited for was established by the await itself.

They could not have lost to event-loop starvation either. An in-process port delivery and a resolved microtask both drain ahead of a due `setTimeout`, even one that is already well overdue, because libuv caches `loop->time` per iteration and picks up signals raised during the poll phase. So these were wall clock and nothing else, and deletion is the right treatment rather than conversion to a barrier.

`pause()` call sites in the file drop from 47 to 39.

## One narrowing, stated explicitly

`does not add duplicate heads-changed listeners` now only catches a duplicate attached synchronously. The deleted trailing sleep was the only window in which an asynchronously attached duplicate could have been observed. Nothing attaches that listener asynchronously today, so this is hypothetical coverage rather than a live gap, and a fixed sleep was a poor instrument for it in any case.

## Not in scope

Two sleeps elsewhere cover work that is genuinely outstanding, so they are handled separately in #752: the one in the shared adapter acceptance tests between disconnect and reconnect, which becomes a `peer-disconnected` wait, and the one in the broadcastchannel suite covering that adapter's own `peerWaitMs` timer, which becomes fake timers. Independent of this PR, either order.

## Verification

Full suite 890 passed / 4 skipped. `Repo.test.ts` alone was run repeatedly under CPU contention, including pinned to a single shared core, with no failures, and with shuffled test order. Each affected assertion was mutation checked: inverting it fails the test in milliseconds rather than timing out, so none of them became unfalsifiable. `oxlint`, `oxfmt --check` and `tsc --noEmit` clean.

## Merge order

Independent of #752, despite both removing fixed sleeps. This one deletes sleeps from `Repo.test.ts` that cover nothing; #752 converts the two that cover something real. Different files, either order.
