### PR TITLE
test(websocket): stop discarding replies between reads

### DIFF
--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -401,6 +401,45 @@ describe("Websocket adapters", () => {
       })
     }
 
+    /**
+     * Reads messages from a socket in order, buffering from the moment it is
+     * created so that a message arriving between reads is queued, not dropped.
+     */
+    function messageReader(socket: WebSocket) {
+      const received: Buffer[] = []
+      const waiting: ((msg: Buffer) => void)[] = []
+      socket.on("message", msg => {
+        const resolve = waiting.shift()
+        if (resolve) resolve(msg as Buffer)
+        else received.push(msg as Buffer)
+      })
+      const next = (): Promise<Buffer> =>
+        new Promise(resolve => {
+          const msg = received.shift()
+          if (msg) resolve(msg)
+          else waiting.push(resolve)
+        })
+      return {
+        next,
+        /** Null if nothing arrives within `ms`. Anything that arrives later
+         * stays buffered for the next read. */
+        nextWithin: (ms: number): Promise<Buffer | null> => {
+          const msg = received.shift()
+          if (msg) return Promise.resolve(msg)
+          return new Promise(resolve => {
+            const settle = (value: Buffer | null) => {
+              clearTimeout(timer)
+              const i = waiting.indexOf(settle as (m: Buffer) => void)
+              if (i !== -1) waiting.splice(i, 1)
+              resolve(value)
+            }
+            const timer = setTimeout(() => settle(null), ms)
+            waiting.push(settle as (m: Buffer) => void)
+          })
+        },
+      }
+    }
+
     it("should disconnect from a closed client", async () => {
       const {
         serverAdapter,
@@ -701,10 +740,7 @@ describe("Websocket adapters", () => {
         }
       }
 
-      function assertIsPeerMessage(msg: Buffer | null) {
-        if (msg == null) {
-          throw new Error("expected a peer message, got null")
-        }
+      function assertIsPeerMessage(msg: Buffer) {
         let decoded = CBOR.decode(msg)
         if (decoded.type !== "peer") {
           throw new Error(`expected a peer message, got type: ${decoded.type}`)
@@ -713,11 +749,8 @@ describe("Websocket adapters", () => {
 
       function assertIsSyncMessage(
         forDocument: DocumentId,
-        msg: Buffer | null
+        msg: Buffer
       ): SyncMessage {
-        if (msg == null) {
-          throw new Error("expected a peer message, got null")
-        }
         let decoded = CBOR.decode(msg)
         if (decoded.type !== "sync") {
           throw new Error(`expected a peer message, got type: ${decoded.type}`)
@@ -759,6 +792,7 @@ describe("Websocket adapters", () => {
       // Simulate the initial websocket connection
       let clientSocket = new WebSocket(serverUrl)
       await once(clientSocket, "open")
+      let serverMessages = messageReader(clientSocket)
 
       // Run through the client/server hello
       clientSocket.send(
@@ -769,8 +803,7 @@ describe("Websocket adapters", () => {
         })
       )
 
-      let response = await messageOrTimeout(clientSocket)
-      assertIsPeerMessage(response)
+      assertIsPeerMessage(await serverMessages.next())
 
       // Okay now we start syncing
 
@@ -792,8 +825,7 @@ describe("Websocket adapters", () => {
         })
       )
 
-      response = await messageOrTimeout(clientSocket)
-      assertIsSyncMessage(documentId, response)
+      assertIsSyncMessage(documentId, await serverMessages.next())
 
       // Now, assume either the network or the server is going slow, so the
       // server thinks it has sent the response above, but for whatever reason
@@ -804,6 +836,7 @@ describe("Websocket adapters", () => {
 
       clientSocket = new WebSocket(serverUrl)
       await once(clientSocket, "open")
+      serverMessages = messageReader(clientSocket)
 
       // and we also make a change to the client doc
       clientDoc = A.change(clientDoc, d => (d.foo = "quoxen"))
@@ -817,8 +850,7 @@ describe("Websocket adapters", () => {
         })
       )
 
-      response = await messageOrTimeout(clientSocket)
-      assertIsPeerMessage(response)
+      assertIsPeerMessage(await serverMessages.next())
 
       // Now, we start syncing. If we're not buggy, this loop should terminate.
       while (true) {
@@ -834,7 +866,7 @@ describe("Websocket adapters", () => {
             })
           )
         }
-        const response = await messageOrTimeout(clientSocket)
+        const response = await serverMessages.nextWithin(100)
         if (response) {
           const decoded = assertIsSyncMessage(documentId, response)
           ;[clientDoc, clientState] = A.receiveSyncMessage(
@@ -846,8 +878,6 @@ describe("Websocket adapters", () => {
         if (response == null && message == null) {
           break
         }
-        // Make sure shit has time to happen
-        await pause(50)
       }
 
       // we encode localHeads for consistency with URL formatted heads


### PR DESCRIPTION
The reconnect sync test read from the socket with a helper that raced `socket.once("message")` against a 100ms timer. That caused two distinct problems.

**Replies were discarded, not merely delayed.** Between iterations of the sync loop no `message` listener was attached at all, so anything the server sent during the trailing `pause(50)` was dropped on the floor. The loop then reached the heads comparison short of a message and failed with `heads not equal`.

**A slow server produced a type error rather than a wait.** The helper returned `null` on timeout, and three call sites fed that straight into `assertIsPeerMessage` / `assertIsSyncMessage`, which throw on `null`.

## The change

Read through a small buffering reader attached when the socket opens, so a message arriving between reads is queued rather than lost.

- The three handshake and request sites use an **unbounded** read. That is safe by protocol: the server always answers a join with `peer` or `error`, and a request with `sync` or `doc-unavailable`.
- The sync loop uses a **bounded** read, because it needs to detect that the server has gone quiet, and that is the one thing an unbounded read cannot express. A message that arrives after the bound stays buffered for the next read, which is the part that was broken before.

The loop keeps its original shape: run until neither side has anything more to send, then compare heads. Terminating on first convergence instead would quietly drop the property that the exchange quiesces, and would turn a genuine failure into a five second timeout rather than a `heads not equal` error.

`messageOrTimeout` stays; three other tests still use it.

## Verification

Websocket suite 29 passed over five consecutive runs; full suite 890 passed / 4 skipped. `oxlint`, `oxfmt --check` and `tsc --noEmit` clean.

Mutation checked: making the client stop applying the server's sync messages fails the test with `heads not equal` in 136ms, so the trailing assertion is live and the failure stays crisp rather than becoming a timeout.

## One thing this does not fix

Handled as a follow-up in #755. The test is already weak with respect to its title. Suppressing the rejoin `peer-disconnected` emit, or forcing `addPeer` to reuse a stale sync state, leaves it green both before and after this change, because `addPeer` now resets peer state unconditionally. Worth a separate look at whether the reconnect behaviour it is named for is covered anywhere.

