### PR TITLE
test(websocket): assert the reconnect ordering this test is named for

### DIFF
--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -401,6 +401,45 @@ describe("Websocket adapters", () => {
       })
     }
 
+    /**
+     * Reads messages from a socket in order, buffering from the moment it is
+     * created so that a message arriving between reads is queued, not dropped.
+     */
+    function messageReader(socket: WebSocket) {
+      const received: Buffer[] = []
+      const waiting: ((msg: Buffer) => void)[] = []
+      socket.on("message", msg => {
+        const resolve = waiting.shift()
+        if (resolve) resolve(msg as Buffer)
+        else received.push(msg as Buffer)
+      })
+      const next = (): Promise<Buffer> =>
+        new Promise(resolve => {
+          const msg = received.shift()
+          if (msg) resolve(msg)
+          else waiting.push(resolve)
+        })
+      return {
+        next,
+        /** Null if nothing arrives within `ms`. Anything that arrives later
+         * stays buffered for the next read. */
+        nextWithin: (ms: number): Promise<Buffer | null> => {
+          const msg = received.shift()
+          if (msg) return Promise.resolve(msg)
+          return new Promise(resolve => {
+            const settle = (value: Buffer | null) => {
+              clearTimeout(timer)
+              const i = waiting.indexOf(settle as (m: Buffer) => void)
+              if (i !== -1) waiting.splice(i, 1)
+              resolve(value)
+            }
+            const timer = setTimeout(() => settle(null), ms)
+            waiting.push(settle as (m: Buffer) => void)
+          })
+        },
+      }
+    }
+
     it("should disconnect from a closed client", async () => {
       const {
         serverAdapter,
@@ -701,10 +740,7 @@ describe("Websocket adapters", () => {
         }
       }
 
-      function assertIsPeerMessage(msg: Buffer | null) {
-        if (msg == null) {
-          throw new Error("expected a peer message, got null")
-        }
+      function assertIsPeerMessage(msg: Buffer) {
         let decoded = CBOR.decode(msg)
         if (decoded.type !== "peer") {
           throw new Error(`expected a peer message, got type: ${decoded.type}`)
@@ -713,11 +749,8 @@ describe("Websocket adapters", () => {
 
       function assertIsSyncMessage(
         forDocument: DocumentId,
-        msg: Buffer | null
+        msg: Buffer
       ): SyncMessage {
-        if (msg == null) {
-          throw new Error("expected a peer message, got null")
-        }
         let decoded = CBOR.decode(msg)
         if (decoded.type !== "sync") {
           throw new Error(`expected a peer message, got type: ${decoded.type}`)
@@ -759,6 +792,7 @@ describe("Websocket adapters", () => {
       // Simulate the initial websocket connection
       let clientSocket = new WebSocket(serverUrl)
       await once(clientSocket, "open")
+      let serverMessages = messageReader(clientSocket)
 
       // Run through the client/server hello
       clientSocket.send(
@@ -769,8 +803,7 @@ describe("Websocket adapters", () => {
         })
       )
 
-      let response = await messageOrTimeout(clientSocket)
-      assertIsPeerMessage(response)
+      assertIsPeerMessage(await serverMessages.next())
 
       // Okay now we start syncing
 
@@ -792,8 +825,7 @@ describe("Websocket adapters", () => {
         })
       )
 
-      response = await messageOrTimeout(clientSocket)
-      assertIsSyncMessage(documentId, response)
+      assertIsSyncMessage(documentId, await serverMessages.next())
 
       // Now, assume either the network or the server is going slow, so the
       // server thinks it has sent the response above, but for whatever reason
@@ -804,6 +836,7 @@ describe("Websocket adapters", () => {
 
       clientSocket = new WebSocket(serverUrl)
       await once(clientSocket, "open")
+      serverMessages = messageReader(clientSocket)
 
       // and we also make a change to the client doc
       clientDoc = A.change(clientDoc, d => (d.foo = "quoxen"))
@@ -817,8 +850,7 @@ describe("Websocket adapters", () => {
         })
       )
 
-      response = await messageOrTimeout(clientSocket)
-      assertIsPeerMessage(response)
+      assertIsPeerMessage(await serverMessages.next())
 
       // Now, we start syncing. If we're not buggy, this loop should terminate.
       while (true) {
@@ -834,7 +866,7 @@ describe("Websocket adapters", () => {
             })
           )
         }
-        const response = await messageOrTimeout(clientSocket)
+        const response = await serverMessages.nextWithin(100)
         if (response) {
           const decoded = assertIsSyncMessage(documentId, response)
           ;[clientDoc, clientState] = A.receiveSyncMessage(
@@ -846,8 +878,6 @@ describe("Websocket adapters", () => {
         if (response == null && message == null) {
           break
         }
-        // Make sure shit has time to happen
-        await pause(50)
       }
 
       // we encode localHeads for consistency with URL formatted heads

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -24,6 +24,9 @@ import { WebSocketClientAdapter } from "../src/WebSocketClientAdapter.js"
 import { WebSocketServerAdapter } from "../src/WebSocketServerAdapter.js"
 import { encodeHeads } from "../../automerge-repo/dist/AutomergeUrl.js"
 
+/** Convergence takes a handful of round trips; the bug this guards is unbounded. */
+const MAX_SYNC_EXCHANGES = 20
+
 describe("Websocket adapters", () => {
   const browserPeerId = "browser" as PeerId
   const serverPeerId = "server" as PeerId
@@ -776,6 +779,18 @@ describe("Websocket adapters", () => {
 
       // Now create a websocket sync server with the original document in it's storage
       const adapter = new WebSocketServerAdapter(socket)
+
+      // A join from a peerId that already has a socket must close the old one
+      // and emit peer-disconnected before announcing the new connection.
+      // Observed on this adapter, not the one setupServer() returns unused.
+      const peerEvents: string[] = []
+      adapter.on("peer-disconnected", ({ peerId }) =>
+        peerEvents.push(`disconnected:${peerId}`)
+      )
+      adapter.on("peer-candidate", ({ peerId }) =>
+        peerEvents.push(`candidate:${peerId}`)
+      )
+
       const repo = new Repo({
         network: [adapter],
         storage,
@@ -853,7 +868,14 @@ describe("Websocket adapters", () => {
       assertIsPeerMessage(await serverMessages.next())
 
       // Now, we start syncing. If we're not buggy, this loop should terminate.
+      // The bug shows up as an unbounded exchange, so bound it rather than
+      // letting it run into the suite timeout.
+      let exchanges = 0
       while (true) {
+        assert.ok(
+          ++exchanges <= MAX_SYNC_EXCHANGES,
+          `sync did not converge within ${MAX_SYNC_EXCHANGES} exchanges`
+        )
         ;[clientState, message] = A.generateSyncMessage(clientDoc, clientState)
         if (message) {
           clientSocket.send(
@@ -886,6 +908,12 @@ describe("Websocket adapters", () => {
       if (!headsAreSame(encodeHeads(localHeads), remoteHeads)) {
         throw new Error("heads not equal")
       }
+
+      assert.deepStrictEqual(peerEvents, [
+        "candidate:client",
+        "disconnected:client",
+        "candidate:client",
+      ])
     })
 
     describe("teardown (resource-leak regressions)", () => {


### PR DESCRIPTION
Follow-up to #754, on the same test.

That test asserts an outcome, that the two sides converge, as a proxy for a mechanism. It no longer detects the bug named in its own title. Suppressing the rejoin `peer-disconnected` emit leaves it green, because `addPeer` now resets peer state unconditionally, so convergence happens for a reason unrelated to what is being guarded.

## Assert the mechanism

`WebSocketServerAdapter`, on a join from a peerId that already has a socket, closes the old socket and emits `peer-disconnected` before emitting `peer-candidate` for the new one:

```ts
const existingSocket = this.sockets[senderId]
if (existingSocket) {
  if (existingSocket.readyState === WebSocket.OPEN) existingSocket.close()
  this.emit("peer-disconnected", { peerId: senderId })
}
this.emit("peer-candidate", { peerId: senderId, peerMetadata })
```

That ordering is the title, so record both events and compare the sequence:

```ts
assert.deepStrictEqual(peerEvents, [
  "candidate:client",
  "disconnected:client",
  "candidate:client",
])
```

## Bound the sync loop

The failure this test guards is an unbounded exchange, per its own header comment: steps 6 and 7 repeat forever. An iteration cap reports `sync did not converge within 20 exchanges` rather than letting the suite time out with no explanation.

## Verification

Deleting the rejoin `peer-disconnected` emit now fails the test with a sequence diff. Websocket suite 29 passed over three runs, full suite 890 passed / 4 skipped, `oxlint` / `oxfmt --check` / `tsc --noEmit` clean.

One note in passing: `setupServer()` returns a `serverAdapter` that this test does not use, since it builds its own for the repo. The unused one is inert, because `WebSocketServerAdapter` registers all its server wiring in `connect()` and that is never called on it. Listening on the wrong one is an easy mistake though, so there is a comment saying which is which.
