### PR TITLE
fix(deps): raise runtime floors for cbor-x and ws

### DIFF
--- a/packages/automerge-repo-network-websocket/test/LargeDocument.test.ts
+++ b/packages/automerge-repo-network-websocket/test/LargeDocument.test.ts
@@ -1,0 +1,65 @@
+import { next as A } from "@automerge/automerge"
+import { PeerId, Repo } from "@automerge/automerge-repo"
+import { describe, expect, it, vi } from "vitest"
+import http from "http"
+import { WebSocketServer } from "ws"
+import { getPortPromise as getAvailablePort } from "portfinder"
+import { WebSocketClientAdapter } from "../src/WebSocketClientAdapter.js"
+import { WebSocketServerAdapter } from "../src/WebSocketServerAdapter.js"
+
+describe("large document over websocket", () => {
+  // ws 8.21.3 lowered maxFragments to 16. A message is one frame unless the
+  // sender fragments, and this adapter does not enable permessage-deflate.
+  it("syncs a multi-megabyte document in one frame", async () => {
+    const port = await getAvailablePort({ port: 3310 })
+    const server = http.createServer()
+    const wss = new WebSocketServer({ server })
+    await new Promise<void>(r => server.listen(port, r))
+    const serverAdapter = new WebSocketServerAdapter(wss)
+    const serverRepo = new Repo({
+      network: [serverAdapter],
+      peerId: "server" as PeerId,
+    })
+
+    const clientAdapter = new WebSocketClientAdapter(`ws://localhost:${port}`)
+    const clientRepo = new Repo({
+      network: [clientAdapter],
+      peerId: "client" as PeerId,
+    })
+
+    // ~4 MB of text in one document
+    await Promise.all([
+      new Promise<void>(r =>
+        clientRepo.networkSubsystem.once("peer", () => r())
+      ),
+      new Promise<void>(r =>
+        serverRepo.networkSubsystem.once("peer", () => r())
+      ),
+    ])
+
+    // Unique per block, or automerge deduplicates it down to nothing.
+    let seed = 1
+    const block = () => {
+      let out = ""
+      for (let i = 0; i < 512; i++) {
+        seed = (seed * 1103515245 + 12345) & 0x7fffffff
+        out += seed.toString(36)
+      }
+      return out
+    }
+    const handle = clientRepo.create<{ blocks: string[] }>({ blocks: [] })
+    handle.change(d => {
+      for (let i = 0; i < 1000; i++) d.blocks.push(block())
+    })
+    const bytes = A.save(handle.doc()!).length
+
+    const onServer = await serverRepo.find<{ blocks: string[] }>(handle.url)
+    expect(bytes).toBeGreaterThan(1_000_000)
+    await vi.waitFor(() => expect(onServer.doc()?.blocks.length).toBe(1000), {
+      timeout: 20000,
+    })
+
+    wss.close()
+    server.close()
+  }, 30000)
+})

--- a/packages/automerge-repo/package.json
+++ b/packages/automerge-repo/package.json
@@ -37,7 +37,7 @@
     "eventemitter3": "catalog:",
     "fast-sha256": "^1.3.0",
     "uuid": "catalog:",
-    "xstate": "^5.32.4"
+    "xstate": "^5.32.6"
   },
   "exports": {
     ".": "./dist/entrypoints/fullfat.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^4.1.10
       version: 4.1.10
     cbor-x:
-      specifier: ^1.6.4
-      version: 1.6.4
+      specifier: ^1.6.6
+      version: 1.6.6
     debug:
       specifier: ^4.4.3
       version: 4.4.3
@@ -67,8 +67,8 @@ catalogs:
       specifier: ^6.0.3
       version: 6.0.3
     uuid:
-      specifier: ^14.0.1
-      version: 14.0.1
+      specifier: ^14.0.2
+      version: 14.0.2
     vite:
       specifier: ^8.1.3
       version: 8.1.3
@@ -82,8 +82,8 @@ catalogs:
       specifier: ^4.1.10
       version: 4.1.10
     ws:
-      specifier: ^8.21.0
-      version: 8.21.0
+      specifier: ^8.21.3
+      version: 8.21.3
 
 overrides:
   semver: ^7.5.2
@@ -249,7 +249,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       uuid:
         specifier: 'catalog:'
-        version: 14.0.1
+        version: 14.0.2
     devDependencies:
       '@vitejs/plugin-react-swc':
         specifier: ^4.3.1
@@ -317,7 +317,7 @@ importers:
         version: 15.1.3
       ws:
         specifier: 'catalog:'
-        version: 8.21.0
+        version: 8.21.3
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -367,7 +367,7 @@ importers:
         version: 4.0.0
       cbor-x:
         specifier: 'catalog:'
-        version: 1.6.4
+        version: 1.6.6
       debug:
         specifier: 'catalog:'
         version: 4.4.3
@@ -379,10 +379,10 @@ importers:
         version: 1.3.0
       uuid:
         specifier: 'catalog:'
-        version: 14.0.1
+        version: 14.0.2
       xstate:
-        specifier: ^5.32.4
-        version: 5.32.4
+        specifier: ^5.32.6
+        version: 5.32.6
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -439,7 +439,7 @@ importers:
         version: link:../automerge-repo
       cbor-x:
         specifier: 'catalog:'
-        version: 1.6.4
+        version: 1.6.6
       debug:
         specifier: 'catalog:'
         version: 4.4.3
@@ -448,7 +448,7 @@ importers:
         version: 5.0.4
       ws:
         specifier: 'catalog:'
-        version: 8.21.0
+        version: 8.21.3
     devDependencies:
       '@automerge/automerge':
         specifier: 'catalog:'
@@ -1952,8 +1952,8 @@ packages:
     resolution: {integrity: sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==}
     hasBin: true
 
-  cbor-x@1.6.4:
-    resolution: {integrity: sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==}
+  cbor-x@1.6.6:
+    resolution: {integrity: sha512-8QiD9PGOxyQHo7s2pzwTBH6lTjqekxPdl9Aq6fXvZgCuCJHOht1puDEA/fTr6mciB76c+M+Gi0qT2i1a4pm4Wg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -3002,6 +3002,7 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
@@ -3451,8 +3452,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@14.0.1:
-    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+  uuid@14.0.2:
+    resolution: {integrity: sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==}
     hasBin: true
 
   validate-npm-package-name@6.0.2:
@@ -3641,12 +3642,24 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
-  xstate@5.32.4:
-    resolution: {integrity: sha512-E5WtDB8DBs2ZWliz2Ry9XfbSZTbBRcK/cwefBot04qQ/L5SLP16xpnTDU4/ZFXuXFhNxi7JP2RhuoGwBnM+S4A==}
+  xstate@5.32.6:
+    resolution: {integrity: sha512-WfA8WNrh6r9osuGwVm+aIPM4jmMW2LKHV1Yv9thYpOtL4HVF/kobh95K/O8v2jDCpDmP2EoY+6uvuqHXCZ6ZLw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -4776,7 +4789,7 @@ snapshots:
       '@cbor-extract/cbor-extract-win32-x64': 2.2.2
     optional: true
 
-  cbor-x@1.6.4:
+  cbor-x@1.6.6:
     optionalDependencies:
       cbor-extract: 2.2.2
 
@@ -6257,7 +6270,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@14.0.1: {}
+  uuid@14.0.2: {}
 
   validate-npm-package-name@6.0.2: {}
 
@@ -6441,12 +6454,14 @@ snapshots:
 
   ws@8.21.0: {}
 
+  ws@8.21.3: {}
+
   wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  xstate@5.32.4: {}
+  xstate@5.32.6: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,7 @@ catalog:
   "@vitejs/plugin-react": ^6.0.3
   "@vitest/coverage-v8": ^4.1.10
   "@vitest/ui": ^4.1.10
-  cbor-x: ^1.6.4
+  cbor-x: ^1.6.6
   debug: ^4.4.3
   eventemitter3: ^5.0.4
   execa: ^9.6.1
@@ -40,9 +40,9 @@ catalog:
   rollup-plugin-visualizer: ^7.0.1
   svelte: ^5.56.4
   typescript: ^6.0.3
-  uuid: ^14.0.1
+  uuid: ^14.0.2
   vite: ^8.1.3
   vite-plugin-dts: ^5.0.3
   vite-plugin-wasm: ^3.6.0
   vitest: ^4.1.10
-  ws: ^8.21.0
+  ws: ^8.21.3


### PR DESCRIPTION
Two of these ship quiet hardening on paths that handle untrusted network input. Neither has a published advisory, so `pnpm audit` says nothing about either.

## `cbor-x` 1.6.4 to 1.6.6

The decoder gained bounds checks it did not have:

```js
if (token > srcEnd - position) throw endOfCBORError()        // array length past the buffer
if (token > (srcEnd - position) / 2) throw endOfCBORError()  // map, two bytes minimum per entry
if (isNaN(token)) throw endOfCBORError()                     // corrupt length
if (!(position < srcEnd)) throw endOfCBORError()             // NaN-safe end check
```

Previously a crafted header declaring a huge array or map length allocated and looped before failing. `automerge-repo` decodes peer payloads with cbor-x, so this is directly on the surface a sync server exposes.

It also renames `setMaxLimits` / `MAX_LIMITS_OPTIONS` to `setSizeLimits` / `SizeLimitOptions`, a breaking export change in a patch release. Nothing in this repo calls it.

## `ws` 8.21.0 to 8.21.3

A bypass of its own fragment limit:

```diff
- this._maxFragments > 0 && this._fragments.length >= this._maxFragments
+ this._maxFragments > 0 && ++this._numFragments > this._maxFragments
```

The old check counted only fragments still buffered, so traffic that did not accumulate never tripped the limit. It now counts every fragment received. Defaults drop with it: `maxFragments` 128 to 16, `maxBufferedChunks` 1024 to 256. Also a permessage-deflate window-bits negotiation fix.

Sixteen fragments is low enough to be worth checking rather than assuming, so this adds a test that syncs a 2 MB document end to end over the adapter. It passes: a message is one frame unless the sender fragments, and this adapter does not enable permessage-deflate.

## `uuid` 14.0.2 and `xstate` 5.32.6

Routine patches, along for the ride. `uuid` touches only `v1` and `v7`; this repo uses `v4`.

## Why these are separate from a dependency refresh

All four are runtime dependencies of published packages, so raising their floor is consumer visible: someone pinned at `ws@8.21.0` is forced up. Two carry real behaviour changes. That belongs in its own review rather than inside housekeeping.

## Verification

Full suite 891 passed / 4 skipped, websocket suite 30 passed over three runs. `oxlint`, `oxfmt --check` and `tsc --noEmit` clean. `@automerge/automerge` is deliberately untouched.
