### PR TITLE
fix(build): stop bundling dependencies into react-hooks and solid-primitives

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,18 +20,20 @@
     "preinstall": "npx only-allow pnpm",
     "repocheck": "manypkg check",
     "format": "oxfmt",
-    "lint": "oxfmt --check . && oxlint && pnpm run lint:check-types",
+    "lint": "oxfmt --check . && oxlint && pnpm run lint:check-types && pnpm run check:bundles",
     "test": "vitest",
     "test:log": "cross-env DEBUG='automerge-repo:*' vitest",
     "test:coverage": "vitest --coverage",
     "test:ui": "vitest --coverage --ui",
     "watch": "pnpm run --parallel --stream -r watch ",
-    "lint:check-types": "pnpm run lint:check-types:packages && pnpm run lint:check-types:examples",
+    "lint:check-types": "pnpm run lint:check-types:packages && pnpm run lint:check-types:examples && pnpm run lint:check-types:scripts",
     "lint:check-types:packages": "pnpm --filter './packages/*' exec tsc --noEmit",
-    "lint:check-types:examples": "pnpm --filter './examples/react-*' exec tsc --noEmit && pnpm -F @automerge/automerge-repo-demo-counter-svelte check"
+    "lint:check-types:examples": "pnpm --filter './examples/react-*' exec tsc --noEmit && pnpm -F @automerge/automerge-repo-demo-counter-svelte check",
+    "check:bundles": "node scripts/check-bundles.ts",
+    "lint:check-types:scripts": "tsc --noEmit -p scripts/tsconfig.json"
   },
   "engines": {
-    "node": ">=22.13",
+    "node": ">=22.18",
     "pnpm": "^11"
   },
   "manypkg": {

--- a/packages/automerge-repo-network-websocket/test/Websocket.test.ts
+++ b/packages/automerge-repo-network-websocket/test/Websocket.test.ts
@@ -1,6 +1,7 @@
 import { next as A } from "@automerge/automerge"
 import {
   AutomergeUrl,
+  encodeHeads,
   DocHandle,
   DocumentId,
   PeerId,
@@ -22,7 +23,6 @@ import { afterEach, describe, it, vi } from "vitest"
 import WebSocket, { WebSocketServer } from "ws"
 import { WebSocketClientAdapter } from "../src/WebSocketClientAdapter.js"
 import { WebSocketServerAdapter } from "../src/WebSocketServerAdapter.js"
-import { encodeHeads } from "../../automerge-repo/dist/AutomergeUrl.js"
 
 describe("Websocket adapters", () => {
   const browserPeerId = "browser" as PeerId

--- a/packages/automerge-repo-react-hooks/src/useDocHandle.ts
+++ b/packages/automerge-repo-react-hooks/src/useDocHandle.ts
@@ -1,8 +1,11 @@
-import { AnyDocumentId, DocHandle } from "@automerge/automerge-repo/slim"
+import {
+  anyDocumentIdToAutomergeUrl,
+  AnyDocumentId,
+  DocHandle,
+} from "@automerge/automerge-repo/slim"
 import { PromiseWrapper, wrapPromise } from "./wrapPromise.js"
 import { useRepo } from "./useRepo.js"
 import { useEffect, useRef, useState } from "react"
-import { anyDocumentIdToAutomergeUrl } from "../../automerge-repo/dist/AutomergeUrl.js"
 
 // Shared with useDocHandles
 export const wrapperCache = new Map<

--- a/packages/automerge-repo-react-hooks/vite.config.ts
+++ b/packages/automerge-repo-react-hooks/vite.config.ts
@@ -22,7 +22,13 @@ export default defineConfig({
     },
     target: "esnext",
     rollupOptions: {
-      external: [/^@automerge\//, "react", "react/jsx-runtime", "react-dom"],
+      // Bundle this package's own source and nothing else. Matching on
+      // specifiers alone missed workspace siblings, which vite resolves to a
+      // path before the check, so parts of automerge-repo were inlined.
+      external: (id: string) =>
+        !id.startsWith("\0") &&
+        !id.startsWith(".") &&
+        !id.startsWith(resolve(__dirname, "src")),
       output: {
         globals: {
           react: "React",

--- a/packages/automerge-repo-solid-primitives/vite.config.ts
+++ b/packages/automerge-repo-solid-primitives/vite.config.ts
@@ -25,7 +25,13 @@ export default defineConfig({
     },
     target: "esnext",
     rollupOptions: {
-      external: [/^@automerge\//, "solid-js", "solid-js/store"],
+      // Bundle this package's own source and nothing else. Matching on
+      // specifiers alone missed workspace siblings, which vite resolves to a
+      // path before the check.
+      external: (id: string) =>
+        !id.startsWith("\0") &&
+        !id.startsWith(".") &&
+        !id.startsWith(resolve(__dirname, "src")),
     },
   },
   resolve: {

--- a/packages/automerge-repo/src/index.ts
+++ b/packages/automerge-repo/src/index.ts
@@ -28,6 +28,7 @@
 
 export { DocHandle } from "./DocHandle.js"
 export {
+  anyDocumentIdToAutomergeUrl,
   isValidAutomergeUrl,
   isValidDocumentId,
   parseAutomergeUrl,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3002,6 +3002,7 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}

--- a/scripts/check-bundles.ts
+++ b/scripts/check-bundles.ts
@@ -1,0 +1,38 @@
+// The bundled packages must ship their own source and nothing else. An inlined
+// dependency is delivered twice, once bundled and once installed, and for
+// anything identity-bearing the two copies are not interchangeable. #660 tried
+// to fix this with externals matched on import specifiers, which does not catch
+// a workspace sibling because vite resolves it to a path first.
+//
+// The sourcemap lists every file that contributed to the bundle, so use that
+// rather than scanning for inlined module markers: rolldown emits no //#region
+// for some inlined packages.
+import { readFileSync, existsSync } from "node:fs"
+
+const BUNDLED = [
+  "packages/automerge-repo-react-hooks",
+  "packages/automerge-repo-solid-primitives",
+]
+
+type SourceMap = { sources?: string[] }
+
+let failed = false
+for (const pkg of BUNDLED) {
+  const map = `${pkg}/dist/index.js.map`
+  if (!existsSync(map)) {
+    console.error(`${map}: not built, run pnpm build first`)
+    failed = true
+    continue
+  }
+  const sourceMap: SourceMap = JSON.parse(readFileSync(map, "utf8"))
+  const sources = sourceMap.sources ?? []
+  const foreign = sources.filter(
+    s => s.includes("node_modules") || s.startsWith("../../")
+  )
+  if (foreign.length > 0) {
+    console.error(`${pkg} bundles code from outside its own source:`)
+    for (const s of foreign) console.error(`  ${s}`)
+    failed = true
+  }
+}
+if (failed) process.exit(1)

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
#660 externalized `/^@automerge\//` in the react-hooks and solid-primitives bundles, with the stated intent that "consumers don't get a second bundled copy of automerge". It got most of the way there, measured on today's source:

| externals | bundle | foreign sources |
|---|---|---|
| before #660 | 195,453 bytes | 40 |
| #660 | 62,451 bytes | 21 |
| this PR | 13,764 bytes | 0 |

So #660 cut two thirds of the bytes and half the inlined sources. What it could not reach was one import that is not a specifier:

```ts
// packages/automerge-repo-react-hooks/src/useDocHandle.ts:5
import { anyDocumentIdToAutomergeUrl } from "../../automerge-repo/dist/AutomergeUrl.js"
```

A relative path into the sibling package's build output. No specifier pattern can match it, so vite inlined it, and through it five `automerge-repo` modules pulled `uuid`, `bs58check`, `bs58`, `base-x`, `@noble/hashes`, `debug` and `ms` back in:

```
//#region ../automerge-repo/dist/helpers/bufferFromHex.js
//#region ../automerge-repo/dist/subdoc-handles/types.js
//#region ../automerge-repo/dist/subdoc-handles/parser.js
//#region bs58check/... base-x/... @noble/hashes/... debug/... ms/...
```

So the published `@automerge/automerge-repo-react-hooks` contained a duplicate copy of `subdoc-handles/parser.js` and `types.js` while also declaring `@automerge/automerge-repo` as a dependency. A consumer got both. That is exactly the hazard #660's own commit message describes for automerge: "two coexisting copies leave the /slim copy's wasm uninitialized". Two module instances of code where identity matters are not interchangeable.

## The fix, in order

**Export the helper.** `anyDocumentIdToAutomergeUrl` is not exported from any entrypoint, so the deep import was the only way to reach it. It composes four helpers `index.ts` already exports, and its signature types are already public, so this adds one name to an existing export block and no new surface.

**Import it from the package.** `useDocHandle.ts` now imports from `@automerge/automerge-repo/slim` like everything else.

**Externalize by origin rather than by name.** Bundle this package's own source and nothing else, in both packages. That also externalizes `eventemitter3`, which was declared as a dependency and bundled anyway.

```
react-hooks       62,469 -> 13,764 bytes
solid-primitives   6,262 bytes, content unchanged
```

## Keeping it fixed

`scripts/check-bundles.ts` reads each bundle's sourcemap and fails if any contributing source is outside the package. It runs from `pnpm lint`.

It reads the sourcemap rather than scanning the output for inlined module markers because that does not work: rolldown emits no `//#region` for `eventemitter3`, so a marker-based check passes a bundle that is inlining it. Restoring the old externals fails this one, naming both files.

The script is TypeScript and is typechecked. Nothing covered `scripts/` before, so this adds `scripts/tsconfig.json` and a `lint:check-types:scripts` step. `scripts/version.mjs` is left alone.

**Why `engines.node` moves from `>=22.13` to `>=22.18`.** Node runs the script directly, with no loader and no added dependency, because it strips types by default from 22.18. On 22.13 through 22.17 that needs `--experimental-strip-types`, so the floor has to move to match. This is contributor-only: the root package is `private: true`, so `engines` never reaches consumers, and CI already runs 22, 24 and 25 where the latest 22.x is well past 22.18. The alternative was keeping `tsx` as a root devDependency purely to run one lint script.

## Also

`Websocket.test.ts` reached into the same sibling `dist` for `encodeHeads`, which is already exported. It now imports it from the package. That leaves no cross-package `dist` imports anywhere in the repo.

## Verification

`pnpm lint` clean end to end, full suite 890 passed / 4 skipped, both bundles verified to contain only their own sources. Both guards were mutation checked: reverting the externals fails the bundle check, and mistyping the sourcemap parse fails the new typecheck.

## Merge order

**Land this before #757.** Until this is in, `automerge-repo-react-hooks` inlines its dependencies, so any lockfile refresh changes its published `dist/index.js`. That is how this defect was found in the first place: a change advertised as lockfile-only was altering a published artifact.

Clean against #756, #757, #759 and #760.
